### PR TITLE
Start v1.5a cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# DEV NOTE (v1.4.1)
+# DEV NOTE (v1.5a): Version bumped to 1.5a and new development rules added.
 This file was rewritten entirely to document the current Copernican Suite structure and the model plugin system introduced in version 1.4b.
 
 # Copernican Suite Development Guide
@@ -163,5 +163,7 @@ To keep the project maintainable all contributors, human or AI, must follow thes
 1. **Add a `DEV NOTE` at the top of each changed file** summarizing your modifications.
 2. **Comment code extensively** to explain non-obvious logic or algorithms.
 3. **Update documentation**, including this `AGENTS.md` and `README.md`, whenever behavior or structure changes.
+4. **Version changes require explicit human approval.**
+5. **Never insert Git conflict markers (<<<<<<<, =======, >>>>>>>) into any file.**
 
 Failure to follow these guidelines will compromise the Copernican Suite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Copernican Suite Change Log
+## Version 1.5a (Development Release)
+- Updated documentation and version constants.
+- Added development rules about version changes and Git conflict markers.
+
 ## Version 1.4.1 (Maintenance Release)
 - LCDM model separated into lcdm.py plugin.
 - Added splash screen and improved logging with per-run timestamps.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,20 @@
+<!-- DEV NOTE (v1.5a): Created plan document and completed Phase 1 tasks. -->
+# Development Plan
+
+## Phase 1: Version 1.5a Preparation
+This phase bumps the development version to **1.5a** and establishes new
+contributor rules.
+
+### Work Performed
+- Updated version references in documentation and key modules.
+- Added a rule requiring human approval for any future version changes.
+- Added a rule forbidding Git conflict markers in all files.
+
+### Implementation Notes
+The updates were applied directly in `README.md`, `AGENTS.md` and several
+package `__init__` files. The main program `copernican.py` and
+`output_manager.py` now report version `1.5a` via the `COPERNICAN_VERSION`
+constant and header comments. The `CHANGELOG.md` was extended to include this
+development entry.
+
+Future phases will build upon this foundation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+<!-- DEV NOTE (v1.5a): Updated version number to 1.5a -->
 # Copernican Suite
 
-**Version:** 1.4.1
+**Version:** 1.5a
 **Last Updated:** 2025-06-15
 
 The Copernican Suite is a Python toolkit for testing cosmological models against

--- a/copernican.py
+++ b/copernican.py
@@ -2,7 +2,7 @@
 """
 Copernican Suite - Main Orchestrator.
 """
-# DEV NOTE (v1.4.1): Added splash screen, per-run logging with timestamps, and
+# DEV NOTE (v1.5a): Updated version constants and documentation.
 # migrated the base model import to the new `lcdm.py` plugin file. Previous
 # refactor notes retained below for context.
 # DEV NOTE (v1.4): Refactored into a pluggable architecture. Models, parsers,
@@ -21,7 +21,7 @@ import shutil
 import glob
 import time
 
-COPERNICAN_VERSION = "1.4.1"
+COPERNICAN_VERSION = "1.5a"
 
 def show_splash_screen():
     """Displays the startup banner once at launch."""

--- a/engines/__init__.py
+++ b/engines/__init__.py
@@ -1,1 +1,1 @@
-# DEV NOTE (v1.4): Package init for engines.
+# DEV NOTE (v1.5a): Version identifier updated to 1.5a.

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,1 @@
-# DEV NOTE (v1.4): Package init for model plugins.
+# DEV NOTE (v1.5a): Version identifier updated to 1.5a.

--- a/output_manager.py
+++ b/output_manager.py
@@ -1,6 +1,6 @@
 # copernican_suite/output_manager.py
-# DEV NOTE (v1.4.1): Logging now initializes per run and records the start and
-# end timestamps. Previous notes retained below.
+# DEV NOTE (v1.5a): Version updated to 1.5a; no functional changes.
+# DEV NOTE (v1.4.1): Logging now initializes per run and records the start and end timestamps. Previous notes retained below.
 """
 Output Manager for the Copernican Suite.
 Handles all forms of output (logging, plots, CSVs) with a consistent format.

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -1,1 +1,1 @@
-# DEV NOTE (v1.4): Package init for parser modules.
+# DEV NOTE (v1.5a): Version identifier updated to 1.5a.

--- a/parsers/bao/__init__.py
+++ b/parsers/bao/__init__.py
@@ -1,1 +1,1 @@
-# DEV NOTE (v1.4): Package init for BAO parsers.
+# DEV NOTE (v1.5a): Version identifier updated to 1.5a.

--- a/parsers/sne/__init__.py
+++ b/parsers/sne/__init__.py
@@ -1,1 +1,1 @@
-# DEV NOTE (v1.4): Package init for SNe parsers.
+# DEV NOTE (v1.5a): Version identifier updated to 1.5a.


### PR DESCRIPTION
## Summary
- create PLAN.md to track new development phases
- bump documentation and headers to version 1.5a
- clarify development rules in AGENTS.md
- update `COPERNICAN_VERSION`
- document version bump in CHANGELOG

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684eca2910cc832f89423b6384aeaca1