### PR TITLE
Implement DSL compiler and bump version to 1.5b

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# DEV NOTE (v1.5a)
+# DEV NOTE (v1.5b)
 This file was rewritten entirely to document the current Copernican Suite structure and the model plugin system introduced in version 1.4b.
 
 # Copernican Suite Development Guide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Copernican Suite Change Log
-# DEV NOTE (v1.5a): Recorded Phase 0 and Phase 1 completion.
-## Version 1.5a (Development)
-- Pipeline skeleton introduced under `scripts/` implementing the new modular
-  architecture.
-- Added JSON DSL example `cosmo_model_lcdm.json` and documentation updates.
+# DEV NOTE (v1.5b): Recorded Phase 2 completion and version bump.
+## Version 1.5b (Development)
+- Implemented DSL parser validation and new `model_compiler.py` replacing
+  `model_compiler.py`.
+- Improved error handling for malformed JSON and numerical issues.
+- Updated documentation and version metadata for the 1.5b development cycle.
 
 ## Version 1.4.1 (Maintenance Release)
 - LCDM model separated into lcdm.py plugin.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,4 +1,4 @@
-# DEV NOTE (v1.5a)
+# DEV NOTE (v1.5b)
 Updated for Phase 0 and Phase 1 completion. Added pipeline skeleton modules and
 documented the new JSON DSL with an example model file.
 
@@ -18,7 +18,7 @@ the following helper modules:
 
 1. **`scripts/model_parser.py`** – validates `cosmo_model_*.json` files against
    the DSL template and writes validated information to `models/cache/cache_*`.
-2. **`scripts/model_converter.py`** – converts the parsed DSL into Python
+2. **`scripts/model_compiler.py`** – converts the parsed DSL into Python
    callables stored in the cache. No executable code is kept inside model JSON
    files.
 3. **`scripts/engine_interface.py`** – loads the compiled callables from the
@@ -64,6 +64,7 @@ complete Phase 1 for version 1.5a.
    - Guard against division by zero and other numerical pitfalls when compiling
      wild theories.
 
+**Progress:** Phase 2 implemented in version 1.5b. Parser validates JSON and compiler generates safe callables.
 ## Phase 3 – Engine Abstraction Layer
 1. **Create `engine_interface.py`**
    - Serves as a manager between compiled models and the chosen engine.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Copernican Suite
-# DEV NOTE (v1.5a): Updated documentation for the new modular pipeline and JSON DSL.
+# DEV NOTE (v1.5b): Updated documentation for the new modular pipeline and JSON DSL.
 
-**Version:** 1.5a
+**Version:** 1.5b
 **Last Updated:** 2025-06-16
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
@@ -37,7 +37,7 @@ Under the hood the program now follows a modular pipeline:
    are prepared.
 3. **Model Parsing** – `scripts/model_parser.py` validates `cosmo_model_*.json`
    files and caches the sanitized content.
-4. **Model Conversion** – `scripts/model_converter.py` turns the cached data
+4. **Model Conversion** – `scripts/model_compiler.py` turns the cached data
    into Python callables used by the engines.
 5. **Engine Execution** – `scripts/engine_interface.py` hands the callables and
    parsed data to the selected engine.
@@ -90,7 +90,7 @@ Model definition follows a two-file system and detailed instructions are in
    Place this module in the `models` package and reference its filename in the
    Markdown front matter under `model_plugin`.
 
-Version 1.5a introduces an experimental **JSON DSL** for model definitions. A
+Version 1.5b introduces an experimental **JSON DSL** for model definitions. A
 `cosmo_model_name.json` file contains:
 
 - `model_name`, `version`, and `date` metadata
@@ -121,7 +121,7 @@ Copernican Suite.
 1.  **Dependency Check**: `copernican.py` verifies required Python libraries.
 2.  **Initialization**: Logging via `scripts/logger.py` starts and the `./output/` directory is created.
 3.  **Configuration**: The user specifies model and data paths. Test mode (`test`) runs ΛCDM against itself.
-4.  **Model Parsing and Conversion**: The JSON DSL is processed by `model_parser.py` and `model_converter.py`.
+4.  **Model Parsing and Conversion**: The JSON DSL is processed by `model_parser.py` and `model_compiler.py`.
 5.  **SNe Ia Fitting**: The selected engine receives callables through `engine_interface.py` and fits parameters.
 6.  **BAO Analysis**: Using best-fit parameters, the engine computes BAO observables.
 7.  **Output Generation**: Plots and CSVs are produced via `plotter.py`, `csv_writer.py`, and `output_manager.py`.

--- a/copernican.py
+++ b/copernican.py
@@ -2,7 +2,7 @@
 """
 Copernican Suite - Main Orchestrator.
 """
-# DEV NOTE (v1.5a): Pipeline hooks added for new `scripts` package. Previous
+# DEV NOTE (v1.5b): Pipeline hooks added for new `scripts` package. Previous
 # notes retained below for context.
 # DEV NOTE (v1.4.1): Added splash screen, per-run logging with timestamps, and
 # migrated the base model import to the new `lcdm.py` plugin file. Previous
@@ -23,7 +23,7 @@ import shutil
 import glob
 import time
 
-COPERNICAN_VERSION = "1.5a"
+COPERNICAN_VERSION = "1.5b"
 
 def show_splash_screen():
     """Displays the startup banner once at launch."""

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,2 +1,2 @@
-# DEV NOTE (v1.5a)
+# DEV NOTE (v1.5b)
 """Package initialization for Copernican helper scripts."""

--- a/scripts/csv_writer.py
+++ b/scripts/csv_writer.py
@@ -1,5 +1,5 @@
 """CSV output utilities for Copernican Suite."""
-# DEV NOTE (v1.5a): Skeleton module created during Phase 0.
+# DEV NOTE (v1.5b): Skeleton module created during Phase 0.
 
 def write_csv(filepath, data_frame):
     """Placeholder CSV writer."""

--- a/scripts/engine_interface.py
+++ b/scripts/engine_interface.py
@@ -1,5 +1,5 @@
 """Interface between compiled models and computational engines."""
-# DEV NOTE (v1.5a): Initial placeholder for Phase 0.
+# DEV NOTE (v1.5b): Initial placeholder for Phase 0.
 
 def run_engine(engine_module, model_callables, sne_data, bao_data):
     """Send prepared callables and data to the selected engine."""

--- a/scripts/error_handler.py
+++ b/scripts/error_handler.py
@@ -1,5 +1,5 @@
 """Centralized error handling utilities for the Copernican Suite."""
-# DEV NOTE (v1.5a): Skeleton error reporting helper added in Phase 0.
+# DEV NOTE (v1.5b): Skeleton error reporting helper added in Phase 0.
 import logging
 
 def report_error(message):

--- a/scripts/logger.py
+++ b/scripts/logger.py
@@ -1,5 +1,5 @@
 """Logging configuration for the Copernican Suite."""
-# DEV NOTE (v1.5a): Initial logging utility for Phase 0.
+# DEV NOTE (v1.5b): Initial logging utility for Phase 0.
 import logging
 import os
 

--- a/scripts/model_compiler.py
+++ b/scripts/model_compiler.py
@@ -1,0 +1,63 @@
+"""Compile sanitized model data into executable Python callables."""
+# DEV NOTE (v1.5b): Implemented initial compiler using SymPy with basic
+# validation and safety checks. Replaces the old model_converter stub.
+
+import json
+import numpy as np
+from sympy import symbols, sympify, lambdify
+from . import error_handler
+
+
+def compile_cached_model(cache_path):
+    """Return dictionary of callables compiled from a cached model JSON."""
+    try:
+        with open(cache_path, 'r', encoding='utf-8') as handle:
+            model = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        error_handler.report_error(f"Failed to read cache '{cache_path}': {exc}")
+        return {}
+
+    param_names = [p.get("name") for p in model.get("parameters", [])]
+    param_syms = symbols(param_names)
+    z = symbols('z')
+    constants = model.get("constants", {})
+
+    locals_dict = {name: sym for name, sym in zip(param_names, param_syms)}
+    locals_dict.update(constants)
+
+    def _safe_callable(expr):
+        """Wrap lambdified expression with error and NaN handling."""
+        func = lambdify((z, *param_syms), expr, 'numpy')
+
+        def wrapper(z_array, *params):
+            try:
+                result = func(z_array, *params)
+                arr = np.asarray(result, dtype=float)
+                if np.any(np.isnan(arr) | np.isinf(arr)):
+                    raise ZeroDivisionError("Numerical instability detected")
+                return arr
+            except Exception as exc:
+                error_handler.report_error(
+                    f"Computation failed for expression '{expr}': {exc}")
+                return np.full_like(np.asarray(z_array, dtype=float), np.nan)
+
+        return wrapper
+
+    compiled = {"sne": [], "bao": []}
+
+    for label in ("sne", "bao"):
+        for eq in model.get("equations", {}).get(label, []):
+            try:
+                rhs = eq.split('=', 1)[1] if '=' in eq else eq
+                expr = sympify(rhs, locals=locals_dict)
+                # simple numerical test using initial guesses
+                guesses = [p.get("guess") for p in model.get("parameters", [])]
+                test_func = _safe_callable(expr)
+                test_val = test_func(0.1, *guesses)
+                if np.any(np.isnan(test_val) | np.isinf(test_val)):
+                    raise ValueError("invalid numeric result")
+                compiled[label].append(_safe_callable(expr))
+            except Exception as exc:
+                error_handler.report_error(
+                    f"Failed to compile equation '{eq}' in {label}: {exc}")
+    return compiled

--- a/scripts/model_converter.py
+++ b/scripts/model_converter.py
@@ -1,8 +1,0 @@
-"""Converts cached DSL data into executable Python callables."""
-# DEV NOTE (v1.5a): Skeleton for Phase 0. Actual conversion logic will be
-# implemented in Phase 2.
-
-def convert_cached_model(cache_path):
-    """Placeholder stub that should return Python callables."""
-    # TODO: parse the cached JSON and generate callables
-    return {}

--- a/scripts/model_parser.py
+++ b/scripts/model_parser.py
@@ -1,12 +1,38 @@
 """Model Parser for Copernican Suite."""
-# DEV NOTE (v1.5a): Initial skeleton implementing Phase 0.
+# DEV NOTE (v1.5b): Added field validation and integration with error_handler.
+
 import json
 import os
+from . import error_handler
+
+# Required keys for the root of a model JSON file
+REQUIRED_ROOT_FIELDS = ["model_name", "version", "date", "parameters", "equations"]
+# Required keys for each parameter entry
+REQUIRED_PARAMETER_FIELDS = ["name", "latex", "guess", "bounds", "unit"]
+
 
 def validate_and_cache(json_path, cache_dir):
     """Validate a DSL file and write sanitized JSON to the cache."""
-    with open(json_path, 'r', encoding='utf-8') as handle:
-        model_data = json.load(handle)
+    try:
+        with open(json_path, 'r', encoding='utf-8') as handle:
+            model_data = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        error_handler.report_error(f"Failed to read '{json_path}': {exc}")
+        return None
+
+    missing = [f for f in REQUIRED_ROOT_FIELDS if f not in model_data]
+    if missing:
+        error_handler.report_error(
+            f"Model file '{json_path}' missing required fields: {missing}")
+        return None
+
+    for idx, param in enumerate(model_data.get("parameters", [])):
+        p_missing = [f for f in REQUIRED_PARAMETER_FIELDS if f not in param]
+        if p_missing:
+            error_handler.report_error(
+                f"Parameter index {idx} missing fields: {p_missing}")
+            return None
+
     os.makedirs(cache_dir, exist_ok=True)
     cache_file = os.path.join(cache_dir, os.path.basename(json_path))
     with open(cache_file, 'w', encoding='utf-8') as handle:

--- a/scripts/plotter.py
+++ b/scripts/plotter.py
@@ -1,5 +1,5 @@
 """Plotting utilities for Copernican analysis results."""
-# DEV NOTE (v1.5a): Skeleton placeholder added in Phase 0.
+# DEV NOTE (v1.5b): Skeleton placeholder added in Phase 0.
 
 def plot_results(results):
     """Placeholder for future plotting routines."""


### PR DESCRIPTION
## Summary
- bump Copernican Suite development version to **1.5b**
- implement `model_compiler.py` to convert cached models to callables
- validate DSL fields in `model_parser.py`
- rename `model_converter.py` to `model_compiler.py`
- update docs and progress for Phase 2

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ed0c69f44832fa7ab1a6a73a60b8a