### PR TITLE
Rename converter to encoder and clarify DSL migration

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # DEV NOTE (v1.5a)
-Updated for Phase 0 and Phase 1 completion. Added pipeline skeleton modules and
-documented the new JSON DSL with an example model file.
+Updated to clarify that Markdown models will be migrated to JSON and compiled
+dynamically. `model_converter.py` is renamed to `model_encoder.py`.
 
 # Development Roadmap
 This document outlines the steps required to refactor the Copernican Suite so
@@ -18,7 +18,7 @@ the following helper modules:
 
 1. **`scripts/model_parser.py`** – validates `cosmo_model_*.json` files against
    the DSL template and writes validated information to `models/cache/cache_*`.
-2. **`scripts/model_converter.py`** – converts the parsed DSL into Python
+2. **`scripts/model_encoder.py`** – encodes the parsed DSL into Python
    callables stored in the cache. No executable code is kept inside model JSON
    files.
 3. **`scripts/engine_interface.py`** – loads the compiled callables from the
@@ -55,9 +55,9 @@ under `models/`.
 complete Phase 1 for version 1.5a.
 
 ## Phase 2 – Implement a DSL Parser/Compiler
-1. **Create `model_parser.py` and `model_compiler.py`**
+1. **Create `model_parser.py` and `model_encoder.py`**
    - `model_parser.py` validates the DSL files and writes sanitized content to the cache.
-   - `model_compiler.py` reads that cache entry, parses equations with SymPy, and
+   - `model_encoder.py` reads that cache entry, parses equations with SymPy, and
      generates Python callables that match the current engine interface.
 2. **Error handling and robustness**
    - Provide clear messages for missing fields or malformed equations.
@@ -77,11 +77,13 @@ complete Phase 1 for version 1.5a.
 
 ## Phase 4 – Incremental Migration of Models
 1. **Convert Markdown models**
-   - Translate each `cosmo_model_*.md` and its plugin into a single JSON file using the DSL.
+   - Translate each `cosmo_model_*.md` file into a single JSON file using the DSL.
+   - Existing `.py` plugin modules remain only as reference examples.
 2. **Validate conversions**
    - Confirm that compiled JSON models reproduce the outputs of the original plugins.
 3. **Retire `.py` plugins**
-   - Remove outdated plugin files once all engines operate on the DSL.
+   - After every Markdown model is migrated, delete the old plugin modules because
+     `model_encoder.py` will generate equivalent code dynamically.
 4. **Cache management**
     - Store compiled code in `models/cache/cache_*.json` during runs and prompt
       the user to delete or keep the cache afterward.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Copernican Suite
-# DEV NOTE (v1.5a): Updated documentation for the new modular pipeline and JSON DSL.
+# DEV NOTE (v1.5a): Updated pipeline references; model_converter.py renamed to
+# model_encoder.py.
 
 **Version:** 1.5a
 **Last Updated:** 2025-06-16
@@ -37,7 +38,7 @@ Under the hood the program now follows a modular pipeline:
    are prepared.
 3. **Model Parsing** – `scripts/model_parser.py` validates `cosmo_model_*.json`
    files and caches the sanitized content.
-4. **Model Conversion** – `scripts/model_converter.py` turns the cached data
+4. **Model Encoding** – `scripts/model_encoder.py` turns the cached data
    into Python callables used by the engines.
 5. **Engine Execution** – `scripts/engine_interface.py` hands the callables and
    parsed data to the selected engine.
@@ -80,18 +81,20 @@ should not be modified by AI-driven code changes.
   are cleaned automatically.
 
 ## Creating New Models
-Model definition follows a two-file system and detailed instructions are in
+Model definition historically used a two-file system (Markdown + Python module).
+The legacy approach is preserved here for reference and is documented in
 `AGENTS.md`:
 1. **Markdown file** (`cosmo_model_name.md`) describing equations and providing
    a table of parameters. Each model file should conclude with the *Internal
    Formatting Guide for Model Definition Files* so contributors understand the
    required structure.
 2. **Python plugin** implementing the required functions listed in `AGENTS.md`.
-   Place this module in the `models` package and reference its filename in the
-   Markdown front matter under `model_plugin`.
+   These plugins will be retired once every Markdown file is migrated to the JSON
+   DSL, but they remain as examples for now.
 
 Version 1.5a introduces an experimental **JSON DSL** for model definitions. A
-`cosmo_model_name.json` file contains:
+`cosmo_model_name.json` file will eventually replace both the Markdown file and
+the Python plugin. It contains:
 
 - `model_name`, `version`, and `date` metadata
 - a list of parameter objects with `name`, `latex`, `guess`, `bounds`, and
@@ -121,7 +124,7 @@ Copernican Suite.
 1.  **Dependency Check**: `copernican.py` verifies required Python libraries.
 2.  **Initialization**: Logging via `scripts/logger.py` starts and the `./output/` directory is created.
 3.  **Configuration**: The user specifies model and data paths. Test mode (`test`) runs ΛCDM against itself.
-4.  **Model Parsing and Conversion**: The JSON DSL is processed by `model_parser.py` and `model_converter.py`.
+4.  **Model Parsing and Encoding**: The JSON DSL is processed by `model_parser.py` and `model_encoder.py`.
 5.  **SNe Ia Fitting**: The selected engine receives callables through `engine_interface.py` and fits parameters.
 6.  **BAO Analysis**: Using best-fit parameters, the engine computes BAO observables.
 7.  **Output Generation**: Plots and CSVs are produced via `plotter.py`, `csv_writer.py`, and `output_manager.py`.

--- a/scripts/model_converter.py
+++ b/scripts/model_converter.py
@@ -1,8 +1,0 @@
-"""Converts cached DSL data into executable Python callables."""
-# DEV NOTE (v1.5a): Skeleton for Phase 0. Actual conversion logic will be
-# implemented in Phase 2.
-
-def convert_cached_model(cache_path):
-    """Placeholder stub that should return Python callables."""
-    # TODO: parse the cached JSON and generate callables
-    return {}

--- a/scripts/model_encoder.py
+++ b/scripts/model_encoder.py
@@ -1,0 +1,8 @@
+"""Encodes cached DSL data into executable Python callables."""
+# DEV NOTE (v1.5a): File renamed from model_converter.py.
+# It remains a placeholder until Phase 2 implements the real encoder.
+
+def convert_cached_model(cache_path):
+    """Placeholder stub that should return Python callables."""
+    # TODO: parse the cached JSON and generate callables
+    return {}


### PR DESCRIPTION
## Summary
- rename `model_converter.py` to `model_encoder.py`
- update README and PLAN to mention the new name
- document that only Markdown files will be migrated to JSON and Python plugins will be removed
- adjust README description of legacy plugin system

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ef2e73354832f99d8786dd1d2c4ca