### PR TITLE
Implement Phase 6 and bump version to 1.5f

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,16 @@
-# DEV NOTE (v1.5e)
-Updated for Phase 5. Added Numba engine and modular utilities.
+# DEV NOTE (v1.5f)
+Updated for Phase 6. Added placeholder parsers for CMB, gravitational waves and standard sirens, and expanded JSON schema.
 
 # Copernican Suite Development Guide
 
 This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications.
 
 ## 1. Program Overview
-The suite evaluates cosmological models against SNe Ia and BAO data. Users interact with `copernican.py`, choose a model from `./models/`, pick a computational engine from `./engines/` and select data parsers from `./parsers/`. Results are saved under `./output/`.
+The suite evaluates cosmological models against SNe Ia and BAO data. Support for
+additional observations such as CMB, gravitational waves and standard sirens is
+being prepared. Users interact with `copernican.py`, choose a model from
+`./models/`, pick a computational engine from `./engines/` and select data
+parsers from `./parsers/`. Results are saved under `./output/`.
 
 The default engine is `engines/cosmo_engine_1_4b.py`. All model plugins are validated
 through `scripts/engine_interface.py` before being passed to the engine. This
@@ -16,7 +20,7 @@ ensures the expected functions are present and callable.
 ```
 models/           - JSON model definitions (Markdown files optional)
 engines/          - Computational backends (SciPy CPU by default)
-parsers/          - Data format parsers for SNe and BAO
+parsers/          - Data format parsers for SNe, BAO, CMB, gravitational waves and standard sirens
 data/             - Example data files
 output/           - Generated plots and CSV tables
 AGENTS.md         - Development specification and contributor rules
@@ -32,7 +36,7 @@ suite automatically. This mechanism works on Windows, macOS and Linux so new
 engines can introduce additional dependencies without manual updates.
 
 ## 4. JSON Model System
-As of version 1.5e every cosmological model is described by a single JSON file
+As of version 1.5f every cosmological model is described by a single JSON file
 `cosmo_model_*.json`. Markdown files may accompany the JSON for human
 readability, but there are no permanent Python plugins in the repository.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Copernican Suite Change Log
-<!-- DEV NOTE (v1.5e): Added release notes for Phase 5 and bumped version. -->
+<!-- DEV NOTE (v1.5f): Added release notes for Phase 6 and bumped version. -->
+## Version 1.5f (Development Release)
+- Completed Phase 6: JSON schema extended with optional fields for CMB,
+  gravitational waves and standard sirens. Added placeholder parser modules
+  and loader functions for these data types.
+- Updated documentation for version 1.5f.
+
 ## Version 1.5e (Development Release)
 - Added Numba-based engine and modular utility wrappers.
 - Updated documentation for version 1.5e.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,5 +1,5 @@
-# DEV NOTE (v1.5e)
-Updated for Phase 5 completion and version bump to 1.5e.
+# DEV NOTE (v1.5f)
+Updated for Phase 6 completion and version bump to 1.5f.
 
 # Copernican Suite Refactoring Plan
 This document explains how the project will evolve from the current Markdown + Python plugin system to a cleaner architecture where cosmological models are described solely in JSON. All engines will load code generated on the fly.
@@ -62,8 +62,10 @@ This pipeline ensures that models stay purely declarative while engines receive 
 ## Phase 6 – Future Data Types & Extensibility
 1. **Prepare the schema for new observations**
    - Add optional fields in the JSON for CMB, gravitational waves, standard sirens, and any other data types we may add later.
+   - *Done 2025-06-20 – JSON schema updated with optional CMB, gravitational wave and standard siren sections.*
 2. **Update parsers and documentation**
    - When new data become available, introduce matching parser modules and update examples so users can easily extend the suite.
+   - *Done 2025-06-20 – Parser registries and placeholder modules added for CMB, gravitational waves and standard sirens; documentation updated.*
 
 ---
 ### Progress Tracking
@@ -77,3 +79,4 @@ Whenever a phase or bullet point is completed, insert a short note below it summ
 - **2025-06-18** – Added automatic dependency installation triggered by `copernican.py`.
 
 - **2025-06-19** – Phase 5 completed. Added Numba engine and split output utilities into separate modules.
+- **2025-06-20** – Phase 6 completed. JSON schema now includes optional fields for CMB, gravitational waves and standard sirens. Parser framework extended accordingly.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Copernican Suite
-<!-- DEV NOTE (v1.5e): Updated for Phase 5, added Numba engine and modular utilities. -->
+<!-- DEV NOTE (v1.5f): Updated for Phase 6 with new data-type placeholders and schema fields. -->
 
-**Version:** 1.5e
-**Last Updated:** 2025-06-19
+**Version:** 1.5f
+**Last Updated:** 2025-06-20
 engines/          - Computational backends (SciPy CPU by default, plus Numba)
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
-Supernovae Type Ia (SNe Ia) and Baryon Acoustic Oscillation (BAO) data. It
-provides a modular architecture that allows new models, data parsers and
-computational engines to be plugged in with minimal effort.
+Supernovae Type Ia (SNe Ia) and Baryon Acoustic Oscillation (BAO) data. Future
+releases will also handle Cosmic Microwave Background (CMB) measurements,
+gravitational waves and standard siren events. The suite provides a modular
+architecture so new models, data parsers and computational engines can be
+plugged in with minimal effort.
 
 ---
 
@@ -64,7 +66,7 @@ packages include `numpy`, `scipy`, `matplotlib`, `pandas`, `sympy`, `psutil` and
 ```
 models/           - JSON model definitions (Markdown optional)
 engines/          - Computational backends (SciPy CPU and Numba)
-parsers/          - Data format parsers for SNe and BAO
+parsers/          - Data format parsers for SNe, BAO, CMB, gravitational waves and standard sirens
 data/             - Example data files
 output/           - All generated results
 AGENTS.md         - Development specification and contributor rules
@@ -79,7 +81,8 @@ should not be modified by AI-driven code changes.
 ## Using the Suite
 - The program discovers available models from `models/cosmo_model_*.md`.
 - Data files for SNe and BAO are chosen interactively from `data/sne` and
-  `data/bao`.
+  `data/bao`. Future datasets such as CMB or gravitational waves will use
+  their own folders.
 - Parsers and engines are also selected interactively from their respective
   directories.
 - After each run you may choose to evaluate another model or exit. Cache files
@@ -105,7 +108,10 @@ auto-generates the necessary Python functions.
   ],
   "equations": {
     "distance_modulus_model": "5*sympy.log(1+z,10)*H0"
-  }
+  },
+  "cmb": {},
+  "gravitational_waves": {},
+  "standard_sirens": {}
 }
 ```
 `model_parser.py` validates this structure and `model_coder.py` translates the

--- a/copernican.py
+++ b/copernican.py
@@ -2,9 +2,9 @@
 """
 Copernican Suite - Main Orchestrator.
 """
-# DEV NOTE (v1.5e): Added Numba engine option and separated utilities into modules.
-# automatic dependency installer triggered by missing packages. Plugin
-# validation now occurs on the generated module.
+# DEV NOTE (v1.5f): Added placeholders for future data types and bumped version.
+# Automatic dependency installer still triggers when packages are missing.
+# Plugin validation now occurs on the generated module.
 # Previous notes retained below for context.
 # DEV NOTE (v1.4.1): Added splash screen, per-run logging with timestamps, and
 # migrated the base model import to the new `lcdm.py` plugin file.
@@ -27,7 +27,7 @@ import glob
 import time
 from scripts import model_parser, model_coder, engine_interface
 
-COPERNICAN_VERSION = "1.5e"
+COPERNICAN_VERSION = "1.5f"
 
 def show_splash_screen():
     """Displays the startup banner once at launch."""

--- a/data_loaders.py
+++ b/data_loaders.py
@@ -1,4 +1,6 @@
 # copernican_suite/data_loaders.py
+# DEV NOTE (v1.5f): Added registries and loader functions for CMB, gravitational
+# wave, and standard siren data types as preparation for future datasets.
 """
 Modular data loading for various cosmological datasets (SNe, BAO, etc.).
 """
@@ -12,6 +14,9 @@ import importlib
 # --- Parser Registry ---
 SNE_PARSERS = {}
 BAO_PARSERS = {}
+CMB_PARSERS = {}
+GW_PARSERS = {}
+SIREN_PARSERS = {}
 
 # --- Helper function for user input, localized to this module ---
 def _get_user_input_filepath(prompt_message, base_dir, must_exist=True):
@@ -48,11 +53,32 @@ def register_bao_parser(name, description=""):
         return func
     return decorator
 
+def register_cmb_parser(name, description=""):
+    """Decorator to register a CMB data parsing function."""
+    def decorator(func):
+        CMB_PARSERS[name] = {'function': func, 'description': description}
+        return func
+    return decorator
+
+def register_gw_parser(name, description=""):
+    """Decorator to register a gravitational wave data parsing function."""
+    def decorator(func):
+        GW_PARSERS[name] = {'function': func, 'description': description}
+        return func
+    return decorator
+
+def register_siren_parser(name, description=""):
+    """Decorator to register a standard siren data parsing function."""
+    def decorator(func):
+        SIREN_PARSERS[name] = {'function': func, 'description': description}
+        return func
+    return decorator
+
 # --- Dynamic Discovery of Parser Modules ---
 def _discover_parsers():
     """Imports all parser modules under the ./parsers directory."""
     base_dir = os.path.join(os.path.dirname(__file__), 'parsers')
-    for sub in ('sne', 'bao'):
+    for sub in ('sne', 'bao', 'cmb', 'gw', 'sirens'):
         subdir = os.path.join(base_dir, sub)
         if not os.path.isdir(subdir):
             continue
@@ -166,4 +192,112 @@ def load_bao_data(filepath, format_key=None, **kwargs):
         return data_df
     except Exception as e:
         logger.critical(f"CRITICAL Error during BAO data parsing ({filepath}, {format_key}): {e}", exc_info=True)
+        return None
+
+def load_cmb_data(filepath, format_key=None, **kwargs):
+    """Loads CMB data using a registered parser."""
+    logger = logging.getLogger()
+    if not os.path.isfile(filepath):
+        logger.error(f"CMB data file not found at {filepath}")
+        return None
+
+    if format_key is None:
+        format_key = _select_parser(CMB_PARSERS, "CMB")
+        if format_key is None:
+            logger.info("CMB data loading canceled by user.")
+            return None
+
+    if format_key not in CMB_PARSERS:
+        logger.error(f"No CMB parser registered for format_key '{format_key}'")
+        return None
+
+    try:
+        logger.info(f"Attempting to load CMB data from '{os.path.basename(filepath)}' using format: {format_key}")
+        parser_func = CMB_PARSERS[format_key]['function']
+        data_df = parser_func(filepath, **kwargs)
+        if data_df is not None and not data_df.empty:
+            data_df.attrs['filepath'] = filepath
+            data_df.attrs['format_key'] = format_key
+            if 'dataset_name_attr' not in data_df.attrs:
+                data_df.attrs['dataset_name_attr'] = f"CMB_{format_key.replace(' ', '_')}"
+            logger.info(f"Successfully loaded {len(data_df)} CMB data points.")
+        elif data_df is None:
+            logger.error(f"CMB parser '{format_key}' returned None for {filepath}.")
+        else:
+            logger.error(f"CMB parser '{format_key}' returned an empty DataFrame for {filepath}.")
+        return data_df
+    except Exception as e:
+        logger.critical(f"CRITICAL Error during CMB data parsing ({filepath}, {format_key}): {e}", exc_info=True)
+        return None
+
+def load_gw_data(filepath, format_key=None, **kwargs):
+    """Loads gravitational wave data using a registered parser."""
+    logger = logging.getLogger()
+    if not os.path.isfile(filepath):
+        logger.error(f"Gravitational wave data file not found at {filepath}")
+        return None
+
+    if format_key is None:
+        format_key = _select_parser(GW_PARSERS, "GW")
+        if format_key is None:
+            logger.info("Gravitational wave data loading canceled by user.")
+            return None
+
+    if format_key not in GW_PARSERS:
+        logger.error(f"No gravitational wave parser registered for format_key '{format_key}'")
+        return None
+
+    try:
+        logger.info(f"Attempting to load GW data from '{os.path.basename(filepath)}' using format: {format_key}")
+        parser_func = GW_PARSERS[format_key]['function']
+        data_df = parser_func(filepath, **kwargs)
+        if data_df is not None and not data_df.empty:
+            data_df.attrs['filepath'] = filepath
+            data_df.attrs['format_key'] = format_key
+            if 'dataset_name_attr' not in data_df.attrs:
+                data_df.attrs['dataset_name_attr'] = f"GW_{format_key.replace(' ', '_')}"
+            logger.info(f"Successfully loaded {len(data_df)} GW data points.")
+        elif data_df is None:
+            logger.error(f"GW parser '{format_key}' returned None for {filepath}.")
+        else:
+            logger.error(f"GW parser '{format_key}' returned an empty DataFrame for {filepath}.")
+        return data_df
+    except Exception as e:
+        logger.critical(f"CRITICAL Error during GW data parsing ({filepath}, {format_key}): {e}", exc_info=True)
+        return None
+
+def load_siren_data(filepath, format_key=None, **kwargs):
+    """Loads standard siren data using a registered parser."""
+    logger = logging.getLogger()
+    if not os.path.isfile(filepath):
+        logger.error(f"Standard siren data file not found at {filepath}")
+        return None
+
+    if format_key is None:
+        format_key = _select_parser(SIREN_PARSERS, "standard siren")
+        if format_key is None:
+            logger.info("Standard siren data loading canceled by user.")
+            return None
+
+    if format_key not in SIREN_PARSERS:
+        logger.error(f"No standard siren parser registered for format_key '{format_key}'")
+        return None
+
+    try:
+        logger.info(f"Attempting to load siren data from '{os.path.basename(filepath)}' using format: {format_key}")
+        parser_func = SIREN_PARSERS[format_key]['function']
+        data_df = parser_func(filepath, **kwargs)
+        if data_df is not None and not data_df.empty:
+            data_df.attrs['filepath'] = filepath
+            data_df.attrs['format_key'] = format_key
+            if 'dataset_name_attr' not in data_df.attrs:
+                data_df.attrs['dataset_name_attr'] = f"SIREN_{format_key.replace(' ', '_')}"
+            logger.info(f"Successfully loaded {len(data_df)} standard siren data points.")
+        elif data_df is None:
+            logger.error(f"Standard siren parser '{format_key}' returned None for {filepath}.")
+        else:
+            logger.error(f"Standard siren parser '{format_key}' returned an empty DataFrame for {filepath}.")
+        return data_df
+    except Exception as e:
+        logger.critical(f"CRITICAL Error during standard siren data parsing ({filepath}, {format_key}): {e}", exc_info=True)
         return None

--- a/parsers/cmb/__init__.py
+++ b/parsers/cmb/__init__.py
@@ -1,0 +1,1 @@
+# DEV NOTE (v1.5f): Package init for CMB parsers.

--- a/parsers/cmb/cosmo_parser_cmb_placeholder.py
+++ b/parsers/cmb/cosmo_parser_cmb_placeholder.py
@@ -1,0 +1,10 @@
+# DEV NOTE (v1.5f): Placeholder parser for future CMB data formats.
+import logging
+from data_loaders import register_cmb_parser
+
+@register_cmb_parser("cmb_placeholder_v1", "Placeholder CMB parser.")
+def parse_cmb_placeholder(filepath, **kwargs):
+    """Stub parser that logs a message and returns None."""
+    logger = logging.getLogger()
+    logger.info(f"CMB parser placeholder invoked for {filepath}. Feature not implemented.")
+    return None

--- a/parsers/gw/__init__.py
+++ b/parsers/gw/__init__.py
@@ -1,0 +1,1 @@
+# DEV NOTE (v1.5f): Package init for gravitational wave parsers.

--- a/parsers/gw/cosmo_parser_gw_placeholder.py
+++ b/parsers/gw/cosmo_parser_gw_placeholder.py
@@ -1,0 +1,10 @@
+# DEV NOTE (v1.5f): Placeholder parser for future gravitational wave data formats.
+import logging
+from data_loaders import register_gw_parser
+
+@register_gw_parser("gw_placeholder_v1", "Placeholder GW parser.")
+def parse_gw_placeholder(filepath, **kwargs):
+    """Stub parser that logs a message and returns None."""
+    logger = logging.getLogger()
+    logger.info(f"GW parser placeholder invoked for {filepath}. Feature not implemented.")
+    return None

--- a/parsers/sirens/__init__.py
+++ b/parsers/sirens/__init__.py
@@ -1,0 +1,1 @@
+# DEV NOTE (v1.5f): Package init for standard siren parsers.

--- a/parsers/sirens/cosmo_parser_sirens_placeholder.py
+++ b/parsers/sirens/cosmo_parser_sirens_placeholder.py
@@ -1,0 +1,10 @@
+# DEV NOTE (v1.5f): Placeholder parser for future standard siren data formats.
+import logging
+from data_loaders import register_siren_parser
+
+@register_siren_parser("siren_placeholder_v1", "Placeholder standard siren parser.")
+def parse_siren_placeholder(filepath, **kwargs):
+    """Stub parser that logs a message and returns None."""
+    logger = logging.getLogger()
+    logger.info(f"Standard siren parser placeholder invoked for {filepath}. Feature not implemented.")
+    return None

--- a/scripts/model_parser.py
+++ b/scripts/model_parser.py
@@ -1,6 +1,7 @@
 """Model parser for Copernican Suite JSON models."""
-# DEV NOTE (v1.5e): Writes validated JSON models to the cache directory and
-# reports errors through ``error_handler``.
+# DEV NOTE (v1.5f): Schema updated with optional CMB, gravitational wave, and
+# standard siren fields for Phase 6. Writes validated JSON models to the cache
+# directory and reports errors through ``error_handler``.
 
 import json
 from jsonschema import validate, ValidationError
@@ -33,7 +34,10 @@ MODEL_SCHEMA = {
                 }
             }
         },
-        "equations": {"type": "object"}
+        "equations": {"type": "object"},
+        "cmb": {"type": "object"},
+        "gravitational_waves": {"type": "object"},
+        "standard_sirens": {"type": "object"}
     }
 }
 


### PR DESCRIPTION
## Summary
- extend JSON schema for future data types
- add placeholder parser modules for CMB, gravitational waves and standard sirens
- expand data loader with registries and loaders for new data
- document Phase 6 completion and bump development version to 1.5f

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f4b0ac99c832fa063cb5daa7af499