### PR TITLE
Fix dependency scanner and SymPy parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 # DEV NOTE (v1.5f)
+Hotfix: improved dependency scanner to skip relative imports and added SymPy aliasing in model_coder.
 Updated for Phase 6. Added placeholder parsers for CMB, gravitational waves and standard sirens, and expanded JSON schema.
 
 # Copernican Suite Development Guide

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Copernican Suite
 <!-- DEV NOTE (v1.5f): Updated for Phase 6 with new data-type placeholders and schema fields. -->
+<!-- DEV NOTE (v1.5f hotfix): Dependency scanner ignores relative imports; JSON models now support "sympy." prefix. -->
 
 **Version:** 1.5f
 **Last Updated:** 2025-06-20

--- a/copernican.py
+++ b/copernican.py
@@ -3,6 +3,7 @@
 Copernican Suite - Main Orchestrator.
 """
 # DEV NOTE (v1.5f): Added placeholders for future data types and bumped version.
+# DEV NOTE (v1.5f hotfix): Fixed dependency scanner to ignore relative imports.
 # Automatic dependency installer still triggers when packages are missing.
 # Plugin validation now occurs on the generated module.
 # Previous notes retained below for context.
@@ -66,15 +67,24 @@ def _gather_required_packages():
                             if line.startswith('import '):
                                 parts = line.split()
                                 if len(parts) >= 2:
-                                    pkg_names.add(parts[1].split('.')[0])
+                                    mod = parts[1].split('.')[0]
+                                    if mod and not mod.startswith('.'):
+                                        pkg_names.add(mod)
                             elif line.startswith('from '):
                                 parts = line.split()
                                 if len(parts) >= 2:
-                                    pkg_names.add(parts[1].split('.')[0])
+                                    mod = parts[1].split('.')[0]
+                                    if mod and not mod.startswith('.'):
+                                        pkg_names.add(mod)
     ignore = {
+        # Standard library modules or local packages that should not trigger
+        # the dependency installer
         'os', 'sys', 'time', 'json', 'logging', 'subprocess', 'importlib',
         'multiprocessing', 'glob', 'shutil', 'platform', 'inspect', 'types',
-        'pathlib', 'builtins'
+        'pathlib', 'builtins', 'traceback', 'typing',
+        # Local modules within this repository
+        'data_loaders', 'output_manager', 'csv_writer', 'plotter', 'logger',
+        'utils'
     }
     return {pkg for pkg in pkg_names if not pkg.startswith(('scripts', 'engines', 'parsers')) and pkg not in ignore}
 

--- a/scripts/model_coder.py
+++ b/scripts/model_coder.py
@@ -1,5 +1,6 @@
 """Model coder that turns validated JSON into callable Python functions."""
 # DEV NOTE (v1.5e): Loads sanitized models from ``models/cache`` and stores the
+# DEV NOTE (v1.5e hotfix): Allow sympy-prefixed expressions by mapping "sympy" to SymPy.
 # generated SymPy expressions back to that cache.
 
 import json
@@ -29,6 +30,8 @@ def generate_callables(cache_path):
     param_syms = [sp.symbols(p['python_var']) for p in model_data['parameters']]
     local_dict = {p['python_var']: sym for p, sym in zip(model_data['parameters'], param_syms)}
     local_dict['z'] = z
+    # Allow JSON equations to reference the full 'sympy' prefix as well as shorthand
+    local_dict['sympy'] = sp
 
     funcs = {}
     code_dict = {}


### PR DESCRIPTION
## Summary
- ensure dependency scanning ignores relative imports and local modules
- handle `sympy.` prefix in model JSON equations
- document changes in AGENTS and README

## Testing
- `python copernican.py 2>&1 | head -n 20`
- `python - <<'EOF'
from scripts import model_parser, model_coder
cache_path=model_parser.parse_model_json('models/cosmo_model_lcdm.json','models/cache')
funcs,data=model_coder.generate_callables(cache_path)
print('functions created:', list(funcs.keys()))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684f4e4237d8832fbbdbed7d5e849d57