### PR TITLE
Move helper modules under scripts

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -12,7 +12,7 @@ After finishing each phase or major step, append a short paragraph here describi
 3. **`scripts/model_parser.py`** – Checks that the JSON follows the `cosmo_model_template.json` format. If valid, it writes a `models/cache/cache_*.json` file containing the cleaned data. If invalid, details are handed to `scripts/error_handler.py` so the user knows what to fix.
 4. **`scripts/model_coder.py`** – Reads the cache, converts the model equations and plan into executable Python code, and stores that generated code back in the same cache file. There is no permanent Python model file.
 5. **`scripts/engine_interface.py`** – Loads the generated code from the cache and passes it to whichever engine (`cosmo_engine_*.py`, Numba, OpenCL, etc.) the user chooses. Engines themselves remain black boxes.
-6. **Results & cleanup** – `output_manager.py` orchestrates plotting via `plotter.py`, writes CSV files with `csv_writer.py`, and `logger.py` records every step. Afterward, the user is asked whether to delete the cache file.
+6. **Results & cleanup** – `scripts/output_manager.py` orchestrates plotting via `scripts/plotter.py`, writes CSV files with `scripts/csv_writer.py`, and `scripts/logger.py` records every step. Afterward, the user is asked whether to delete the cache file.
    - *Done 2025-06-15 – Initial pipeline implemented with stub modules and JSON detection in `copernican.py`.*
 
 This pipeline ensures that models stay purely declarative while engines receive ready-to-run Python functions.
@@ -57,7 +57,7 @@ This pipeline ensures that models stay purely declarative while engines receive 
 1. **Add alternative engines**
    - Implement faster back ends using Numba or GPU acceleration. Each engine simply consumes the callables provided by `engine_interface.py`.
 2. **Refine modular utilities**
-   - Keep `logger.py`, `plotter.py`, and `csv_writer.py` separate so they can be reused across engines and future data types.
+  - Keep `scripts/logger.py`, `scripts/plotter.py`, and `scripts/csv_writer.py` separate so they can be reused across engines and future data types.
 
 ## Phase 6 – Future Data Types & Extensibility
 1. **Prepare the schema for new observations**

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Under the hood the program follows a clear pipeline:
    for both the ΛCDM reference and the alternative model.
 5. **BAO Analysis** – using the best-fit parameters the engine predicts BAO
    observables and computes chi-squared statistics.
-6. **Output Generation** – `logger.py`, `plotter.py` and `csv_writer.py` handle logs, plots and tables.
+6. **Output Generation** – `scripts/logger.py`, `scripts/plotter.py` and `scripts/csv_writer.py` handle logs, plots and tables.
 7. **Loop or Exit** – the user may evaluate another model or quit, at which
    point temporary cache files are cleaned automatically.
 
@@ -73,9 +73,13 @@ data/             - Example data files
 output/           - All generated results
 AGENTS.md         - Development specification and contributor rules
 CHANGELOG.md      - Release history
-logger.py         - Logging setup and helpers
-plotter.py       - Plotting functions
-csv_writer.py    - CSV output helpers
+scripts/          - Helper modules
+  logger.py         - Logging setup and helpers
+  plotter.py        - Plotting functions
+  csv_writer.py     - CSV output helpers
+  output_manager.py - Plotting, CSV, and logging utilities
+  data_loaders.py   - Data loading utilities
+  utils.py          - Common helpers
 ```
 **Note:** Files in `data/` are treated as read-only reference datasets and
 should not be modified by AI-driven code changes.

--- a/copernican.py
+++ b/copernican.py
@@ -82,7 +82,7 @@ def _gather_required_packages():
         'os', 'sys', 'time', 'json', 'logging', 'subprocess', 'importlib',
         'multiprocessing', 'glob', 'shutil', 'platform', 'inspect', 'types',
         'pathlib', 'builtins', 'traceback', 'typing',
-        # Local modules within this repository
+        # Local modules within this repository (under ``scripts``)
         'data_loaders', 'output_manager', 'csv_writer', 'plotter', 'logger',
         'utils'
     }
@@ -121,8 +121,7 @@ def check_dependencies():
 
 
 # Import sibling modules after the dependency check
-import data_loaders
-import output_manager
+from scripts import data_loaders, output_manager
 
 lcdm = None
 

--- a/parsers/bao/cosmo_parser_bao_json.py
+++ b/parsers/bao/cosmo_parser_bao_json.py
@@ -1,11 +1,12 @@
 # DEV NOTE (v1.5e): General BAO JSON parser separated for modular discovery.
+# DEV NOTE (v1.5f hotfix): Updated import path for ``data_loaders`` package.
 
 import pandas as pd
 import json
 import os
 import logging
 
-from data_loaders import register_bao_parser
+from scripts.data_loaders import register_bao_parser
 
 
 @register_bao_parser("bao_json_general_v1", "General BAO JSON format (e.g., bao1.json).")

--- a/parsers/cmb/cosmo_parser_cmb_placeholder.py
+++ b/parsers/cmb/cosmo_parser_cmb_placeholder.py
@@ -1,6 +1,7 @@
 # DEV NOTE (v1.5f): Placeholder parser for future CMB data formats.
+# DEV NOTE (v1.5f hotfix): Updated import path for ``data_loaders`` module.
 import logging
-from data_loaders import register_cmb_parser
+from scripts.data_loaders import register_cmb_parser
 
 @register_cmb_parser("cmb_placeholder_v1", "Placeholder CMB parser.")
 def parse_cmb_placeholder(filepath, **kwargs):

--- a/parsers/gw/cosmo_parser_gw_placeholder.py
+++ b/parsers/gw/cosmo_parser_gw_placeholder.py
@@ -1,6 +1,7 @@
 # DEV NOTE (v1.5f): Placeholder parser for future gravitational wave data formats.
+# DEV NOTE (v1.5f hotfix): Updated ``data_loaders`` import to new location.
 import logging
-from data_loaders import register_gw_parser
+from scripts.data_loaders import register_gw_parser
 
 @register_gw_parser("gw_placeholder_v1", "Placeholder GW parser.")
 def parse_gw_placeholder(filepath, **kwargs):

--- a/parsers/sirens/cosmo_parser_sirens_placeholder.py
+++ b/parsers/sirens/cosmo_parser_sirens_placeholder.py
@@ -1,6 +1,7 @@
 # DEV NOTE (v1.5f): Placeholder parser for future standard siren data formats.
+# DEV NOTE (v1.5f hotfix): Updated import path for ``data_loaders``.
 import logging
-from data_loaders import register_siren_parser
+from scripts.data_loaders import register_siren_parser
 
 @register_siren_parser("siren_placeholder_v1", "Placeholder standard siren parser.")
 def parse_siren_placeholder(filepath, **kwargs):

--- a/parsers/sne/cosmo_parser_h1_unistra.py
+++ b/parsers/sne/cosmo_parser_h1_unistra.py
@@ -1,10 +1,11 @@
 # DEV NOTE (v1.5e): Extracted from data_loaders.py during modular refactor.
 # This module registers the UniStra fixed-nuisance (h1) parser.
+# DEV NOTE (v1.5f hotfix): Updated ``data_loaders`` import path.
 
 import pandas as pd
 import logging
 
-from data_loaders import register_sne_parser
+from scripts.data_loaders import register_sne_parser
 
 DEFAULT_SALT2_M_ABS_FIXED = -19.3
 DEFAULT_SALT2_ALPHA_FIXED = 0.14

--- a/parsers/sne/cosmo_parser_h2_unistra.py
+++ b/parsers/sne/cosmo_parser_h2_unistra.py
@@ -1,10 +1,11 @@
 # DEV NOTE (v1.5e): Extracted from data_loaders.py for modular architecture.
 # Registers the UniStra raw light-curve (h2) parser.
+# DEV NOTE (v1.5f hotfix): Updated ``data_loaders`` import path.
 
 import pandas as pd
 import logging
 
-from data_loaders import register_sne_parser
+from scripts.data_loaders import register_sne_parser
 
 @register_sne_parser(
     "unistra_raw_lc_h2",

--- a/parsers/sne/cosmo_parser_pantheon.py
+++ b/parsers/sne/cosmo_parser_pantheon.py
@@ -1,11 +1,12 @@
 # DEV NOTE (v1.5e): Pantheon+ covariance parser separated for plugin architecture.
+# DEV NOTE (v1.5f hotfix): Updated ``data_loaders`` import path.
 
 import pandas as pd
 import numpy as np
 import os
 import logging
 
-from data_loaders import register_sne_parser, _get_user_input_filepath
+from scripts.data_loaders import register_sne_parser, _get_user_input_filepath
 
 
 def _get_pantheon_plus_args(base_dir):

--- a/scripts/csv_writer.py
+++ b/scripts/csv_writer.py
@@ -1,9 +1,10 @@
 # Copernican Suite CSV Writer
 """Wrapper module exposing CSV writing utilities."""
+# DEV NOTE (v1.5f): Moved into ``scripts/`` package and updated output_manager import.
 # DEV NOTE (v1.5e): Thin wrappers calling `output_manager` CSV helpers.
 
 from typing import Any
-import output_manager as _om
+from . import output_manager as _om
 
 
 def save_sne_results_detailed_csv(*args: Any, **kwargs: Any) -> None:

--- a/scripts/data_loaders.py
+++ b/scripts/data_loaders.py
@@ -1,6 +1,7 @@
 # copernican_suite/data_loaders.py
 # DEV NOTE (v1.5f): Added registries and loader functions for CMB, gravitational
 # wave, and standard siren data types as preparation for future datasets.
+# DEV NOTE (v1.5f hotfix): File moved to ``scripts/`` package; import paths for parsers updated.
 """
 Modular data loading for various cosmological datasets (SNe, BAO, etc.).
 """

--- a/scripts/logger.py
+++ b/scripts/logger.py
@@ -1,11 +1,12 @@
 # Copernican Suite Logger
 """Logging utilities for the Copernican Suite."""
+# DEV NOTE (v1.5f): Module moved to ``scripts/`` package and import path updated.
 # DEV NOTE (v1.5e): Separated from output_manager for Phase 5 modularization.
 
 import logging
 import os
 import sys
-from utils import get_timestamp, ensure_dir_exists
+from .utils import get_timestamp, ensure_dir_exists
 
 
 def setup_logging(log_dir="."):

--- a/scripts/output_manager.py
+++ b/scripts/output_manager.py
@@ -1,4 +1,5 @@
 # copernican_suite/output_manager.py
+# DEV NOTE (v1.5f): Module moved under ``scripts/`` package; internal references remain unchanged.
 # DEV NOTE (v1.5e): Logging utilities now accessible via logger.py; plotting and CSV functions via new wrappers.
 """
 Output Manager for the Copernican Suite.

--- a/scripts/plotter.py
+++ b/scripts/plotter.py
@@ -1,9 +1,10 @@
 # Copernican Suite Plotter
 """Wrapper module exposing plotting utilities."""
+# DEV NOTE (v1.5f): Relocated into ``scripts/`` package; import adjusted.
 # DEV NOTE (v1.5e): Thin wrappers calling `output_manager` functions for reuse across engines.
 
 from typing import Any
-import output_manager as _om
+from . import output_manager as _om
 
 
 def format_model_summary_text(*args: Any, **kwargs: Any) -> str:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,5 +1,6 @@
 # utils.py
 """Common utility functions for the Copernican Suite."""
+# DEV NOTE (v1.5f): File relocated into ``scripts/`` package.
 # DEV NOTE (v1.5e): Extracted timestamp and filename helpers for modular utilities.
 
 import os


### PR DESCRIPTION
## Summary
- relocate utility modules to `scripts/`
- update imports across code base
- refresh documentation for new locations

## Testing
- `python3 -m py_compile copernican.py scripts/*.py parsers/*/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684f63b3084c832fa1f10cfcd8e02871