### PR TITLE
Add symbolic Hz_expression system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Hotfix 2: JSON models now contain optional abstract, description and notes field
 Hotfix 3: `copernican.py` now performs the dependency check before importing third-party packages to avoid start-up failures. Style fixes applied across the codebase.
 Hotfix 4: Multiprocessing's `freeze_support` is now called using a local import after the dependency check to prevent NoneType errors.
 Hotfix 5: Removed automatic dependency installer. The suite now instructs users to run `pip install` manually when packages are missing.
+Hotfix 7: Models now provide a symbolic `Hz_expression` compiled at runtime for distance calculations.
 Updated for Phase 6. Added placeholder parsers for CMB, gravitational waves and standard sirens, and expanded JSON schema.
 
 # Copernican Suite Development Guide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Updated documentation for version 1.5f.
 - Hotfix 5: Removed automatic dependency installer. Users are now instructed to
   run a printed `pip install` command when packages are missing.
+- Hotfix 7: `Hz_expression` added to JSON models and compiled automatically for
+  distance predictions.
 
 ## Version 1.5e (Development Release)
 - Added Numba-based engine and modular utility wrappers.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ included for explanatory text but are not required. To create a new model:
    your theory.
 2. Optionally create `cosmo_model_name.md` to document the equations in LaTeX so
    other researchers can read them easily.
+3. Include an `Hz_expression` string defining `H(z)` in terms of your model
+   parameters. This enables BAO and distance-based predictions.
 The suite validates the JSON, stores a sanitized copy under `models/cache/`, and
 auto-generates the necessary Python functions.
 
@@ -114,6 +116,7 @@ auto-generates the necessary Python functions.
 {
   "model_name": "My Model",
   "version": "1.0",
+  "Hz_expression": "H0 * sympy.sqrt(Om*(1+z)**3 + Ol)",
   "parameters": [
     {"name": "H0", "python_var": "H0", "initial_guess": 70.0, "bounds": [50, 100]}
   ],
@@ -129,7 +132,9 @@ auto-generates the necessary Python functions.
 }
 ```
 `model_parser.py` validates this structure and `model_coder.py` translates the
-equations into NumPy-ready callables used by `engine_interface.py`.
+equations into NumPy-ready callables. When `Hz_expression` is present it is
+compiled into `get_Hz_per_Mpc` and related distance functions used by
+`engine_interface.py`.
 
 ## Development Notes
 All changes must include a `DEV NOTE` at the top of modified files explaining

--- a/models/cosmo_model_lcdm.json
+++ b/models/cosmo_model_lcdm.json
@@ -1,14 +1,14 @@
 {
-  "dev_note": "v1.5f hotfix: added abstract description notes fields",
+  "dev_note": "v1.5f hotfix 7: added Hz_expression key for automatic H(z)",
   "model_name": "LambdaCDM",
   "version": "1.0",
+  "Hz_expression": "H0*sympy.sqrt(Omega_m0*(1+z)**3 + (1 - Omega_m0))",
   "parameters": [
     {"name": "H0", "python_var": "H0", "initial_guess": 67.7, "bounds": [50.0, 100.0], "unit": "km/s/Mpc"},
     {"name": "Omega_m0", "python_var": "Omega_m0", "initial_guess": 0.31, "bounds": [0.05, 0.7]},
     {"name": "Omega_b0", "python_var": "Omega_b0", "initial_guess": 0.0486, "bounds": [0.01, 0.1]}
   ],
   "equations": {
-    "get_Hz_per_Mpc": "H0*sympy.sqrt(Omega_m0*(1+z)**3 + (1 - Omega_m0))",
     "distance_modulus_model": "5*sympy.log(1+z,10)*H0"
   },
   "abstract": "LambdaCDM model describes a flat universe dominated by cold dark matter and a cosmological constant serving as the reference model",

--- a/models/cosmo_model_usmf2.json
+++ b/models/cosmo_model_usmf2.json
@@ -1,7 +1,8 @@
 {
-  "dev_note": "v1.5d: Converted from Markdown/Plugin for JSON pipeline; v1.5f hotfix added abstract description notes",
+  "dev_note": "v1.5f hotfix 7: added Hz_expression key for automatic H(z)",
   "model_name": "USMFv2",
   "version": "2.0",
+  "Hz_expression": "H_A*(1+z)",
   "parameters": [
     {"name": "H_A", "python_var": "H_A", "initial_guess": 77.111, "bounds": [50.0, 100.0], "unit": "", "latex_name": "$H_A$"},
     {"name": "p_alpha", "python_var": "p_alpha", "initial_guess": 0.4313, "bounds": [0.1, 1.5], "unit": "", "latex_name": "$p_{\\alpha}$"},
@@ -14,7 +15,6 @@
     {"name": "phi_osc", "python_var": "phi_osc", "initial_guess": 0.10905, "bounds": [-3.1416, 3.1416], "unit": "rad", "latex_name": "$\\phi_{osc}$"}
   ],
   "equations": {
-    "get_Hz_per_Mpc": "H_A*(1+z)",
     "distance_modulus_model": "5*sympy.log(1+z,10)*H_A"
   },
   "abstract": "Unified Shrinking Matter Framework proposes cosmic acceleration and dark matter effects are apparent from observing within shrinking systems refined with early universe evolution",

--- a/models/cosmo_model_usmf3b.json
+++ b/models/cosmo_model_usmf3b.json
@@ -1,7 +1,8 @@
 {
-  "dev_note": "v1.5d: Converted from Markdown/Plugin for JSON pipeline; v1.5f hotfix added abstract description notes",
+  "dev_note": "v1.5f hotfix 7: added Hz_expression key for automatic H(z)",
   "model_name": "USMFv3b_Kinematic",
   "version": "3b",
+  "Hz_expression": "H_A*(1+z)**(1/p_kin)",
   "parameters": [
     {"name": "H_A", "python_var": "H_A", "initial_guess": 70.0, "bounds": [50.0, 100.0], "unit": "", "latex_name": "$H_A$"},
     {"name": "t0_age_Gyr", "python_var": "t0_age_Gyr", "initial_guess": 14.0, "bounds": [10.0, 20.0], "unit": "Gyr", "latex_name": "$t_{0,age}$"},
@@ -10,7 +11,6 @@
     {"name": "Omega_b0_fid", "python_var": "Omega_b0_fid", "initial_guess": 0.0486, "bounds": [0.03, 0.07], "unit": "", "latex_name": "$\\Omega_{b0,fid}$"}
   ],
   "equations": {
-    "get_Hz_per_Mpc": "H_A*(1+z)**(1/p_kin)",
     "distance_modulus_model": "5*sympy.log(1+z,10)*H_A"
   },
   "abstract": "USMFv3b kinematic simplifies shrinking matter model with power law index p_kin giving analytic distance solutions",

--- a/models/cosmo_model_usmf4_qk.json
+++ b/models/cosmo_model_usmf4_qk.json
@@ -1,14 +1,14 @@
 {
-  "dev_note": "v1.5d: Converted from Markdown/Plugin for JSON pipeline; v1.5f hotfix added abstract description notes",
+  "dev_note": "v1.5f hotfix 7: added Hz_expression key for automatic H(z)",
   "model_name": "USMFv4_QuantumKinematic",
   "version": "4",
+  "Hz_expression": "H0*sympy.sqrt(Omega_m0*(1+z)**4 + (1-Omega_m0))",
   "parameters": [
     {"name": "H0", "python_var": "H0", "initial_guess": 68.0, "bounds": [50, 80], "unit": "km/s/Mpc", "latex_name": "$H_0$"},
     {"name": "Omega_m0", "python_var": "Omega_m0", "initial_guess": 0.3, "bounds": [0.1, 0.5], "unit": "", "latex_name": "$\\Omega_{m0}$"},
     {"name": "Omega_b0", "python_var": "Omega_b0", "initial_guess": 0.0486, "bounds": [0.04, 0.06], "unit": "", "latex_name": "$\\Omega_{b0}$"}
   ],
   "equations": {
-    "get_Hz_per_Mpc": "H0*sympy.sqrt(Omega_m0*(1+z)**4 + (1-Omega_m0))",
     "distance_modulus_model": "5*sympy.log(1+z,10)*H0"
   },
   "abstract": "USMFv4 quantum kinematic links particle mass to inverse scale factor giving rho_m as one plus z to the fourth and new expansion history for strong fits",

--- a/models/cosmo_model_usmf5.json
+++ b/models/cosmo_model_usmf5.json
@@ -1,7 +1,8 @@
 {
-  "dev_note": "v1.5d: Converted from Markdown/Plugin for JSON pipeline; v1.5f hotfix added abstract description notes",
+  "dev_note": "v1.5f hotfix 7: added Hz_expression key for automatic H(z)",
   "model_name": "USMFv5",
   "version": "5",
+  "Hz_expression": "H_A*(1+z)**(1/m_e)",
   "parameters": [
     {"name": "H_A", "python_var": "H_A", "initial_guess": 70.0, "bounds": [50.0, 90.0], "unit": "km/s/Mpc", "latex_name": "$H_A$"},
     {"name": "p_alpha", "python_var": "p_alpha", "initial_guess": 1.0, "bounds": [0.0, 5.0], "unit": "", "latex_name": "$p_\\alpha$"},
@@ -17,7 +18,6 @@
     {"name": "n", "python_var": "n", "initial_guess": 2.0, "bounds": [0.0, 4.0], "unit": "", "latex_name": "$n$"}
   ],
   "equations": {
-    "get_Hz_per_Mpc": "H_A*(1+z)**(1/m_e)",
     "distance_modulus_model": "5*sympy.log(1+z,10)*H_A"
   },
   "abstract": "Fixed Size Filament Contraction model keeps global scale constant while local filaments contract preserving supernova fits with adjustable early exponent",

--- a/scripts/engine_interface.py
+++ b/scripts/engine_interface.py
@@ -39,6 +39,7 @@ def build_plugin(model_data, func_dict):
     plugin.INITIAL_GUESSES = [p['initial_guess'] for p in model_data['parameters']]
     plugin.PARAMETER_BOUNDS = [tuple(p['bounds']) for p in model_data['parameters']]
     plugin.FIXED_PARAMS = {}
+    plugin.valid_for_distance_metrics = model_data.get('valid_for_distance_metrics', True)
     for name, func in func_dict.items():
         setattr(plugin, name, func)
     validate_plugin(plugin)
@@ -54,7 +55,11 @@ def validate_plugin(plugin):
         logger.error(f"Plugin validation failed. Missing attributes: {missing_attrs}")
         return False
 
-    for fname in REQUIRED_FUNCTIONS:
+    required_funcs = REQUIRED_FUNCTIONS
+    if getattr(plugin, 'valid_for_distance_metrics', True) is False:
+        required_funcs = ['distance_modulus_model']
+
+    for fname in required_funcs:
         func = getattr(plugin, fname, None)
         if not callable(func):
             logger.error(f"Plugin validation failed. Missing function '{fname}'.")

--- a/scripts/model_coder.py
+++ b/scripts/model_coder.py
@@ -1,11 +1,16 @@
 """Model coder that turns validated JSON into callable Python functions."""
-# DEV NOTE (v1.5e): Loads sanitized models from ``models/cache`` and stores the
-# DEV NOTE (v1.5e hotfix): Allow sympy-prefixed expressions by mapping "sympy" to SymPy.
-# generated SymPy expressions back to that cache.
+# DEV NOTE (v1.5f hotfix 7): Parses ``Hz_expression`` from each model and
+# generates a callable ``get_Hz_per_Mpc`` along with optional distance
+# functions. The generated SymPy expressions are written back to the cache.
+# Previous hotfix notes: loads sanitized models from ``models/cache`` and allows
+# "sympy." prefix in JSON equations.
 
 import json
 from pathlib import Path
 import sympy as sp
+import numpy as np
+from scipy.integrate import quad
+import logging
 from . import error_handler
 
 
@@ -26,6 +31,8 @@ def generate_callables(cache_path):
     with cache_path.open("r") as f:
         model_data = json.load(f)
 
+    logger = logging.getLogger()
+
     z = sp.symbols('z')
     param_syms = [sp.symbols(p['python_var']) for p in model_data['parameters']]
     local_dict = {p['python_var']: sym for p, sym in zip(model_data['parameters'], param_syms)}
@@ -35,6 +42,50 @@ def generate_callables(cache_path):
 
     funcs = {}
     code_dict = {}
+
+    hz_expr_str = model_data.get('Hz_expression')
+    if hz_expr_str:
+        try:
+            hz_sym = sp.sympify(hz_expr_str, locals=local_dict)
+            used_syms = {str(s) for s in hz_sym.free_symbols if s != z}
+            param_names = {p['python_var'] for p in model_data['parameters']}
+            missing = used_syms - param_names
+            if missing:
+                raise ValueError(
+                    "Parameter '" + "', '".join(missing) + "' used in Hz_expression is not defined in model parameters."
+                )
+            hz_fn = sp.lambdify((z, *param_syms), hz_sym, 'numpy')
+            funcs['get_Hz_per_Mpc'] = hz_fn
+            code_dict['get_Hz_per_Mpc'] = str(hz_sym)
+            model_data['valid_for_distance_metrics'] = True
+
+            def _dm(z_val, *params):
+                integrand = lambda zp: 299792.458 / hz_fn(zp, *params)
+                return quad(integrand, 0, z_val, limit=100)[0]
+
+            if 'get_comoving_distance_Mpc' not in funcs:
+                funcs['get_comoving_distance_Mpc'] = _dm
+                code_dict['get_comoving_distance_Mpc'] = 'integral(c/H(z))'
+            if 'get_luminosity_distance_Mpc' not in funcs:
+                funcs['get_luminosity_distance_Mpc'] = lambda zv, *p: (1 + zv) * _dm(zv, *p)
+                code_dict['get_luminosity_distance_Mpc'] = '(1+z)*DC'
+            if 'get_angular_diameter_distance_Mpc' not in funcs:
+                funcs['get_angular_diameter_distance_Mpc'] = lambda zv, *p: _dm(zv, *p) / (1 + zv)
+                code_dict['get_angular_diameter_distance_Mpc'] = 'DC/(1+z)'
+            if 'get_DV_Mpc' not in funcs:
+                funcs['get_DV_Mpc'] = lambda zv, *p: ((
+                    _dm(zv, *p) ** 2 * 299792.458 * zv / hz_fn(zv, *p)
+                ) ** (1 / 3) if zv > 0 and hz_fn(zv, *p) != 0 else 0.0)
+                code_dict['get_DV_Mpc'] = '((DC^2 * c*z/H)^1/3)'
+            logger.info("Derived distance functions from symbolic Hz_expression in model JSON.")
+        except Exception as e:
+            error_handler.report_error(f"Failed to parse Hz_expression: {e}")
+            raise ValueError(f"Failed to parse Hz_expression: {e}") from e
+    else:
+        print(
+            "\u26A0\uFE0F  Model does not define H(z). Distance-based observables such as BAO, comoving distances, and luminosity distances will be unavailable."
+        )
+        model_data['valid_for_distance_metrics'] = False
     for name, expr in model_data.get('equations', {}).items():
         try:
             sym_expr = sp.sympify(expr, locals=local_dict)


### PR DESCRIPTION
## Summary
- parse `Hz_expression` in `model_coder` and auto-generate distance functions
- support missing distance metrics in `engine_interface`
- update JSON models with new `Hz_expression`
- document how to use `Hz_expression`
- record Hotfix 7 in AGENTS and CHANGELOG

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ff5d8e420832fa02490721504a736