### PR TITLE
Fix parser registry and CLI flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Introduced dynamic parser plugin system with automatic discovery.
 - Data and parsers reorganized by type and source.
 - Added developer template for new parsers.
+- Parser registration is now explicit via `register_parser()` and the CLI
+  walks data type → source → parser → file.
 
 ## Version 1.5f (Development Release)
 - Completed Phase 6: JSON schema extended with optional fields for CMB,

--- a/README.md
+++ b/README.md
@@ -92,12 +92,13 @@ should not be modified by AI-driven code changes.
 
 ## Using the Suite
 - The program discovers available models from `models/cosmo_model_*.md`.
-- Data files for SNe and BAO are organized by source under `data/sne/` and `data/bao/`.
-  The program lists available sources and picks an appropriate parser automatically.
-- Parsers and engines are also selected interactively from their respective
-  directories.
-- After each run you may choose to evaluate another model or exit. Cache files
-  are cleaned automatically.
+- Data files are grouped by type and source under `data/<type>/<source>/`.
+- At runtime you choose the **data type**, **data source**, **parser** and finally
+  the data file to load. Only valid options detected in the directory tree are
+  presented.
+- Parsers and engines are selected interactively from their respective directories.
+- After each run you may choose to evaluate another model or exit. Cache files are
+  cleaned automatically.
 
 ## Creating New Models
 All models are now provided as a single JSON file. Markdown files can still be
@@ -147,8 +148,8 @@ compiled into `get_Hz_per_Mpc` and related distance functions used by
 
 ## Creating New Parsers
 
-Parsers live inside `parsers/<data_type>/<source_name>/` and register
-automatically when imported. Start from `parsers/cosmo_parser_template.py`.
+Parsers live inside `parsers/<data_type>/<source_name>/` and must call
+`register_parser()` when imported. Start from `parsers/cosmo_parser_template.py`.
 
 1. Copy the template into the appropriate folder for your data source.
 2. Fill in `DATA_TYPE`, `SOURCE_NAME`, `PARSER_NAME` and any supported
@@ -158,8 +159,8 @@ automatically when imported. Start from `parsers/cosmo_parser_template.py`.
 4. Ensure each directory has an `__init__.py` so Python recognizes it as a
    package.
 
-The suite scans the `parsers/` tree on startup and reports available sources and
-parsers for each data type.
+The suite scans the `parsers/` tree on startup, dynamically imports each
+`cosmo_parser_*.py` file and builds a registry of available parsers.
 
 ## Development Notes
 All changes must include a `DEV NOTE` at the top of modified files explaining

--- a/copernican.py
+++ b/copernican.py
@@ -310,38 +310,50 @@ def main_workflow():
         engine_module = importlib.import_module(f"engines.{engine_choice[:-3]}")
         cosmo_engine_selected = engine_module
 
-        sne_data_base = os.path.join(SCRIPT_DIR, 'data', 'sne')
-        sne_sources = [d for d in sorted(os.listdir(sne_data_base)) if os.path.isdir(os.path.join(sne_data_base, d))]
-        print('Available SNe sources and parsers:')
-        for src in sne_sources:
-            pars = data_loaders.list_parsers('sne', src)
-            names = ', '.join(p.PARSER_NAME for p in pars) or 'none'
-            print(f'  - {src}: {names}')
-        source_choice = select_from_list(sne_sources, 'Select SNe Ia data source')
-        if not source_choice:
+        def select_dataset_flow(expected_type):
+            while True:
+                data_types = sorted({dt for dt, _ in data_loaders.registry.keys()})
+                type_choice = select_from_list(data_types, 'Select data type')
+                if not type_choice:
+                    return None
+                if type_choice != expected_type:
+                    print(f"Please select data type '{expected_type}'.")
+                    continue
+                sources = data_loaders.list_available_sources(type_choice)
+                if not sources:
+                    print(f"\u274c No parser registered for data type '{type_choice}'.")
+                    return None
+                source_choice = select_from_list(sources, f"Select {type_choice.upper()} data source")
+                if not source_choice:
+                    return None
+                parsers = data_loaders.list_parsers(type_choice, source_choice)
+                if not parsers:
+                    print(f"\u26A0\uFE0F No valid parsers available for {type_choice.upper()} \u2192 {source_choice}.")
+                    return None
+                parser_names = [p['name'] for p in parsers]
+                parser_choice = select_from_list(parser_names, f"Select parser for {type_choice.upper()} \u2192 {source_choice}")
+                if not parser_choice:
+                    return None
+                parser_info = next(p for p in parsers if p['name'] == parser_choice)
+                data_dir = os.path.join(SCRIPT_DIR, 'data', type_choice, source_choice)
+                if not os.path.isdir(data_dir):
+                    print(f"\u274c Data directory not found: {data_dir}")
+                    return None
+                files = sorted(os.listdir(data_dir))
+                if not files:
+                    print(f"\u274c No data files found in {data_dir}.")
+                    return None
+                file_choice = select_from_list(files, f"Select data file for {type_choice.upper()} \u2192 {source_choice}")
+                if not file_choice:
+                    return None
+                filepath = os.path.join(data_dir, file_choice)
+                return data_loaders.load_data(type_choice, source_choice, parser_info, filepath)
+
+        sne_data_df = select_dataset_flow('sne')
+        if sne_data_df is None:
             break
-        sne_files = sorted(os.listdir(os.path.join(sne_data_base, source_choice)))
-        sne_choice = select_from_list(sne_files, 'Select SNe Ia data file')
-        if not sne_choice:
-            break
-        sne_data_filepath = os.path.join(sne_data_base, source_choice, sne_choice)
-        sne_data_df = data_loaders.load_sne_data(sne_data_filepath)
-        bao_data_base = os.path.join(SCRIPT_DIR, 'data', 'bao')
-        bao_sources = [d for d in sorted(os.listdir(bao_data_base)) if os.path.isdir(os.path.join(bao_data_base, d))]
-        print('Available BAO sources and parsers:')
-        for src in bao_sources:
-            pars = data_loaders.list_parsers('bao', src)
-            names = ', '.join(p.PARSER_NAME for p in pars) or 'none'
-            print(f'  - {src}: {names}')
-        bao_source_choice = select_from_list(bao_sources, 'Select BAO data source')
-        if not bao_source_choice:
-            break
-        bao_files = sorted(os.listdir(os.path.join(bao_data_base, bao_source_choice)))
-        bao_choice = select_from_list(bao_files, 'Select BAO data file')
-        if not bao_choice:
-            break
-        bao_data_filepath = os.path.join(bao_data_base, bao_source_choice, bao_choice)
-        bao_data_df = data_loaders.load_bao_data(bao_data_filepath)
+
+        bao_data_df = select_dataset_flow('bao')
         if bao_data_df is None:
             continue
         logger.info("\n--- Stage 2: Supernovae Ia Fitting ---")

--- a/parsers/bao/basic/cosmo_parser_bao_basic.py
+++ b/parsers/bao/basic/cosmo_parser_bao_basic.py
@@ -6,7 +6,7 @@ import json
 import os
 import logging
 
-from scripts.data_loaders import BaseParser
+from scripts.data_loaders import BaseParser, register_parser
 
 
 def parse_bao_json_v1(filepath, **kwargs):
@@ -44,3 +44,12 @@ class BAOJsonV1Parser(BaseParser):
 
     def parse(self, filepath, **kwargs):
         return parse_bao_json_v1(filepath, **kwargs)
+
+
+register_parser(
+    data_type="bao",
+    source="basic",
+    name="BAO JSON General V1",
+    parser=BAOJsonV1Parser()
+)
+

--- a/parsers/cmb/cosmo_parser_cmb_placeholder.py
+++ b/parsers/cmb/cosmo_parser_cmb_placeholder.py
@@ -1,11 +1,29 @@
-# DEV NOTE (v1.5f): Placeholder parser for future CMB data formats.
-# DEV NOTE (v1.5f hotfix): Updated import path for ``data_loaders`` module.
+# DEV NOTE (v1.6a): Placeholder parser updated for explicit registration system.
 import logging
-from scripts.data_loaders import register_cmb_parser
+from scripts.data_loaders import BaseParser, register_parser
 
-@register_cmb_parser("cmb_placeholder_v1", "Placeholder CMB parser.")
+
 def parse_cmb_placeholder(filepath, **kwargs):
     """Stub parser that logs a message and returns None."""
     logger = logging.getLogger()
     logger.info(f"CMB parser placeholder invoked for {filepath}. Feature not implemented.")
     return None
+
+
+class CMBPlaceholderParser(BaseParser):
+    DATA_TYPE = "cmb"
+    SOURCE_NAME = "placeholder"
+    PARSER_NAME = "cmb_placeholder_v1"
+    FILE_EXTENSIONS = []
+
+    def parse(self, filepath, **kwargs):
+        return parse_cmb_placeholder(filepath, **kwargs)
+
+
+register_parser(
+    data_type="cmb",
+    source="placeholder",
+    name="CMB Placeholder",
+    parser=CMBPlaceholderParser()
+)
+

--- a/parsers/gw/cosmo_parser_gw_placeholder.py
+++ b/parsers/gw/cosmo_parser_gw_placeholder.py
@@ -1,11 +1,29 @@
-# DEV NOTE (v1.5f): Placeholder parser for future gravitational wave data formats.
-# DEV NOTE (v1.5f hotfix): Updated ``data_loaders`` import to new location.
+# DEV NOTE (v1.6a): Placeholder parser updated for explicit registration system.
 import logging
-from scripts.data_loaders import register_gw_parser
+from scripts.data_loaders import BaseParser, register_parser
 
-@register_gw_parser("gw_placeholder_v1", "Placeholder GW parser.")
+
 def parse_gw_placeholder(filepath, **kwargs):
     """Stub parser that logs a message and returns None."""
     logger = logging.getLogger()
     logger.info(f"GW parser placeholder invoked for {filepath}. Feature not implemented.")
     return None
+
+
+class GWPlaceholderParser(BaseParser):
+    DATA_TYPE = "gw"
+    SOURCE_NAME = "placeholder"
+    PARSER_NAME = "gw_placeholder_v1"
+    FILE_EXTENSIONS = []
+
+    def parse(self, filepath, **kwargs):
+        return parse_gw_placeholder(filepath, **kwargs)
+
+
+register_parser(
+    data_type="gw",
+    source="placeholder",
+    name="GW Placeholder",
+    parser=GWPlaceholderParser()
+)
+

--- a/parsers/sirens/cosmo_parser_sirens_placeholder.py
+++ b/parsers/sirens/cosmo_parser_sirens_placeholder.py
@@ -1,11 +1,29 @@
-# DEV NOTE (v1.5f): Placeholder parser for future standard siren data formats.
-# DEV NOTE (v1.5f hotfix): Updated import path for ``data_loaders``.
+# DEV NOTE (v1.6a): Placeholder parser updated for explicit registration system.
 import logging
-from scripts.data_loaders import register_siren_parser
+from scripts.data_loaders import BaseParser, register_parser
 
-@register_siren_parser("siren_placeholder_v1", "Placeholder standard siren parser.")
+
 def parse_siren_placeholder(filepath, **kwargs):
     """Stub parser that logs a message and returns None."""
     logger = logging.getLogger()
     logger.info(f"Standard siren parser placeholder invoked for {filepath}. Feature not implemented.")
     return None
+
+
+class SirenPlaceholderParser(BaseParser):
+    DATA_TYPE = "sirens"
+    SOURCE_NAME = "placeholder"
+    PARSER_NAME = "siren_placeholder_v1"
+    FILE_EXTENSIONS = []
+
+    def parse(self, filepath, **kwargs):
+        return parse_siren_placeholder(filepath, **kwargs)
+
+
+register_parser(
+    data_type="sirens",
+    source="placeholder",
+    name="Siren Placeholder",
+    parser=SirenPlaceholderParser()
+)
+

--- a/parsers/sne/pantheon/cosmo_parser_pantheon.py
+++ b/parsers/sne/pantheon/cosmo_parser_pantheon.py
@@ -6,7 +6,7 @@ import numpy as np
 import os
 import logging
 
-from scripts.data_loaders import BaseParser, _get_user_input_filepath
+from scripts.data_loaders import BaseParser, _get_user_input_filepath, register_parser
 
 
 def _get_pantheon_plus_args(base_dir):
@@ -104,3 +104,12 @@ class PantheonPlusMuCovH2Parser(BaseParser):
 
     def parse(self, filepath, cov_filepath=None, **kwargs):
         return parse_pantheon_plus_mu_cov_h2(filepath, cov_filepath=cov_filepath, **kwargs)
+
+
+register_parser(
+    data_type="sne",
+    source="pantheon",
+    name="Pantheon+ Mu Covariance H2",
+    parser=PantheonPlusMuCovH2Parser()
+)
+

--- a/parsers/sne/unistra/cosmo_parser_h1_unistra.py
+++ b/parsers/sne/unistra/cosmo_parser_h1_unistra.py
@@ -5,7 +5,7 @@
 import pandas as pd
 import logging
 
-from scripts.data_loaders import BaseParser
+from scripts.data_loaders import BaseParser, register_parser
 
 DEFAULT_SALT2_M_ABS_FIXED = -19.3
 DEFAULT_SALT2_ALPHA_FIXED = 0.14
@@ -71,3 +71,12 @@ class UniStraH1Parser(BaseParser):
 
     def parse(self, filepath, **kwargs):
         return parse_unistra_h1_style(filepath, **kwargs)
+
+
+register_parser(
+    data_type="sne",
+    source="unistra",
+    name="Unistra H1",
+    parser=UniStraH1Parser()
+)
+

--- a/parsers/sne/unistra/cosmo_parser_h2_unistra.py
+++ b/parsers/sne/unistra/cosmo_parser_h2_unistra.py
@@ -5,7 +5,7 @@
 import pandas as pd
 import logging
 
-from scripts.data_loaders import BaseParser
+from scripts.data_loaders import BaseParser, register_parser
 
 def parse_unistra_h2_style(filepath, **kwargs):
     logger = logging.getLogger()
@@ -56,3 +56,12 @@ class UniStraH2Parser(BaseParser):
 
     def parse(self, filepath, **kwargs):
         return parse_unistra_h2_style(filepath, **kwargs)
+
+
+register_parser(
+    data_type="sne",
+    source="unistra",
+    name="Unistra H2",
+    parser=UniStraH2Parser()
+)
+

--- a/scripts/data_loaders.py
+++ b/scripts/data_loaders.py
@@ -1,5 +1,6 @@
 # copernican_suite/data_loaders.py
-# DEV NOTE (v1.6a): Reworked into dynamic parser plugin registry.
+# DEV NOTE (v1.6a): Reworked parser system with explicit registration and
+# absolute dynamic imports.
 """Modular data loading for various cosmological datasets."""
 
 import pandas as pd
@@ -7,30 +8,20 @@ import numpy as np
 import json
 import os
 import logging
-import importlib
+import importlib.util
 
-# --- Parser Registry using metaclass auto-registration ---
-PARSER_REGISTRY = {
-    'sne': {},
-    'bao': {},
-    'cmb': {},
-    'gw': {},
-    'sirens': {}
-}
+# --- Global Parser Registry -------------------------------------------------
 
-class ParserMeta(type):
-    """Metaclass that registers parser subclasses on import."""
-    def __init__(cls, name, bases, attrs):
-        super().__init__(name, bases, attrs)
-        dt = getattr(cls, 'DATA_TYPE', None)
-        src = getattr(cls, 'SOURCE_NAME', None)
-        if not dt or not src or cls.__name__ == 'BaseParser':
-            return
-        dt = dt.lower()
-        src = src.lower()
-        PARSER_REGISTRY.setdefault(dt, {}).setdefault(src, []).append(cls)
+registry = {}  # {(data_type, source): [{'name': str, 'parser': BaseParser}]}
 
-class BaseParser(metaclass=ParserMeta):
+
+def register_parser(data_type, source, name, parser):
+    """Register a parser instance for a given data type and source."""
+    key = (data_type.lower(), source.lower())
+    registry.setdefault(key, []).append({'name': name, 'parser': parser})
+
+
+class BaseParser:
     """Base class for all data parsers."""
     DATA_TYPE = None
     SOURCE_NAME = None
@@ -67,98 +58,105 @@ def _get_user_input_filepath(prompt_message, base_dir, must_exist=True):
 def _discover_parsers():
     """Import all parser modules under the ./parsers directory."""
     base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'parsers'))
-    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    logger = logging.getLogger()
     for root, _, files in os.walk(base_dir):
         for fname in files:
             if not fname.startswith('cosmo_parser_') or not fname.endswith('.py'):
                 continue
             if fname == 'cosmo_parser_template.py':
                 continue
-
-            rel = os.path.relpath(os.path.join(root, fname), os.path.dirname(__file__))
-
-            module_name = rel.replace(os.sep, '.')[:-3]
+            filepath = os.path.join(root, fname)
+            module_name = f"parser_{abs(hash(filepath))}"
             try:
-                importlib.import_module(module_name)
+                spec = importlib.util.spec_from_file_location(module_name, filepath)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
             except Exception as e:
-                logging.getLogger().error(f"Failed loading parser module {module_name}: {e}")
+                logger.error(f"\u274c Failed to import '{fname}': {e}")
 
 _discover_parsers()
 
-# --- Utility functions ---
+# --- Utility functions ------------------------------------------------------
 
 def list_available_sources(data_type):
     """Return sorted list of sources for a data type."""
-    return sorted(PARSER_REGISTRY.get(data_type, {}).keys())
+    return sorted({src for dt, src in registry.keys() if dt == data_type})
+
 
 def list_parsers(data_type, source):
-    """Return list of parser classes for a source."""
-    return PARSER_REGISTRY.get(data_type, {}).get(source, [])
+    """Return list of parser info dicts for a source."""
+    return registry.get((data_type, source), [])
 
 # --- Generic loading helpers ---
 
-def _try_parsers(data_type, source, filepath, base_dir):
+def load_data(data_type, source, parser_info, filepath):
+    """Load a file using the specified parser info dict."""
     logger = logging.getLogger()
-    parsers = list_parsers(data_type, source)
-    if not parsers:
-        logger.error(f"No valid parsers found for {data_type.upper()} data source '{source}'.")
+    parser = parser_info['parser']
+    if not parser.can_parse(filepath):
+        logger.error(f"{parser_info['name']} cannot parse {os.path.basename(filepath)}.")
         return None
-    for parser_cls in parsers:
-        parser = parser_cls()
-        if not parser.can_parse(filepath):
-            continue
-        extra_kwargs = {}
-        if hasattr(parser, 'get_extra_args'):
-            extra_kwargs = parser.get_extra_args(base_dir)
-            if extra_kwargs is None:
-                logger.info(f"{parser.PARSER_NAME} parser canceled by user.")
-                return None
-        try:
-            logger.info(f"Attempting {parser.PARSER_NAME} on {os.path.basename(filepath)}")
-            data_df = parser.parse(filepath, **extra_kwargs)
-            if data_df is not None and not data_df.empty:
-                data_df.attrs['filepath'] = filepath
-                data_df.attrs['parser_name'] = parser.PARSER_NAME
-                if 'dataset_name_attr' not in data_df.attrs:
-                    data_df.attrs['dataset_name_attr'] = f"{data_type.upper()}_{parser.PARSER_NAME}"
-                logger.info(f"Successfully loaded {len(data_df)} points using {parser.PARSER_NAME}.")
-                return data_df
-            elif data_df is None:
-                logger.error(f"{parser.PARSER_NAME} returned None for {filepath}.")
-            else:
-                logger.error(f"{parser.PARSER_NAME} produced empty DataFrame for {filepath}.")
-        except Exception as e:
-            logger.error(f"Failed to parse '{filepath}' using {parser.PARSER_NAME}: {e}")
-    logger.error(f"No parser succeeded for {filepath}.")
+    extra_kwargs = {}
+    if hasattr(parser, 'get_extra_args'):
+        extra_kwargs = parser.get_extra_args(os.path.dirname(filepath))
+        if extra_kwargs is None:
+            logger.info(f"{parser_info['name']} parser canceled by user.")
+            return None
+    try:
+        logger.info(f"Using parser {parser_info['name']} on {os.path.basename(filepath)}")
+        data_df = parser.parse(filepath, **extra_kwargs)
+        if data_df is not None and not data_df.empty:
+            data_df.attrs['filepath'] = filepath
+            data_df.attrs['parser_name'] = parser_info['name']
+            if 'dataset_name_attr' not in data_df.attrs:
+                data_df.attrs['dataset_name_attr'] = f"{data_type.upper()}_{parser_info['name']}"
+            logger.info(f"Successfully loaded {len(data_df)} points using {parser_info['name']}.")
+            return data_df
+        elif data_df is None:
+            logger.error(f"{parser_info['name']} returned None for {filepath}.")
+        else:
+            logger.error(f"{parser_info['name']} produced empty DataFrame for {filepath}.")
+    except Exception as e:
+        logger.error(f"Failed to parse '{filepath}' using {parser_info['name']}: {e}")
+    return None
+# --- Backwards Compatibility Helpers ---------------------------------------
+
+def _try_all_parsers(data_type, source, filepath):
+    """Attempt parsing with all registered parsers for fallback use."""
+    for info in list_parsers(data_type, source):
+        df = load_data(data_type, source, info, filepath)
+        if df is not None:
+            return df
+    logging.getLogger().error(f"No parser succeeded for {filepath}.")
     return None
 
-# --- Public Loading Functions ---
 
 def load_sne_data(filepath):
     base_dir = os.path.dirname(filepath)
     source = os.path.basename(os.path.dirname(filepath))
-    return _try_parsers('sne', source, filepath, base_dir)
+    return _try_all_parsers('sne', source, filepath)
 
 
 def load_bao_data(filepath):
     base_dir = os.path.dirname(filepath)
     source = os.path.basename(os.path.dirname(filepath))
-    return _try_parsers('bao', source, filepath, base_dir)
+    return _try_all_parsers('bao', source, filepath)
 
 
 def load_cmb_data(filepath):
     base_dir = os.path.dirname(filepath)
     source = os.path.basename(os.path.dirname(filepath))
-    return _try_parsers('cmb', source, filepath, base_dir)
+    return _try_all_parsers('cmb', source, filepath)
 
 
 def load_gw_data(filepath):
     base_dir = os.path.dirname(filepath)
     source = os.path.basename(os.path.dirname(filepath))
-    return _try_parsers('gw', source, filepath, base_dir)
+    return _try_all_parsers('gw', source, filepath)
 
 
 def load_siren_data(filepath):
     base_dir = os.path.dirname(filepath)
     source = os.path.basename(os.path.dirname(filepath))
-    return _try_parsers('sirens', source, filepath, base_dir)
+    return _try_all_parsers('sirens', source, filepath)
+


### PR DESCRIPTION
## Summary
- rework parser registry with explicit `register_parser`
- dynamically import parser modules via file paths
- update CLI data selection flow to type → source → parser → file
- update parser modules to register themselves
- document new process in README and changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685014e4f0b8832f8642f32b4042d1f4