### PR TITLE
Refactor dataset selection order and add confirmation step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,10 @@
 # DEV NOTE (v1.6a update)
 Parser registry now uses explicit `register_parser()` calls. The CLI selects
 datasets in the fixed order SNe → BAO without prompting for data type.
+# DEV NOTE (v1.6a patch)
+Datasets are now chosen before selecting a computational engine. Available
+datasets are read from `data/<type>/` directories and a summary confirmation
+step has been added to the workflow.
 # DEV NOTE (v1.5f)
 Hotfix: improved dependency scanner to skip relative imports and added SymPy aliasing in model_coder.
 Hotfix 2: JSON models now contain optional abstract, description and notes fields.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!-- DEV NOTE (v1.6a update): CLI selection now follows dataset → parser → file for SNe then BAO. -->
+<!-- DEV NOTE (v1.6a patch): Dataset and parser are chosen before selecting the computation engine, and a summary confirmation is shown. -->
 # Copernican Suite
 <!-- DEV NOTE (v1.5f): Updated for Phase 6 with new data-type placeholders and schema fields. -->
 <!-- DEV NOTE (v1.5f hotfix): Dependency scanner ignores relative imports; JSON models now support "sympy." prefix. -->
@@ -43,9 +44,10 @@ Under the hood the program follows a clear pipeline:
 1. **Dependency Check** – `copernican.py` scans for required packages and
    prints a `pip install` command if any are missing.
 2. **Initialization** – the output directory is created and logging begins.
-3. **Configuration** – the user chooses a model, an engine from `./engines/`,
-  and data parsers for SNe Ia and BAO. Models are discovered from
-  `cosmo_model_*.json` files which are converted into Python code on the fly.
+3. **Configuration** – the user chooses a model, selects SNe and BAO datasets
+   along with their parsers, then picks a computation engine. Models are
+   discovered from `cosmo_model_*.json` files which are converted into Python
+   code on the fly. A summary of all choices is displayed for confirmation.
 4. **SNe Ia Fitting** – the selected engine estimates cosmological parameters
    for both the ΛCDM reference and the alternative model.
 5. **BAO Analysis** – using the best-fit parameters the engine predicts BAO
@@ -96,6 +98,9 @@ should not be modified by AI-driven code changes.
 - During each run you first pick an **SNe dataset** (e.g. Pantheon+, UniStra),
   choose a parser within that dataset and then select the exact data file.
 - The same sequence repeats for **BAO data**.
+- After all datasets are chosen you select a computational engine.
+- A summary of the selected model, datasets, parsers and engine is displayed and
+  you must confirm before calculations begin.
 
 - Parsers and engines are selected interactively from their respective directories.
 - After each run you may choose to evaluate another model or exit. Cache files are

--- a/copernican.py
+++ b/copernican.py
@@ -4,6 +4,9 @@ Copernican Suite - Main Orchestrator.
 # DEV NOTE (v1.6a update): CLI now selects datasets in fixed order
 # (SNe then BAO) without prompting for data type. Parser plugin system uses
 # explicit registration.
+# DEV NOTE (v1.6a patch): Dataset selection now occurs before engine choice and
+# directories under ``data/<type>/`` are enumerated for available datasets. The
+# user is shown a summary and must confirm before calculations proceed.
 """
 # DEV NOTE (v1.5f): Added placeholders for future data types and bumped version.
 # DEV NOTE (v1.5f hotfix): Fixed dependency scanner to ignore relative imports.
@@ -304,22 +307,18 @@ def main_workflow():
         if not alt_model_plugin:
             continue
 
-        engines_dir = os.path.join(SCRIPT_DIR, 'engines')
-        engine_files = sorted([f for f in os.listdir(engines_dir) if f.startswith('cosmo_engine_') and f.endswith('.py')])
-        engine_choice = select_from_list(engine_files, 'Select computation engine')
-        if not engine_choice:
-            break
-        engine_module = importlib.import_module(f"engines.{engine_choice[:-3]}")
-        cosmo_engine_selected = engine_module
-
         def select_dataset_flow(data_type):
             """Handle dataset selection for a fixed data type."""
             while True:
-                sources = data_loaders.list_available_sources(data_type)
-                if not sources:
-                    print(f"\u274c No parser registered for data type '{data_type}'.")
+                data_base = os.path.join(SCRIPT_DIR, 'data', data_type)
+                if not os.path.isdir(data_base):
+                    print(f"\u274c Data directory not found: {data_base}")
                     return None
-                source_choice = select_from_list(sources, f"Select {data_type.upper()} data source")
+                dir_sources = sorted([d for d in os.listdir(data_base) if os.path.isdir(os.path.join(data_base, d))])
+                if not dir_sources:
+                    print(f"\u274c No datasets found for '{data_type}'.")
+                    return None
+                source_choice = select_from_list(dir_sources, f"Select {data_type.upper()} dataset")
                 if not source_choice:
                     return None
                 parsers = data_loaders.list_parsers(data_type, source_choice)
@@ -331,10 +330,7 @@ def main_workflow():
                 if not parser_choice:
                     return None
                 parser_info = next(p for p in parsers if p['name'] == parser_choice)
-                data_dir = os.path.join(SCRIPT_DIR, 'data', data_type, source_choice)
-                if not os.path.isdir(data_dir):
-                    print(f"\u274c Data directory not found: {data_dir}")
-                    return None
+                data_dir = os.path.join(data_base, source_choice)
                 files = sorted(os.listdir(data_dir))
                 if not files:
                     print(f"\u274c No data files found in {data_dir}.")
@@ -343,14 +339,39 @@ def main_workflow():
                 if not file_choice:
                     return None
                 filepath = os.path.join(data_dir, file_choice)
-                return data_loaders.load_data(data_type, source_choice, parser_info, filepath)
+                data_df = data_loaders.load_data(data_type, source_choice, parser_info, filepath)
+                if data_df is None:
+                    return None
+                dataset_name = data_df.attrs.get('dataset_name_attr', os.path.basename(filepath))
+                return data_df, {'source': source_choice, 'parser': parser_choice, 'file': file_choice, 'dataset': dataset_name}
 
-        sne_data_df = select_dataset_flow('sne')
-        if sne_data_df is None:
+        sne_result = select_dataset_flow('sne')
+        if sne_result is None:
             break
+        sne_data_df, sne_info = sne_result
 
-        bao_data_df = select_dataset_flow('bao')
-        if bao_data_df is None:
+        bao_result = select_dataset_flow('bao')
+        if bao_result is None:
+            continue
+        bao_data_df, bao_info = bao_result
+
+        engines_dir = os.path.join(SCRIPT_DIR, 'engines')
+        engine_files = sorted([f for f in os.listdir(engines_dir) if f.startswith('cosmo_engine_') and f.endswith('.py')])
+        engine_choice = select_from_list(engine_files, 'Select computation engine')
+        if not engine_choice:
+            break
+        engine_module = importlib.import_module(f"engines.{engine_choice[:-3]}")
+        cosmo_engine_selected = engine_module
+
+        print("\nConfiguration summary:")
+        print(f"  Model: {alt_model_plugin.MODEL_NAME}")
+        print(f"  SNe dataset: {sne_info['dataset']} parsed by {sne_info['parser']}")
+        print(f"  BAO dataset: {bao_info['dataset']} parsed by {bao_info['parser']}")
+        print(f"  Engine: {engine_choice}")
+        proceed = input("Proceed? (y/n): ").strip().lower()
+        if proceed not in ['y', 'yes']:
+            cleanup_cache(SCRIPT_DIR)
+            logger.info("Run canceled by user after summary.")
             continue
         logger.info("\n--- Stage 2: Supernovae Ia Fitting ---")
         lcdm_sne_fit_results = cosmo_engine_selected.fit_sne_parameters(sne_data_df, lcdm)


### PR DESCRIPTION
## Summary
- reorder CLI workflow so datasets are chosen before selecting a computation engine
- enumerate available datasets from directories under `data/<type>/`
- present a configuration summary and require confirmation
- document new workflow in `README.md` and `AGENTS.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68502a9c2f38832fb13c117866deab3f