### PR TITLE
Hotfix 9: restore parser auto-discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Hotfix 4: Multiprocessing's `freeze_support` is now called using a local import 
 Hotfix 5: Removed automatic dependency installer. The suite now instructs users to run `pip install` manually when packages are missing.
 Hotfix 7: Models now provide a symbolic `Hz_expression` compiled at runtime for distance calculations.
 Hotfix 8: When `rs_expression` is absent but `Ob`, `Og` and `z_recomb` exist, the suite derives `get_sound_horizon_rs_Mpc` using SciPy's `quad` integral.
+Hotfix 9: Parser auto-discovery fixed to look in the top-level `parsers` directory.
 Updated for Phase 6. Added placeholder parsers for CMB, gravitational waves and standard sirens, and expanded JSON schema.
 
 # Copernican Suite Development Guide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   distance predictions.
 - Hotfix 8: Sound horizon `r_s` is now computed automatically when possible using
   a fallback integral if `rs_expression` is missing.
+- Hotfix 9: Parser auto-discovery now searches the project's top-level `parsers`
+  directory instead of a nonexistent `scripts/parsers` folder.
 
 ## Version 1.5e (Development Release)
 - Added Numba-based engine and modular utility wrappers.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ should not be modified by AI-driven code changes.
   `data/bao`. Future datasets such as CMB or gravitational waves will use
   their own folders.
 - Parsers and engines are also selected interactively from their respective
-  directories.
+  directories. Parsers for each data type are automatically discovered from
+  `parsers/<type>/` subfolders at startup.
 - After each run you may choose to evaluate another model or exit. Cache files
   are cleaned automatically.
 

--- a/scripts/data_loaders.py
+++ b/scripts/data_loaders.py
@@ -2,6 +2,7 @@
 # DEV NOTE (v1.5f): Added registries and loader functions for CMB, gravitational
 # wave, and standard siren data types as preparation for future datasets.
 # DEV NOTE (v1.5f hotfix): File moved to ``scripts/`` package; import paths for parsers updated.
+# DEV NOTE (v1.5f hotfix 9): Corrected parser discovery path to top-level ``parsers`` directory.
 """
 Modular data loading for various cosmological datasets (SNe, BAO, etc.).
 """
@@ -77,8 +78,10 @@ def register_siren_parser(name, description=""):
 
 # --- Dynamic Discovery of Parser Modules ---
 def _discover_parsers():
-    """Imports all parser modules under the ./parsers directory."""
-    base_dir = os.path.join(os.path.dirname(__file__), 'parsers')
+    """Imports all parser modules under the project's ``parsers`` directory."""
+    # ``data_loaders.py`` lives in ``scripts/`` so we move one level up to find
+    # the root ``parsers`` folder next to ``scripts``.
+    base_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'parsers')
     for sub in ('sne', 'bao', 'cmb', 'gw', 'sirens'):
         subdir = os.path.join(base_dir, sub)
         if not os.path.isdir(subdir):


### PR DESCRIPTION
## Summary
- fix parser discovery path in `data_loaders.py`
- document hotfix in AGENTS, README, and CHANGELOG

## Testing
- `python3 -m py_compile scripts/data_loaders.py`
- `python3 - <<'PY'
import scripts.data_loaders as dl
print('SNE parsers:', list(dl.SNE_PARSERS.keys()))
print('BAO parsers:', list(dl.BAO_PARSERS.keys()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_685035d61f18832f89117b198d656e5d