### PR TITLE
Fix BAO sound horizon integral

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 <!-- DEV NOTE (v1.5f hotfix 10): BAO smooth curve generation fixed by vectorizing distance integrals. -->
 <!-- DEV NOTE (v1.5f hotfix 11): Volume-averaged distance function now supports
      array inputs to prevent BAO plotting errors. -->
+<!-- DEV NOTE (v1.5f hotfix 12): r_s fallback integral includes radiation
+     density for accurate BAO scaling. -->
 
 **Version:** 1.5f
 **Last Updated:** 2025-06-20


### PR DESCRIPTION
## Summary
- adjust sound horizon fallback integral to add radiation density
- document hotfix for BAO scaling

## Testing
- `python3 -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6850a4dff59c832f8ee833da48690ba2