### PR TITLE
Fix webapp init

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Hotfix 5: Removed automatic dependency installer. The suite now instructs users 
 Hotfix 7: Models now provide a symbolic `Hz_expression` compiled at runtime for distance calculations.
 Hotfix 8: When `rs_expression` is absent but `Ob`, `Og` and `z_recomb` exist, the suite derives `get_sound_horizon_rs_Mpc` using SciPy's `quad` integral.
 Hotfix 9: Parser auto-discovery fixed to look in the top-level `parsers` directory.
+Hotfix 10: `webapp.__init__` lazily imports the Flask app to prevent runpy warnings when executed with `python -m webapp.app`.
 Updated for Phase 6. Added placeholder parsers for CMB, gravitational waves and standard sirens, and expanded JSON schema.
 Web transition plan added. CLI remains for now but will be deprecated when the new Flask interface is complete.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Copernican Suite
 <!-- DEV NOTE (v1.5h): Added Flask web interface skeleton and session management. -->
+<!-- DEV NOTE (v1.5h hotfix 10): `webapp.__init__` now lazy-loads the Flask app to avoid runpy warnings when starting the server. -->
 <!-- DEV NOTE (v1.5f): Updated for Phase 6 with new data-type placeholders and schema fields. -->
 <!-- DEV NOTE (v1.5f hotfix): Dependency scanner ignores relative imports; JSON models now support "sympy." prefix. -->
 <!-- DEV NOTE (v1.5f hotfix 2): JSON models include abstract, description and notes fields for upcoming UI modules. -->

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,5 +1,12 @@
-# DEV NOTE (v1.5h): Package initialization for the Flask web interface.
+# DEV NOTE (v1.5h hotfix 10): Package now lazy-loads the Flask app to
+# avoid runpy warnings when executed with ``python -m webapp.app``.
 """Expose the Flask application for external runners."""
-from .app import app
 
 __all__ = ["app"]
+
+def __getattr__(name: str):
+    """Lazily import and return the Flask application instance."""
+    if name == "app":
+        from .app import app as flask_app
+        return flask_app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- fix runtime warning when launching Flask app
- update docs with dev note about the change

## Testing
- `python3 -m py_compile webapp/__init__.py`
- `python3 -m webapp.app` (server starts)

------
https://chatgpt.com/codex/tasks/task_e_68515d31871c832fb9daaeff862bbc86