### PR TITLE
Switch to semantic versioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
+# DEV NOTE (v1.5.0) Semantic versioning adopted; version constant updated.
 # DEV NOTE (v1.5g)
 Added pyproject configuration and installation instructions.
 Hotfix: improved dependency scanner to skip relative imports and added SymPy aliasing in model_coder.
@@ -98,3 +99,9 @@ To keep the project maintainable all contributors, human or AI, must follow thes
 5. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in any file.**
 
 Failure to follow these guidelines will compromise the Copernican Suite.
+
+## 7. Versioning Policy
+The project follows Semantic Versioning (`MAJOR.MINOR.PATCH`). Increment the
+`MAJOR` number for breaking changes, the `MINOR` for new backward-compatible
+features and the `PATCH` for bug fixes. Package versions are derived from Git
+tags using `setuptools_scm`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Copernican Suite Change Log
+<!-- DEV NOTE (v1.5.0): Adopted semantic versioning. -->
 <!-- DEV NOTE (v1.5g): Data source reorganization and version bump. -->
-## Version 1.5g (Development Release)
+## Version 1.5.0 (Development Release)
 - Data files and parsers reorganized under ``data/<type>/<source>/``.
 - Parser selection now based on data source only.
 - Removed deprecated `parsers/` directory and UniStra h2 parser.
-- Updated documentation for version 1.5g.
+- Updated documentation for version 1.5.0.
 - Hotfix: Prompts list friendly dataset names with a clear title for every selection.
 
 ## Version 1.5f (Development Release)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <!-- DEV NOTE (v1.5g): Data sources restructured under data/<type>/<source>; parsers moved accordingly. -->
 <!-- DEV NOTE (v1.5g hotfix): Selection prompts now display descriptive dataset and engine names. -->
+# DEV NOTE (v1.5.0): Adopted semantic versioning and updated documentation.
 # Copernican Suite
 <!-- DEV NOTE (v1.5f): Updated for Phase 6 with new data-type placeholders and schema fields. -->
 <!-- DEV NOTE (v1.5f hotfix): Dependency scanner ignores relative imports; JSON models now support "sympy." prefix. -->
@@ -15,7 +16,7 @@
 <!-- DEV NOTE (v1.5g hotfix 14): Replaced GPL reference with Copernican Suite License (CSL). -->
 <!-- DEV NOTE (v1.5g update): Added pyproject build instructions and install section. -->
 
-**Version:** 1.5g
+**Version:** 1.5.0
 **Last Updated:** 2025-06-20
 engines/          - Computational backends (SciPy CPU by default, plus Numba)
 
@@ -37,6 +38,7 @@ plugged in with minimal effort.
 6. [Development Notes](#development-notes)
 7. [AI Development Laws](#ai-development-laws)
 8. [License](#license)
+9. [Versioning Policy](#versioning-policy)
 
 ---
 
@@ -176,6 +178,11 @@ Copernican Suite.
 ## License
 The Copernican Suite is distributed under the terms of the [Copernican Suite License (CSL)](LICENSE.md).
 
+## Versioning Policy
+The project now follows [Semantic Versioning](https://semver.org/). Versions are
+listed as `MAJOR.MINOR.PATCH`, where breaking changes increment `MAJOR`, new
+features increment `MINOR` and bug fixes increment `PATCH`. Package builds use
+`setuptools_scm` to derive the version from Git tags.
 
 ## 4. Workflow Overview
 

--- a/copernican.py
+++ b/copernican.py
@@ -2,6 +2,7 @@
 """
 Copernican Suite - Main Orchestrator.
 """
+# DEV NOTE (v1.5.0): Adopted semantic versioning; constant updated accordingly.
 # DEV NOTE (v1.5f): Added placeholders for future data types and bumped version.
 # DEV NOTE (v1.5f hotfix): Fixed dependency scanner to ignore relative imports.
 # DEV NOTE (v1.5f hotfix 5): Removed automatic dependency installer. The program
@@ -37,7 +38,7 @@ engine_interface = None
 output_manager = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.5g"
+COPERNICAN_VERSION = "1.5.0"
 
 def show_splash_screen():
     """Displays the startup banner once at launch."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
+# DEV NOTE (v1.5.0): Added setuptools_scm for Git-based versioning.
 # DEV NOTE (v1.5g): Added packaging metadata and entry point.
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -25,5 +26,6 @@ copernican = "copernican:main_workflow"
 packages = ["scripts", "engines"]
 py-modules = ["copernican"]
 
-[tool.setuptools.dynamic]
-version = {attr = "copernican.COPERNICAN_VERSION"}
+
+[tool.setuptools_scm]
+version_scheme = "no-guess-dev"


### PR DESCRIPTION
## Summary
- switch project version string to semantic format `1.5.0`
- document Semantic Versioning policy in README and AGENTS
- note Semantic Versioning in CHANGELOG
- update constant and packaging metadata

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68557917b488832fb096c96b144326fc