### PR TITLE
Fix location spelling in license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,9 @@
+# DEV NOTE: corrected location spelling to Bulgaria in copyright line.
 SPDX-License-Identifier: LicenseRef-CSL-1.4
 
 # Copernican Suite License (CSL) v1.4
 
-© 2025 Apostol Valentinov Apostolov and Black Epsilon Ltd., Sofia, Buglaria
+© 2025 Apostol Valentinov Apostolov and Black Epsilon Ltd., Sofia, **Bulgaria**
 All rights reserved.
 
 ## 1. Definitions


### PR DESCRIPTION
## Summary
- add dev note to LICENSE
- fix Bulgaria spelling in license line

## Testing
- `grep -n Buglaria -n LICENSE.md`

------
https://chatgpt.com/codex/tasks/task_e_68559c2a8bf8832f81e82d8b302affea