### PR TITLE
Improve Numba JIT fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **Version:** 1.5.0
 **Last Updated:** 2025-06-20
-engines/          - Computational backends (SciPy CPU by default, plus Numba)
+engines/          - Computational backends (SciPy CPU by default; optional Numba acceleration with fallback)
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia) and Baryon Acoustic Oscillation (BAO) data. Future
@@ -87,7 +87,7 @@ Run `pip install .` from the repository root to build and install the `copernica
 ## Directory Layout
 ```
 models/           - JSON model definitions (Markdown optional)
-engines/          - Computational backends (SciPy CPU and Numba)
+engines/          - Computational backends (SciPy CPU and Numba with automatic fallback)
 data/             - Observation data organized as ``data/<type>/<source>/``
 output/           - All generated results
 AGENTS.md         - Development specification and contributor rules

--- a/engines/cosmo_engine_numba.py
+++ b/engines/cosmo_engine_numba.py
@@ -1,6 +1,8 @@
 # Copernican Suite Numba Engine
 """Numba-accelerated engine wrapper."""
 # DEV NOTE (v1.5e): Introduced in Phase 5 to provide a faster backend.
+# DEV NOTE (patch): Improved JIT helper to compile functions individually and
+# fall back to Python when compilation fails.
 
 from numba import njit
 import logging
@@ -8,21 +10,36 @@ from types import SimpleNamespace
 from . import cosmo_engine_1_4b as cpu_engine
 
 
+def _try_njit(func, name):
+    """Attempt to JIT compile ``func``; return original on failure."""
+    logger = logging.getLogger()
+    try:
+        return njit(func)
+    except Exception as exc:  # pragma: no cover - runtime dependent
+        logger.warning(f"JIT compile failed for {name}: {exc}")
+        return func
+
+
 def _jit_plugin(plugin):
     """Return a copy of `plugin` with JIT-compiled functions where possible."""
     attrs = {k: getattr(plugin, k) for k in dir(plugin) if not k.startswith('__')}
     compiled = SimpleNamespace(**attrs)
-    try:
-        compiled.distance_modulus_model = njit(plugin.distance_modulus_model)
-        compiled.get_comoving_distance_Mpc = njit(plugin.get_comoving_distance_Mpc)
-        compiled.get_luminosity_distance_Mpc = njit(plugin.get_luminosity_distance_Mpc)
-        compiled.get_angular_diameter_distance_Mpc = njit(plugin.get_angular_diameter_distance_Mpc)
-        compiled.get_Hz_per_Mpc = njit(plugin.get_Hz_per_Mpc)
-        compiled.get_DV_Mpc = njit(plugin.get_DV_Mpc)
-        compiled.get_sound_horizon_rs_Mpc = njit(plugin.get_sound_horizon_rs_Mpc)
-    except Exception as e:
-        logging.getLogger().warning(f"Numba JIT compilation failed: {e}")
-        return plugin
+
+    func_names = [
+        'distance_modulus_model',
+        'get_comoving_distance_Mpc',
+        'get_luminosity_distance_Mpc',
+        'get_angular_diameter_distance_Mpc',
+        'get_Hz_per_Mpc',
+        'get_DV_Mpc',
+        'get_sound_horizon_rs_Mpc',
+    ]
+
+    for fname in func_names:
+        func = getattr(plugin, fname, None)
+        if callable(func):
+            setattr(compiled, fname, _try_njit(func, fname))
+
     return compiled
 
 


### PR DESCRIPTION
## Summary
- more flexible JIT compilation for the Numba engine
- update documentation to mention automatic fallback

## Testing
- `python -m compileall engines/cosmo_engine_numba.py`
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6855a5003dd0832f804134c45de31288