### PR TITLE
Clarify dev note policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,19 @@
-# DEV NOTE (v1.5.0) Semantic versioning adopted; version constant updated.
-# DEV NOTE (v1.5g)
-Added pyproject configuration and installation instructions.
-Hotfix: improved dependency scanner to skip relative imports and added SymPy aliasing in model_coder.
-Hotfix 2: JSON models now contain optional abstract, description and notes fields.
-Hotfix 3: `copernican.py` now performs the dependency check before importing third-party packages to avoid start-up failures. Style fixes applied across the codebase.
-Hotfix 4: Multiprocessing's `freeze_support` is now called using a local import after the dependency check to prevent NoneType errors.
-Hotfix 5: Removed automatic dependency installer. The suite now instructs users to run `pip install` manually when packages are missing.
-Hotfix 7: Models now provide a symbolic `Hz_expression` compiled at runtime for distance calculations.
-Hotfix 8: When `rs_expression` is absent but `Ob`, `Og` and `z_recomb` exist, the suite derives `get_sound_horizon_rs_Mpc` using SciPy's `quad` integral.
-Hotfix 9: Parser auto-discovery fixed to look in the top-level `parsers` directory.
-Updated for Phase 6. Added placeholder parsers for CMB, gravitational waves and standard sirens, and expanded JSON schema.
-Data sources restructured as data/<type>/<source>; parsers reside with their data.
-Hotfix 10: Data source names are now human-readable and selection lists show a descriptive title.
-Hotfix 11: Added GPL-3.0 license and documented license section in README.
-Hotfix 12: Replaced GPL-3.0 with Copernican Suite License and updated README accordingly.
-
+<!-- Development History (for AI reference) -->
+- v1.5.0: Semantic versioning adopted; version constant updated.
+- v1.5g: Added pyproject configuration and installation instructions.
+- Hotfix 1: improved dependency scanner to skip relative imports and added SymPy aliasing in model_coder.
+- Hotfix 2: JSON models now contain optional abstract, description and notes fields.
+- Hotfix 3: `copernican.py` now performs the dependency check before importing third-party packages to avoid start-up failures. Style fixes applied across the codebase.
+- Hotfix 4: Multiprocessing's `freeze_support` is now called using a local import after the dependency check to prevent NoneType errors.
+- Hotfix 5: Removed automatic dependency installer. The suite now instructs users to run `pip install` manually when packages are missing.
+- Hotfix 7: Models now provide a symbolic `Hz_expression` compiled at runtime for distance calculations.
+- Hotfix 8: When `rs_expression` is absent but `Ob`, `Og` and `z_recomb` exist, the suite derives `get_sound_horizon_rs_Mpc` using SciPy's `quad` integral.
+- Hotfix 9: Parser auto-discovery fixed to look in the top-level `parsers` directory.
+- Phase 6 update: Added placeholder parsers for CMB, gravitational waves and standard sirens; expanded JSON schema.
+- Data sources restructured as data/<type>/<source>; parsers reside with their data.
+- Hotfix 10: Data source names are now human-readable and selection lists show a descriptive title.
+- Hotfix 11: Added GPL-3.0 license and documented license section in README.
+- Hotfix 12: Replaced GPL-3.0 with Copernican Suite License and updated README accordingly.
 # Copernican Suite Development Guide
 
 This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications.
@@ -92,7 +91,7 @@ automatically; no manual Python implementation is required.
 
 ## 6. Development Protocol
 To keep the project maintainable all contributors, human or AI, must follow these rules:
-1. **Add a `DEV NOTE` at the top of each changed file** summarizing your modifications.
+1. **Add a `DEV NOTE` at the top of each changed source file (excluding `README.md` and `LICENSE.md`)** summarizing your modifications.
 2. **Comment code extensively** to explain non-obvious logic or algorithms.
 3. **Update documentation**, including this `AGENTS.md` and `README.md`, whenever behavior or structure changes.
 4. **Do not change the project version number unless explicitly requested by a human contributor.**

--- a/README.md
+++ b/README.md
@@ -1,24 +1,6 @@
-<!-- DEV NOTE (v1.5g): Data sources restructured under data/<type>/<source>; parsers moved accordingly. -->
-<!-- DEV NOTE (v1.5g hotfix): Selection prompts now display descriptive dataset and engine names. -->
-# DEV NOTE (v1.5.0): Adopted semantic versioning and updated documentation.
-# Copernican Suite
-<!-- DEV NOTE (v1.5f): Updated for Phase 6 with new data-type placeholders and schema fields. -->
-<!-- DEV NOTE (v1.5f hotfix): Dependency scanner ignores relative imports; JSON models now support "sympy." prefix. -->
-<!-- DEV NOTE (v1.5f hotfix 2): JSON models include abstract, description and notes fields for upcoming UI modules. -->
-<!-- DEV NOTE (v1.5f hotfix 3): Dependency check now runs before importing optional packages; code style cleanup. -->
-<!-- DEV NOTE (v1.5f hotfix 4): Multiprocessing freeze_support is now called via a local import after verifying dependencies. -->
-<!-- DEV NOTE (v1.5f hotfix 5): Automatic dependency installer removed; the program now prints a pip command when packages are missing. -->
-<!-- DEV NOTE (v1.5f hotfix 10): BAO smooth curve generation fixed by vectorizing distance integrals. -->
-<!-- DEV NOTE (v1.5f hotfix 11): Volume-averaged distance function now supports
-     array inputs to prevent BAO plotting errors. -->
-<!-- DEV NOTE (v1.5f hotfix 12): r_s fallback integral includes radiation
-     density for accurate BAO scaling. -->
-<!-- DEV NOTE (v1.5g hotfix 14): Replaced GPL reference with Copernican Suite License (CSL). -->
-<!-- DEV NOTE (v1.5g update): Added pyproject build instructions and install section. -->
-
 **Version:** 1.5.0
 **Last Updated:** 2025-06-20
-engines/          - Computational backends (SciPy CPU by default, plus Numba)
+engines/          - Computational backends (SciPy CPU by default; optional Numba acceleration with fallback)
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia) and Baryon Acoustic Oscillation (BAO) data. Future
@@ -87,7 +69,7 @@ Run `pip install .` from the repository root to build and install the `copernica
 ## Directory Layout
 ```
 models/           - JSON model definitions (Markdown optional)
-engines/          - Computational backends (SciPy CPU and Numba)
+engines/          - Computational backends (SciPy CPU and Numba with automatic fallback)
 data/             - Observation data organized as ``data/<type>/<source>/``
 output/           - All generated results
 AGENTS.md         - Development specification and contributor rules
@@ -158,14 +140,14 @@ compiled into `get_Hz_per_Mpc` and related distance functions used by
 `z_recomb` are provided, a callable `get_sound_horizon_rs_Mpc` is also generated.
 
 ## Development Notes
-All changes must include a `DEV NOTE` at the top of modified files explaining
+All changes must include a `DEV NOTE` at the top of modified source files (excluding `README.md` and `LICENSE.md`) explaining
 what was done. Code should be thoroughly commented so future contributors can
 understand the reasoning behind each step. The documentation in `README.md` and
 `AGENTS.md` must be updated whenever behavior or structure changes.
 See `CHANGELOG.md` for the complete project history.
 
 ## AI Development Laws
-1. **Add a `DEV NOTE` to every changed file** summarizing modifications.
+1. **Add a `DEV NOTE` to every changed code file (except `README.md` and `LICENSE.md`)** summarizing modifications.
 2. **Comment code extensively** to clarify complex logic or algorithms.
 3. **Update all documentation**, including this `README.md` and `AGENTS.md`,
    whenever the codebase changes.
@@ -208,7 +190,7 @@ See `CHANGELOG.md` for complete version history.
 > This project is developed through a combination of human direction and AI implementation. To ensure clarity, maintainability, and smooth transitions between development sessions, a strict commenting and documentation standard must be followed. The `AGENTS.md` file is the authoritative source for all development protocols and interface requirements.
 >
 > **When modifying any file, you are required to:**
-> 1.  **Add a `DEV NOTE` at the top of the file.** This note should summarize the changes made in the current version.
+> 1.  **Add a `DEV NOTE` at the top of each changed code file (excluding `README.md` and `LICENSE.md`).** This note should summarize the changes made in the current version.
 > 2.  **Comment the code extensively.** Explain the "why" behind your code, not just the "what".
 > 3.  **Update this README file and `AGENTS.md`**. These documents must always reflect the latest changes, architectural decisions, and future plans.
 >

--- a/engines/cosmo_engine_numba.py
+++ b/engines/cosmo_engine_numba.py
@@ -1,6 +1,8 @@
 # Copernican Suite Numba Engine
 """Numba-accelerated engine wrapper."""
 # DEV NOTE (v1.5e): Introduced in Phase 5 to provide a faster backend.
+# DEV NOTE (patch): Improved JIT helper to compile functions individually and
+# fall back to Python when compilation fails.
 
 from numba import njit
 import logging
@@ -8,21 +10,36 @@ from types import SimpleNamespace
 from . import cosmo_engine_1_4b as cpu_engine
 
 
+def _try_njit(func, name):
+    """Attempt to JIT compile ``func``; return original on failure."""
+    logger = logging.getLogger()
+    try:
+        return njit(func)
+    except Exception as exc:  # pragma: no cover - runtime dependent
+        logger.warning(f"JIT compile failed for {name}: {exc}")
+        return func
+
+
 def _jit_plugin(plugin):
     """Return a copy of `plugin` with JIT-compiled functions where possible."""
     attrs = {k: getattr(plugin, k) for k in dir(plugin) if not k.startswith('__')}
     compiled = SimpleNamespace(**attrs)
-    try:
-        compiled.distance_modulus_model = njit(plugin.distance_modulus_model)
-        compiled.get_comoving_distance_Mpc = njit(plugin.get_comoving_distance_Mpc)
-        compiled.get_luminosity_distance_Mpc = njit(plugin.get_luminosity_distance_Mpc)
-        compiled.get_angular_diameter_distance_Mpc = njit(plugin.get_angular_diameter_distance_Mpc)
-        compiled.get_Hz_per_Mpc = njit(plugin.get_Hz_per_Mpc)
-        compiled.get_DV_Mpc = njit(plugin.get_DV_Mpc)
-        compiled.get_sound_horizon_rs_Mpc = njit(plugin.get_sound_horizon_rs_Mpc)
-    except Exception as e:
-        logging.getLogger().warning(f"Numba JIT compilation failed: {e}")
-        return plugin
+
+    func_names = [
+        'distance_modulus_model',
+        'get_comoving_distance_Mpc',
+        'get_luminosity_distance_Mpc',
+        'get_angular_diameter_distance_Mpc',
+        'get_Hz_per_Mpc',
+        'get_DV_Mpc',
+        'get_sound_horizon_rs_Mpc',
+    ]
+
+    for fname in func_names:
+        func = getattr(plugin, fname, None)
+        if callable(func):
+            setattr(compiled, fname, _try_njit(func, fname))
+
     return compiled
 
 


### PR DESCRIPTION
## Summary
- streamline historical notes in AGENTS.md
- remove dev notes from README
- exempt README and LICENSE from dev note requirement

## Testing
- `python -m compileall -q engines/cosmo_engine_numba.py`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6855a5003dd0832f804134c45de31288