### PR TITLE
Update docs for JSON-only models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 <!-- Development History (for AI reference) -->
+# DEV NOTE (v1.5g update): clarified that all model details reside in JSON files; Markdown is optional for readability only.
 - v1.5.0: Semantic versioning adopted; version constant updated.
 - v1.5g: Added pyproject configuration and installation instructions.
 - Hotfix 1: improved dependency scanner to skip relative imports and added SymPy aliasing in model_coder.
@@ -32,7 +33,7 @@ ensures the expected functions are present and callable.
 
 ## 2. Directory Layout
 ```
-models/           - JSON model definitions (Markdown files optional)
+models/           - JSON model definitions with embedded theory text and equations (Markdown optional)
 engines/          - Computational backends (SciPy CPU by default)
 data/             - Observation files under ``data/<type>/<source>/``
 output/           - Generated plots and CSV tables
@@ -53,8 +54,10 @@ To install the suite as a package, run `pip install .` at the repository root. U
 
 ## 4. JSON Model System
 As of version 1.5f every cosmological model is described by a single JSON file
-`cosmo_model_*.json`. Markdown files may accompany the JSON for human
-readability, but there are no permanent Python plugins in the repository.
+`cosmo_model_*.json`. All theory text, equations and parameters reside in this
+file. Markdown files may mirror the JSON for readability, but there are no
+permanent Python plugins in the repository. Models are automatically discovered
+by scanning for `cosmo_model_*.json` files in the `models/` directory.
 
 ### 4.1 JSON Model File
 The schema requires `model_name`, `version`, `parameters` and `equations`.
@@ -67,8 +70,8 @@ being passed to the chosen engine.
 ## 5. Creating a New Model
 1. Copy an existing `cosmo_model_*.json` file such as `cosmo_model_lcdm.json`.
 2. Edit the JSON fields to describe your model, following the schema above.
-3. Optionally provide a Markdown file with the same base name to document the
-   model for human readers.
+3. Optionally create a Markdown file with the same base name if you want a
+   human-readable summary. The JSON must contain the complete theory.
 
 ### 5.1 JSON Template
 Use the following structure when creating new models:

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ plugged in with minimal effort.
 
 ## Overview
 The suite compares the reference \(\Lambda\)CDM model with alternative theories
-provided by the user. Each model is defined by a Markdown file under
-`./models/` and a matching Python implementation residing in the same package.
+provided by the user. Each model is defined entirely by a JSON file
+`cosmo_model_*.json` under `./models/`. The JSON contains all theory text,
+equations and parameters. Markdown files may optionally mirror the JSON for
+human readability.
 Users select models, datasets, and computational engines at runtime through a
 simple command line interface. Results are saved as plots and CSV files in the
 `./output/` directory.
@@ -68,7 +70,8 @@ Run `pip install .` from the repository root to build and install the `copernica
 
 ## Directory Layout
 ```
-models/           - JSON model definitions (Markdown optional)
+models/           - JSON model definitions containing all theory text and
+                    equations (Markdown optional)
 engines/          - Computational backends (SciPy CPU and Numba with automatic fallback)
 data/             - Observation data organized as ``data/<type>/<source>/``
 output/           - All generated results
@@ -85,7 +88,7 @@ scripts/          - Helper modules
 should not be modified by AI-driven code changes.
 
 ## Using the Suite
-- The program discovers available models from `models/cosmo_model_*.md`.
+- The program discovers available models from `models/cosmo_model_*.json`.
 - Data sources for SNe and BAO are chosen interactively. Once a source is
   selected, its parser and files are loaded automatically from
   `data/<type>/<source>/`. Future datasets will follow the same structure.
@@ -95,12 +98,13 @@ should not be modified by AI-driven code changes.
   are cleaned automatically.
 
 ## Creating New Models
-All models are now provided as a single JSON file. Markdown files can still be
-included for explanatory text but are not required. To create a new model:
+All model details, including theory text and equations, must be stored in a
+single JSON file. Markdown files can optionally mirror this information for
+readability but are not required. To create a new model:
 1. Copy an existing `cosmo_model_*.json` file and edit the fields to describe
    your theory.
-2. Optionally create `cosmo_model_name.md` to document the equations in LaTeX so
-   other researchers can read them easily.
+2. Optionally create `cosmo_model_name.md` if you want a human-friendly summary
+   of the same content.
 3. Include an `Hz_expression` string defining `H(z)` in terms of your model
    parameters. This enables BAO and distance-based predictions.
 4. Optionally provide an `rs_expression` for the sound horizon at recombination


### PR DESCRIPTION
## Summary
- clarify that model details live solely in `cosmo_model_*.json`
- mark Markdown as optional in README and AGENTS
- document automatic discovery of models from JSON files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855b64c6558832fb39b316d7a3f3696