### PR TITLE
Update docs for schema keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ Optional fields such as `unit` and `latex_name` provide additional context.
 `models/cache/`. `scripts/model_coder.py` transforms the equations into NumPy
 callables. These callables are validated by `scripts/engine_interface.py` before
 being passed to the chosen engine.
+`model_parser.py` ignores unrecognized keys and copies them to the cache, so
+new metadata can be added without breaking older JSON files.
 
 ## 5. Creating a New Model
 1. Copy an existing `cosmo_model_*.json` file such as `cosmo_model_lcdm.json`.
@@ -91,6 +93,8 @@ Use the following structure when creating new models:
 
 `model_parser.py` and `model_coder.py` handle validation and code generation
 automatically; no manual Python implementation is required.
+The parser keeps unknown keys intact, ensuring the DSL stays backward
+compatible as new fields are introduced.
 
 ## 6. Development Protocol
 To keep the project maintainable all contributors, human or AI, must follow these rules:

--- a/README.md
+++ b/README.md
@@ -134,9 +134,15 @@ auto-generates the necessary Python functions.
   "standard_sirens": {},
   "abstract": "short overview text",
   "description": "longer explanation with optional equations",
-  "notes": "any additional remarks"
+  "notes": "any additional remarks",
+  "title": "Human friendly model title",
+  "date": "2025-06-20",
+  "theory": {}
 }
 ```
+`model_parser.py` accepts unknown keys and simply copies them to the sanitized
+cache. This allows the domain-specific JSON language to evolve while remaining
+compatible with older models.
 `model_parser.py` validates this structure and `model_coder.py` translates the
 equations into NumPy-ready callables. When `Hz_expression` is present it is
 compiled into `get_Hz_per_Mpc` and related distance functions used by


### PR DESCRIPTION
## Summary
- expand README schema example with `title`, `date` and `theory`
- document parser tolerance of unknown JSON keys

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855baec5f04832f91c4559b6c23ccc1