### PR TITLE
Clarify JSON-only model format in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ ensures the expected functions are present and callable.
 
 ## 2. Directory Layout
 ```
-models/           - JSON model definitions with embedded theory text and equations (Markdown optional)
+models/           - JSON model definitions with embedded theory text and equations. Optional `.md` files may accompany a model for readability.
 engines/          - Computational backends (SciPy CPU by default)
 data/             - Observation files under ``data/<type>/<source>/``
 output/           - Generated plots and CSV tables
@@ -55,8 +55,9 @@ To install the suite as a package, run `pip install .` at the repository root. U
 ## 4. JSON Model System
 As of version 1.5f every cosmological model is described by a single JSON file
 `cosmo_model_*.json`. All theory text, equations and parameters reside in this
-file. Markdown files may mirror the JSON for readability, but there are no
-permanent Python plugins in the repository. Models are automatically discovered
+file. Markdown files may mirror the JSON for readability, but models are
+distributed only as JSON. No permanent Python plugins exist in the repository.
+Models are automatically discovered
 by scanning for `cosmo_model_*.json` files in the `models/` directory.
 
 ### 4.1 JSON Model File
@@ -72,8 +73,8 @@ new metadata can be added without breaking older JSON files.
 ## 5. Creating a New Model
 1. Copy an existing `cosmo_model_*.json` file such as `cosmo_model_lcdm.json`.
 2. Edit the JSON fields to describe your model, following the schema above.
-3. Optionally create a Markdown file with the same base name if you want a
-   human-readable summary. The JSON must contain the complete theory.
+3. *(Optional)* Create a Markdown file with the same base name if you want a
+   human-readable summary. The JSON file remains the single source of truth.
 
 ### 5.1 JSON Template
 Use the following structure when creating new models:

--- a/OLD_PLAN.md
+++ b/OLD_PLAN.md
@@ -2,7 +2,7 @@
 Updated for data source reorganization and version bump to 1.5g.
 Hotfix: Improved selection prompts with descriptive dataset names.
 # Copernican Suite Refactoring Plan
-This document explains how the project will evolve from the current Markdown + Python plugin system to a cleaner architecture where cosmological models are described solely in JSON. All engines will load code generated on the fly.
+This document explains how the project evolved from an initial Markdown + Python plugin system to a cleaner architecture where cosmological models are described solely in JSON. All engines load code generated on the fly.
 
 After finishing each phase or major step, append a short paragraph here describing what was done and when. This living document keeps everyone in sync.
 
@@ -23,7 +23,7 @@ This pipeline ensures that models stay purely declarative while engines receive 
    - Optional fields for constants and notes about future data types.
    - Keep the syntax approachable so scientists can copy any existing `cosmo_model_*.json` and fill in their own theory without writing code.
 2. **Create example models**
-   - Translate one Markdown + plugin pair into JSON to serve as the official template.
+   - Translate one of the original Markdown and plugin pairs into JSON to serve as the official template.
    - Document the schema in `README.md` so non-programmers can create models correctly.
    - *Done 2025-06-15 – Schema documented and example `cosmo_model_lcdm.json` added.*
 
@@ -45,7 +45,7 @@ This pipeline ensures that models stay purely declarative while engines receive 
 
 ## Phase 4 – Migrate Existing Models
 1. **Convert `.md` definitions**
-   - For each model, read its Markdown file and Python plugin. Recreate the same information in a single `.json` file using the new schema.
+   - For each original model, read its Markdown file and Python plugin. Recreate the same information in a single `.json` file using the new schema.
    - During this period, the original `.py` files can serve as edge-case examples of what the engine might need to compute.
 2. **Validate outputs**
    - Run the converted models through the suite and compare results with the original plugins to ensure correctness.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ plugged in with minimal effort.
 ## Overview
 The suite compares the reference \(\Lambda\)CDM model with alternative theories
 provided by the user. Each model is defined entirely by a JSON file
-`cosmo_model_*.json` under `./models/`. The JSON contains all theory text,
-equations and parameters. Markdown files may optionally mirror the JSON for
-human readability.
+`cosmo_model_*.json` under `./models/`. This JSON stores all theory text,
+equations and parameters and serves as the sole source of truth. Optional
+Markdown summaries may exist for human readers but are ignored by the
+software.
 Users select models, datasets, and computational engines at runtime through a
 simple command line interface. Results are saved as plots and CSV files in the
 `./output/` directory.
@@ -71,7 +72,8 @@ Run `pip install .` from the repository root to build and install the `copernica
 ## Directory Layout
 ```
 models/           - JSON model definitions containing all theory text and
-                    equations (Markdown optional)
+                    equations. Optional `.md` files may provide human-readable
+                    summaries but are not required.
 engines/          - Computational backends (SciPy CPU and Numba with automatic fallback)
 data/             - Observation data organized as ``data/<type>/<source>/``
 output/           - All generated results
@@ -99,12 +101,12 @@ should not be modified by AI-driven code changes.
 
 ## Creating New Models
 All model details, including theory text and equations, must be stored in a
-single JSON file. Markdown files can optionally mirror this information for
-readability but are not required. To create a new model:
+single JSON file. Markdown summaries are optional and have no effect on the
+software. To create a new model:
 1. Copy an existing `cosmo_model_*.json` file and edit the fields to describe
    your theory.
-2. Optionally create `cosmo_model_name.md` if you want a human-friendly summary
-   of the same content.
+2. *(Optional)* Create `cosmo_model_name.md` if you want a human-friendly
+   summary of the same content. The suite does not read this file.
 3. Include an `Hz_expression` string defining `H(z)` in terms of your model
    parameters. This enables BAO and distance-based predictions.
 4. Optionally provide an `rs_expression` for the sound horizon at recombination


### PR DESCRIPTION
## Summary
- emphasize that models are distributed strictly as JSON
- note that Markdown summaries are optional and ignored by the suite
- reword documentation of historical Markdown+plugin system

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855c10945f0832faeb7fa089a7a8f8d