### PR TITLE
Refactor model JSONs and auto-initialize parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,13 +84,15 @@ Use the following structure when creating new models:
   "model_name": "My Model",
   "version": "1.0",
   "parameters": [
-    {"name": "H0", "python_var": "H0", "initial_guess": 70.0, "bounds": [50, 100]}
+    {"name": "H0", "python_var": "H0", "bounds": [50, 100]}
   ],
   "equations": {
     "distance_modulus_model": "5*sympy.log(1+z,10)*H0"
   }
 }
 ```
+Initial guesses are computed automatically as the midpoint of each
+parameter's bounds.
 
 `model_parser.py` and `model_coder.py` handle validation and code generation
 automatically; no manual Python implementation is required.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ software. To create a new model:
 4. Optionally provide an `rs_expression` for the sound horizon at recombination
    or include the parameters `Ob`, `Og` and `z_recomb`. The suite will then
    derive `r_s` automatically using a numerical integral.
+5. Parameter initial guesses are calculated automatically as the midpoint of
+   each parameter's bounds.
 The suite validates the JSON, stores a sanitized copy under `models/cache/`, and
 auto-generates the necessary Python functions.
 
@@ -123,10 +125,10 @@ auto-generates the necessary Python functions.
   "Hz_expression": "H0 * sympy.sqrt(Om*(1+z)**3 + Ol)",
   "rs_expression": "integrate(c_s/H, (z, z_recomb, inf))",
   "parameters": [
-    {"name": "H0", "python_var": "H0", "initial_guess": 70.0, "bounds": [50, 100]}
-    ,{"name": "Ob", "python_var": "Ob", "initial_guess": 0.0486, "bounds": [0.01, 0.1]},
-    {"name": "Og", "python_var": "Og", "initial_guess": 5e-5, "bounds": [1e-5, 1e-4]},
-    {"name": "z_recomb", "python_var": "z_recomb", "initial_guess": 1089, "bounds": [1000, 1200]}
+    {"name": "H0", "python_var": "H0", "bounds": [50, 100]},
+    {"name": "Ob", "python_var": "Ob", "bounds": [0.01, 0.1]},
+    {"name": "Og", "python_var": "Og", "bounds": [1e-5, 1e-4]},
+    {"name": "z_recomb", "python_var": "z_recomb", "bounds": [1000, 1200]}
   ],
   "equations": {
     "distance_modulus_model": "5*sympy.log(1+z,10)*H0"
@@ -138,10 +140,10 @@ auto-generates the necessary Python functions.
   "description": "longer explanation with optional equations",
   "notes": "any additional remarks",
   "title": "Human friendly model title",
-  "date": "2025-06-20",
-  "theory": {}
+  "date": "2025-06-20"
 }
 ```
+Initial guesses are derived automatically from each parameter's bounds.
 `model_parser.py` accepts unknown keys and simply copies them to the sanitized
 cache. This allows the domain-specific JSON language to evolve while remaining
 compatible with older models.

--- a/models/cosmo_model_lcdm.json
+++ b/models/cosmo_model_lcdm.json
@@ -7,7 +7,6 @@
     {
       "name": "H0",
       "python_var": "H0",
-      "initial_guess": 67.7,
       "bounds": [
         50.0,
         100.0
@@ -17,7 +16,6 @@
     {
       "name": "Omega_m0",
       "python_var": "Omega_m0",
-      "initial_guess": 0.31,
       "bounds": [
         0.05,
         0.7
@@ -26,7 +24,6 @@
     {
       "name": "Omega_b0",
       "python_var": "Omega_b0",
-      "initial_guess": 0.0486,
       "bounds": [
         0.01,
         0.1
@@ -35,7 +32,6 @@
     {
       "name": "Ob",
       "python_var": "Ob",
-      "initial_guess": 0.0486,
       "bounds": [
         0.01,
         0.1
@@ -44,7 +40,6 @@
     {
       "name": "Og",
       "python_var": "Og",
-      "initial_guess": 5e-05,
       "bounds": [
         1e-05,
         0.0001
@@ -53,7 +48,6 @@
     {
       "name": "z_recomb",
       "python_var": "z_recomb",
-      "initial_guess": 1089,
       "bounds": [
         1000,
         1200
@@ -63,6 +57,5 @@
   "equations": {},
   "abstract": "LambdaCDM model describes a flat universe dominated by cold dark matter and a cosmological constant serving as the reference model",
   "description": "Uses H(z)=H0*sqrt(Omega_m0(1+z)^3+Omega_Lambda0). Luminosity distance integrates c/H. BAO scale DV uses angular distance and H(z).",
-  "notes": "Additional notes available.",
-  "theory": {}
+  "notes": "Additional notes available."
 }

--- a/models/cosmo_model_usmf2.json
+++ b/models/cosmo_model_usmf2.json
@@ -7,7 +7,6 @@
     {
       "name": "H_A",
       "python_var": "H_A",
-      "initial_guess": 77.111,
       "bounds": [
         50.0,
         100.0
@@ -18,7 +17,6 @@
     {
       "name": "p_alpha",
       "python_var": "p_alpha",
-      "initial_guess": 0.4313,
       "bounds": [
         0.1,
         1.5
@@ -29,7 +27,6 @@
     {
       "name": "k_exp",
       "python_var": "k_exp",
-      "initial_guess": -0.3268,
       "bounds": [
         -2.0,
         2.0
@@ -40,7 +37,6 @@
     {
       "name": "s_exp",
       "python_var": "s_exp",
-      "initial_guess": 1.1038,
       "bounds": [
         0.5,
         2.0
@@ -51,7 +47,6 @@
     {
       "name": "t0_age_Gyr",
       "python_var": "t0_age_Gyr",
-      "initial_guess": 13.397,
       "bounds": [
         10.0,
         20.0
@@ -62,7 +57,6 @@
     {
       "name": "A_osc",
       "python_var": "A_osc",
-      "initial_guess": 0.0027088,
       "bounds": [
         0.0,
         0.05
@@ -73,7 +67,6 @@
     {
       "name": "omega_osc",
       "python_var": "omega_osc",
-      "initial_guess": 2.3969,
       "bounds": [
         0.1,
         10.0
@@ -84,7 +77,6 @@
     {
       "name": "ti_osc_Gyr",
       "python_var": "ti_osc_Gyr",
-      "initial_guess": 7.1399,
       "bounds": [
         1.0,
         20.0
@@ -95,7 +87,6 @@
     {
       "name": "phi_osc",
       "python_var": "phi_osc",
-      "initial_guess": 0.10905,
       "bounds": [
         -3.1416,
         3.1416
@@ -106,7 +97,6 @@
     {
       "name": "Ob",
       "python_var": "Ob",
-      "initial_guess": 0.0486,
       "bounds": [
         0.01,
         0.1
@@ -115,7 +105,6 @@
     {
       "name": "Og",
       "python_var": "Og",
-      "initial_guess": 5e-05,
       "bounds": [
         1e-05,
         0.0001
@@ -124,48 +113,29 @@
     {
       "name": "z_recomb",
       "python_var": "z_recomb",
-      "initial_guess": 1089,
       "bounds": [
         1000,
         1200
       ]
     }
   ],
-  "equations": {},
-  "abstract": "Unified Shrinking Matter Framework proposes cosmic acceleration and dark matter effects are apparent from observing within shrinking systems refined with early universe evolution",
-  "description": "Model introduces dual reference frames universal and local. Scale factor alpha(t) evolves with parameters H_A p_alpha k_exp s_exp producing distance measures and BAO predictions.",
-  "notes": "Detailed theory embedded in this JSON.",
-  "title": "The Unified Shrinking Matter Framework (USMF) Version 2",
-  "date": "2025-05-26",
-  "theory": {
-    "abstract": "The Unified Shrinking Matter Framework (USMF) is a cosmological model proposing that the observed accelerated expansion of the Universe and phenomena attributed to dark matter and dark energy are apparent effects. These arise from observations made from within dense cosmic structures (like galaxies) that are themselves shrinking over cosmic time relative to a static universal coordinate system. This paper details the core concepts of USMF, its refined mathematical formulation including considerations for early universe evolution, the mechanisms for inhomogeneous shrinking, its implications for key cosmological observations such as Type Ia supernovae, Big Bang Nucleosynthesis, Baryon Acoustic Oscillations, and the matter-antimatter asymmetry. The framework suggests a dynamic evolution of fundamental scales and the effective gravitational constant ($G_{univ}(t)$), proposing specific modifications to gravitational field equations and offering novel explanations and unique testable predictions for cosmic puzzles without invoking new undiscovered particles or energy fields.",
-    "key_equations": [
-      "**For Supernovae (SNe Ia) Fitting:**",
+  "equations": {
+    "sne": [
       "$$1+z = \\frac{\\alpha(t_e)}{\\alpha(t_0)}$$",
       "$$r = \\int_{t_e}^{t_0} \\frac{c}{\\alpha(t')} dt'$$",
       "$$d_L(z) = |r| \\cdot (1+z)^2 \\cdot \\frac{70.0}{H_A}$$",
-      "$$\\mu = 5 \\log_{10}(d_L) + 25$$",
-      "**For Baryon Acoustic Oscillation (BAO) Analysis:**",
+      "$$\\mu = 5 \\log_{10}(d_L) + 25$$"
+    ],
+    "bao": [
       "$$D_A(z) = |r| \\cdot \\frac{70.0}{H_A}$$",
       "$$H_{USMF}(z) = - \\frac{1}{\\alpha(t_e)} \\left. \\frac{d\\alpha}{dt} \\right|_{t_e}$$",
       "$$D_V(z) = \\left[ (1+z)^2 D_A(z)^2 \\frac{cz}{H(z)} \\right]^{1/3}$$"
-    ],
-    "framework": [
-      "### 1. Introduction",
-      "Modern cosmology, while remarkably successful, faces fundamental challenges centered around the concepts of dark energy and dark matter, hypothetical entities comprising ~95% of the Universe's energy density. The observed accelerated expansion of the Universe [1, 2] and anomalous galactic and cluster dynamics [3, 4] are the primary evidence for their existence. The Unified Shrinking Matter Framework (USMF) offers an alternative perspective, positing that these phenomena are not due to new fundamental entities but are rather illusions. These illusions arise from a continuous, inhomogeneous shrinking of matter and physical scales within dense regions of the Universe, when observations are made with locally shrinking instruments and interpreted against a presumed static background.",
-      "This framework aims to explain the apparent cosmic acceleration and the effects attributed to dark matter by re-evaluating the nature of our reference frames and the evolution of physical scales over cosmic time. This updated document (Version 2) incorporates further elaborations on the model's theoretical underpinnings, mathematical extensions for early universe compatibility, and more detailed unique predictions.",
-      "### 2. Core Concepts of the Unified Shrinking Matter Framework",
-      "USMF is built upon several foundational ideas that distinguish it from standard cosmological models.",
-      "#### 2.1. Dual Reference Frames",
-      "A central tenet of USMF is the existence of two distinct types of reference frames:\n* A **Universal Coordinate System** ($X, Y, Z, T_{univ}$): This is a static, non-shrinking, four-dimensional Cartesian framework representing the Universe at its largest scales. Universal time is denoted as $t_{univ}$ or simply $t$.\n* **Local Coordinate Systems** ($x, y, z, t_{local}$): These are tied to dense regions of matter, such as galaxies and galaxy clusters. Within these local frames, spacetime itself, along with all matter, energy, and measuring instruments, undergoes a process of shrinking over cosmic time relative to the universal coordinates.",
-      "Observations made from Earth are inherently from within such a local, shrinking frame.",
-      "#### 2.2. Inhomogeneous Shrinking and its Quantification",
-      "The process of shrinking is not uniform throughout the Universe. It is posited to occur primarily within regions of significant matter density. Cosmic voids, being largely devoid of matter, are assumed to retain their original scales (established at a \"Universal Creation Event\" or UDE) in the universal coordinate system. As dense regions contract, voids effectively appear to expand or \"empty out\" relative to these shrinking zones. This inhomogeneity is crucial for explaining the apparent distribution of \"dark matter\" effects.",
-      "**Quantifying Inhomogeneous Shrinking**: The Universal Scaling Factor $\\alpha_U$ becomes a function of local environment: $\\alpha_U(\\rho, t_{univ}, \\mathbf{x}) = \\alpha_{U,bg}(t_{univ}) \\cdot f(\\rho_{local}(\\mathbf{x}, t_{univ}), \\text{history})$. Here, $\\alpha_{U,bg}(t_{univ})$ is the background cosmological shrinking factor, and $f$ describes the modulation due to local density $\\rho_{local}$ and potentially its history.",
-      "#### 2.3. The Metric in Dense Regions",
-      "Within a local, dense, shrinking region, the spacetime metric is proposed to take the form:\n$$ds^2 = -c^2 dt_{local}^2 + \\alpha_U(t_{univ}, env)^2 \\delta_{ij} dx^i dx^j$$\nwhere $c$ is the speed of light, $dt_{local}$ is the local time interval, $dx^i$ are local Cartesian spatial coordinate intervals, $\\delta_{ij}$ is the Kronecker delta, and $\\alpha_U(t_{univ}, env)$ is the Universal Scaling Factor. This factor $\\alpha_U$ describes the magnitude of spatial shrinking as a function of universal time $t_{univ}$ and potentially local environmental factors ($env$) such as density $\\rho$. For the background cosmological model, we primarily consider its temporal evolution $\\alpha_U(t_{univ})$. The shrinking implies that $\\alpha_U(t_{univ})$ is a decreasing function of cosmic time.",
-      "*(... The rest of the theoretical sections from the JSON would follow here, formatted with Markdown headings ...)*"
     ]
   },
+  "abstract": "The Unified Shrinking Matter Framework (USMF) is a cosmological model proposing that the observed accelerated expansion of the Universe and phenomena attributed to dark matter and dark energy are apparent effects. These arise from observations made from within dense cosmic structures (like galaxies) that are themselves shrinking over cosmic time relative to a static universal coordinate system. This paper details the core concepts of USMF, its refined mathematical formulation including considerations for early universe evolution, the mechanisms for inhomogeneous shrinking, its implications for key cosmological observations such as Type Ia supernovae, Big Bang Nucleosynthesis, Baryon Acoustic Oscillations, and the matter-antimatter asymmetry. The framework suggests a dynamic evolution of fundamental scales and the effective gravitational constant ($G_{univ}(t)$), proposing specific modifications to gravitational field equations and offering novel explanations and unique testable predictions for cosmic puzzles without invoking new undiscovered particles or energy fields.",
+  "description": "### 1. Introduction\nModern cosmology, while remarkably successful, faces fundamental challenges centered around the concepts of dark energy and dark matter, hypothetical entities comprising ~95% of the Universe's energy density. The observed accelerated expansion of the Universe [1, 2] and anomalous galactic and cluster dynamics [3, 4] are the primary evidence for their existence. The Unified Shrinking Matter Framework (USMF) offers an alternative perspective, positing that these phenomena are not due to new fundamental entities but are rather illusions. These illusions arise from a continuous, inhomogeneous shrinking of matter and physical scales within dense regions of the Universe, when observations are made with locally shrinking instruments and interpreted against a presumed static background.\nThis framework aims to explain the apparent cosmic acceleration and the effects attributed to dark matter by re-evaluating the nature of our reference frames and the evolution of physical scales over cosmic time. This updated document (Version 2) incorporates further elaborations on the model's theoretical underpinnings, mathematical extensions for early universe compatibility, and more detailed unique predictions.\n### 2. Core Concepts of the Unified Shrinking Matter Framework\nUSMF is built upon several foundational ideas that distinguish it from standard cosmological models.\n#### 2.1. Dual Reference Frames\nA central tenet of USMF is the existence of two distinct types of reference frames:\n* A **Universal Coordinate System** ($X, Y, Z, T_{univ}$): This is a static, non-shrinking, four-dimensional Cartesian framework representing the Universe at its largest scales. Universal time is denoted as $t_{univ}$ or simply $t$.\n* **Local Coordinate Systems** ($x, y, z, t_{local}$): These are tied to dense regions of matter, such as galaxies and galaxy clusters. Within these local frames, spacetime itself, along with all matter, energy, and measuring instruments, undergoes a process of shrinking over cosmic time relative to the universal coordinates.\nObservations made from Earth are inherently from within such a local, shrinking frame.\n#### 2.2. Inhomogeneous Shrinking and its Quantification\nThe process of shrinking is not uniform throughout the Universe. It is posited to occur primarily within regions of significant matter density. Cosmic voids, being largely devoid of matter, are assumed to retain their original scales (established at a \"Universal Creation Event\" or UDE) in the universal coordinate system. As dense regions contract, voids effectively appear to expand or \"empty out\" relative to these shrinking zones. This inhomogeneity is crucial for explaining the apparent distribution of \"dark matter\" effects.\n**Quantifying Inhomogeneous Shrinking**: The Universal Scaling Factor $\\alpha_U$ becomes a function of local environment: $\\alpha_U(\\rho, t_{univ}, \\mathbf{x}) = \\alpha_{U,bg}(t_{univ}) \\cdot f(\\rho_{local}(\\mathbf{x}, t_{univ}), \\text{history})$. Here, $\\alpha_{U,bg}(t_{univ})$ is the background cosmological shrinking factor, and $f$ describes the modulation due to local density $\\rho_{local}$ and potentially its history.\n#### 2.3. The Metric in Dense Regions\nWithin a local, dense, shrinking region, the spacetime metric is proposed to take the form:\n$$ds^2 = -c^2 dt_{local}^2 + \\alpha_U(t_{univ}, env)^2 \\delta_{ij} dx^i dx^j$$\nwhere $c$ is the speed of light, $dt_{local}$ is the local time interval, $dx^i$ are local Cartesian spatial coordinate intervals, $\\delta_{ij}$ is the Kronecker delta, and $\\alpha_U(t_{univ}, env)$ is the Universal Scaling Factor. This factor $\\alpha_U$ describes the magnitude of spatial shrinking as a function of universal time $t_{univ}$ and potentially local environmental factors ($env$) such as density $\\rho$. For the background cosmological model, we primarily consider its temporal evolution $\\alpha_U(t_{univ})$. The shrinking implies that $\\alpha_U(t_{univ})$ is a decreasing function of cosmic time.\n*(... The rest of the theoretical sections from the JSON would follow here, formatted with Markdown headings ...)*",
+  "notes": "Detailed theory embedded in this JSON.",
+  "title": "The Unified Shrinking Matter Framework (USMF) Version 2",
+  "date": "2025-05-26",
   "example_results": "-   **Dataset:** UniStra_FixedNuis_h1\n-   **Best-fit $\\chi^2$:** 1662.54"
 }

--- a/models/cosmo_model_usmf3b.json
+++ b/models/cosmo_model_usmf3b.json
@@ -7,7 +7,6 @@
     {
       "name": "H_A",
       "python_var": "H_A",
-      "initial_guess": 70.0,
       "bounds": [
         50.0,
         100.0
@@ -18,7 +17,6 @@
     {
       "name": "t0_age_Gyr",
       "python_var": "t0_age_Gyr",
-      "initial_guess": 14.0,
       "bounds": [
         10.0,
         20.0
@@ -29,7 +27,6 @@
     {
       "name": "p_kin",
       "python_var": "p_kin",
-      "initial_guess": 0.8,
       "bounds": [
         0.1,
         2.0
@@ -40,7 +37,6 @@
     {
       "name": "Omega_m0_fid",
       "python_var": "Omega_m0_fid",
-      "initial_guess": 0.31,
       "bounds": [
         0.2,
         0.4
@@ -51,7 +47,6 @@
     {
       "name": "Omega_b0_fid",
       "python_var": "Omega_b0_fid",
-      "initial_guess": 0.0486,
       "bounds": [
         0.03,
         0.07
@@ -62,7 +57,6 @@
     {
       "name": "Ob",
       "python_var": "Ob",
-      "initial_guess": 0.0486,
       "bounds": [
         0.01,
         0.1
@@ -71,7 +65,6 @@
     {
       "name": "Og",
       "python_var": "Og",
-      "initial_guess": 5e-05,
       "bounds": [
         1e-05,
         0.0001
@@ -80,33 +73,30 @@
     {
       "name": "z_recomb",
       "python_var": "z_recomb",
-      "initial_guess": 1089,
       "bounds": [
         1000,
         1200
       ]
     }
   ],
-  "equations": {},
-  "abstract": "USMFv3b kinematic simplifies shrinking matter model with power law index p_kin giving analytic distance solutions",
-  "description": "Combines the kinematic shrinking law with a standard sound horizon formula enabling rapid testing with SNe Ia and BAO data",
-  "notes": "Additional notes available.",
-  "title": "The Unified Shrinking Matter Framework (USMF) Version 3b - Kinematic",
-  "date": "2025-06-11",
-  "theory": {
-    "abstract": "This paper details the \"Kinematic\" version of the Unified Shrinking Matter Framework (USMF), a cosmological model that posits the apparent accelerated expansion of the Universe is an observational effect arising from matter shrinking over cosmic time. USMFv3b replaces the complex, computationally expensive formulation of previous versions with a simple, elegant power-law describing the shrinking process. This \"kinematic law\" is defined by a single index, `$p_{kin}$`, and leads to fully analytic solutions for cosmological distance measures, dramatically increasing computational speed and model robustness. By coupling this late-time kinematic model with a standard, physically-motivated calculation for the sound horizon (`$r_s$`) at the drag epoch, USMFv3b provides a consistent and powerful framework for testing against both Type Ia Supernovae (SNe Ia) and Baryon Acoustic Oscillation (BAO) data.",
-    "key_equations": [
-      "**For Supernovae (SNe Ia) Fitting:**",
+  "equations": {
+    "sne": [
       "$$\\alpha(t) = \\left( \\frac{t_0}{t} \\right)^{p_{kin}}$$",
       "$$1+z = \\alpha(t_e) \\implies t_e(z) = \\frac{t_0}{(1+z)^{1/p_{kin}}}$$",
       "$$r(z) = \\frac{c \\cdot t_0}{p_{kin}+1} \\left[ 1 - (1+z)^{-\\frac{p_{kin}+1}{p_{kin}}} \\right]$$",
       "$$d_L(z) = |r(z)| \\cdot (1+z)^2 \\cdot \\frac{70.0}{H_A}$$",
-      "$$\\mu = 5 \\log_{10}(d_L) + 25$$",
-      "**For Baryon Acoustic Oscillation (BAO) Analysis:**",
+      "$$\\mu = 5 \\log_{10}(d_L) + 25$$"
+    ],
+    "bao": [
       "$$D_A(z) = |r(z)| \\cdot \\frac{70.0}{H_A}$$",
       "$$H_{USMF}(z) = \\frac{p_{kin}}{t_0} (1+z)^{1/p_{kin}}$$",
       "$$D_V(z) = \\left[ (1+z)^2 D_A(z)^2 \\frac{cz}{H(z)} \\right]^{1/3}$$",
       "$$r_s \\approx \\frac{55.154 \\exp[-72.3(\\Omega_{m0}h^2 - 0.14)^2]}{\\sqrt{(\\Omega_{m0}h^2)^{0.25351}(\\Omega_{b0}h^2)^{0.12807}}} \\quad (\\text{Eisenstein & Hu 1998})$$"
     ]
-  }
+  },
+  "abstract": "This paper details the \"Kinematic\" version of the Unified Shrinking Matter Framework (USMF), a cosmological model that posits the apparent accelerated expansion of the Universe is an observational effect arising from matter shrinking over cosmic time. USMFv3b replaces the complex, computationally expensive formulation of previous versions with a simple, elegant power-law describing the shrinking process. This \"kinematic law\" is defined by a single index, `$p_{kin}$`, and leads to fully analytic solutions for cosmological distance measures, dramatically increasing computational speed and model robustness. By coupling this late-time kinematic model with a standard, physically-motivated calculation for the sound horizon (`$r_s$`) at the drag epoch, USMFv3b provides a consistent and powerful framework for testing against both Type Ia Supernovae (SNe Ia) and Baryon Acoustic Oscillation (BAO) data.",
+  "description": "Combines the kinematic shrinking law with a standard sound horizon formula enabling rapid testing with SNe Ia and BAO data",
+  "notes": "Additional notes available.",
+  "title": "The Unified Shrinking Matter Framework (USMF) Version 3b - Kinematic",
+  "date": "2025-06-11"
 }

--- a/models/cosmo_model_usmf4_qk.json
+++ b/models/cosmo_model_usmf4_qk.json
@@ -7,7 +7,6 @@
     {
       "name": "H0",
       "python_var": "H0",
-      "initial_guess": 68.0,
       "bounds": [
         50,
         80
@@ -18,7 +17,6 @@
     {
       "name": "Omega_m0",
       "python_var": "Omega_m0",
-      "initial_guess": 0.3,
       "bounds": [
         0.1,
         0.5
@@ -29,7 +27,6 @@
     {
       "name": "Omega_b0",
       "python_var": "Omega_b0",
-      "initial_guess": 0.0486,
       "bounds": [
         0.04,
         0.06
@@ -40,7 +37,6 @@
     {
       "name": "Ob",
       "python_var": "Ob",
-      "initial_guess": 0.0486,
       "bounds": [
         0.01,
         0.1
@@ -49,7 +45,6 @@
     {
       "name": "Og",
       "python_var": "Og",
-      "initial_guess": 5e-05,
       "bounds": [
         1e-05,
         0.0001
@@ -58,23 +53,14 @@
     {
       "name": "z_recomb",
       "python_var": "z_recomb",
-      "initial_guess": 1089,
       "bounds": [
         1000,
         1200
       ]
     }
   ],
-  "equations": {},
-  "abstract": "USMFv4 quantum kinematic links particle mass to inverse scale factor giving rho_m as one plus z to the fourth and new expansion history for strong fits",
-  "description": "Rest mass scaling 1/a(t) yields H(z)=H0 sqrt(Omega_m0(1+z)^4+Omega_Lambda0). Model connects to quantum properties and stays Newtonian at low redshift",
-  "notes": "Additional notes available.",
-  "title": "The Unified Shrinking Matter Framework (USMF) Version 4 - Quantum Kinematic",
-  "date": "2025-06-11",
-  "theory": {
-    "abstract": "This paper introduces the \"Quantum Kinematic\" version of the Unified Shrinking Matter Framework (USMFv4), a cosmological model that resolves the observational inconsistencies of its predecessor (USMFv3b). The model is founded on a new physical postulate: the rest mass of fundamental particles evolves in inverse proportion to the cosmic scale factor, $m(t) \\propto 1/a(t)$. This leads to a matter-energy density evolution of $\\rho_m(z) \\propto (1+z)^4$. This simple change has profound implications, creating a model with a direct conceptual link to quantum properties of matter, while yielding a new cosmic expansion history, $H(z) = H_0 \\sqrt{\\Omega_{m0}(1+z)^4 + \\Omega_{\\Lambda0}}$. USMFv4 is computationally robust, providing excellent fits to both Type Ia Supernovae (SNe Ia) and Baryon Acoustic Oscillation (BAO) data, and remains consistent with Newtonian mechanics in the low-redshift limit.",
-    "key_equations": [
-      "**For Supernovae (SNe Ia) and Baryon Acoustic Oscillation (BAO) Fitting:**",
+  "equations": {
+    "sne": [
       "$$H(z) = H_0 \\sqrt{\\Omega_{m0}(1+z)^4 + \\Omega_{\\Lambda0}}$$",
       "$$\\Omega_{\\Lambda0} = 1 - \\Omega_{m0}$$",
       "$$d_L(z) = (1+z) \\int_0^z \\frac{c}{H(z')} dz'$$",
@@ -82,5 +68,10 @@
       "$$D_A(z) = \\frac{1}{1+z} \\int_0^z \\frac{c}{H(z')} dz'$$",
       "$$D_V(z) = \\left[ (1+z)^2 D_A(z)^2 \\frac{cz}{H(z)} \\right]^{1/3}$$"
     ]
-  }
+  },
+  "abstract": "This paper introduces the \"Quantum Kinematic\" version of the Unified Shrinking Matter Framework (USMFv4), a cosmological model that resolves the observational inconsistencies of its predecessor (USMFv3b). The model is founded on a new physical postulate: the rest mass of fundamental particles evolves in inverse proportion to the cosmic scale factor, $m(t) \\propto 1/a(t)$. This leads to a matter-energy density evolution of $\\rho_m(z) \\propto (1+z)^4$. This simple change has profound implications, creating a model with a direct conceptual link to quantum properties of matter, while yielding a new cosmic expansion history, $H(z) = H_0 \\sqrt{\\Omega_{m0}(1+z)^4 + \\Omega_{\\Lambda0}}$. USMFv4 is computationally robust, providing excellent fits to both Type Ia Supernovae (SNe Ia) and Baryon Acoustic Oscillation (BAO) data, and remains consistent with Newtonian mechanics in the low-redshift limit.",
+  "description": "Rest mass scaling 1/a(t) yields H(z)=H0 sqrt(Omega_m0(1+z)^4+Omega_Lambda0). Model connects to quantum properties and stays Newtonian at low redshift",
+  "notes": "Additional notes available.",
+  "title": "The Unified Shrinking Matter Framework (USMF) Version 4 - Quantum Kinematic",
+  "date": "2025-06-11"
 }

--- a/scripts/engine_interface.py
+++ b/scripts/engine_interface.py
@@ -1,4 +1,5 @@
 """Interface to bridge generated model functions with existing engines."""
+# DEV NOTE (hotfix): initial guesses now computed from parameter bounds.
 # DEV NOTE (v1.5e): Validates plugin interfaces and presents generated
 # functions in the same format as classic Python plugins.
 # DEV NOTE (v1.5f hotfix 8): Supports ``valid_for_bao`` flag which skips
@@ -38,7 +39,9 @@ def build_plugin(model_data, func_dict):
     plugin.PARAMETER_NAMES = [p['python_var'] for p in model_data['parameters']]
     plugin.PARAMETER_LATEX_NAMES = [p.get('latex_name', p['name']) for p in model_data['parameters']]
     plugin.PARAMETER_UNITS = [p.get('unit', '') for p in model_data['parameters']]
-    plugin.INITIAL_GUESSES = [p['initial_guess'] for p in model_data['parameters']]
+    plugin.INITIAL_GUESSES = [
+        sum(p['bounds']) / 2.0 for p in model_data['parameters']
+    ]
     plugin.PARAMETER_BOUNDS = [tuple(p['bounds']) for p in model_data['parameters']]
     plugin.FIXED_PARAMS = {}
     plugin.valid_for_distance_metrics = model_data.get('valid_for_distance_metrics', True)

--- a/scripts/model_parser.py
+++ b/scripts/model_parser.py
@@ -1,4 +1,5 @@
 """Model parser for Copernican Suite JSON models."""
+# DEV NOTE (hotfix): removed ``initial_guess`` from the model schema.
 # DEV NOTE (v1.5f): Schema updated with optional CMB, gravitational wave, and
 # standard siren fields for Phase 6. Writes validated JSON models to the cache
 # directory and reports errors through ``error_handler``.
@@ -22,11 +23,10 @@ MODEL_SCHEMA = {
             "type": "array",
             "items": {
                 "type": "object",
-                "required": ["name", "python_var", "initial_guess", "bounds"],
+                "required": ["name", "python_var", "bounds"],
                 "properties": {
                     "name": {"type": "string"},
                     "python_var": {"type": "string"},
-                    "initial_guess": {"type": "number"},
                     "bounds": {
                         "type": "array",
                         "minItems": 2,


### PR DESCRIPTION
## Summary
- remove `initial_guess` from model schema and JSON files
- move theory details to `abstract`, `description` and `equations` fields
- compute parameter initial guesses from bounds at runtime
- ignore non-string entries in `equations`
- document automatic guess behaviour in README and AGENTS

## Testing
- `pip install -e .`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68566d288360832fb12590c05fc599db