### PR TITLE
Release v1.6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files are being phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current stable release is **version 1.6**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Add one line for each substantive commit or pull request directly under the late
 
 Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
+## Version 1.6 (Stable Release)
+- 2025-06-21: First stable release with reliable SNe Ia and BAO calculations (AI assistant)
 ## Version 1.5.1 (Development Release)
 - 2025-06-21: Added CHANGELOG template and updated docs to reference it (AI assistant)
 - Removed ``initial_guess`` from JSON models; parameter guesses now computed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.5.1
+**Version:** 1.6
 **Last Updated:** 2025-06-21
 engines/          - Computational backends (SciPy CPU by default; optional Numba acceleration with fallback)
 

--- a/copernican.py
+++ b/copernican.py
@@ -2,7 +2,7 @@
 """
 Copernican Suite - Main Orchestrator.
 """
-# DEV NOTE (v1.5.1): Version updated and documentation revised. Automatic
+# DEV NOTE (v1.6): Release version. Documentation and constants updated. Automatic
 # parameter guess generation uses bounds midpoints.
 # DEV NOTE (v1.5.0): Adopted semantic versioning; constant updated accordingly.
 # DEV NOTE (v1.5f): Added placeholders for future data types and bumped version.
@@ -43,7 +43,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.5.1"
+COPERNICAN_VERSION = "1.6"
 
 def show_splash_screen():
     """Displays the startup banner once at launch."""


### PR DESCRIPTION
## Summary
- bump the Copernican Suite release to **1.6**
- mark 1.6 stable release in docs and changelog
- update version constant and documentation references

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856f7b05f48832f996967ebe184b881