### PR TITLE
Expose model equations and filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Example:
 ## Version 1.6 (Stable Release)
 - 2025-06-21: First stable release with reliable SNe Ia and BAO calculations (AI assistant)
 - 2025-06-21: Legacy DEV NOTE headers removed from source files and notes migrated to `CHANGELOG.md` (AI assistant)
+- 2025-06-22: Plugin now exposes model equations and filename (AI assistant)
 ## Version 1.5.1 (Development Release)
 - 2025-06-21: Added CHANGELOG template and updated docs to reference it (AI assistant)
 - Removed ``initial_guess`` from JSON models; parameter guesses now computed

--- a/scripts/engine_interface.py
+++ b/scripts/engine_interface.py
@@ -41,6 +41,11 @@ def build_plugin(model_data, func_dict):
     plugin.FIXED_PARAMS = {}
     plugin.valid_for_distance_metrics = model_data.get('valid_for_distance_metrics', True)
     plugin.valid_for_bao = model_data.get('valid_for_bao', True)
+    eqs = model_data.get('equations', {})
+    plugin.MODEL_EQUATIONS_LATEX_SN = eqs.get('sne', [])
+    plugin.MODEL_EQUATIONS_LATEX_BAO = eqs.get('bao', [])
+    if 'filename' in model_data:
+        plugin.MODEL_FILENAME = model_data['filename']
     for name, func in func_dict.items():
         setattr(plugin, name, func)
     validate_plugin(plugin)


### PR DESCRIPTION
## Summary
- capture any model equations and filenames when building plugins
- document engine interface change in changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857de3bfee0832f8583c5d425902a6f