### PR TITLE
Record filename for generated plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Example:
 - 2025-06-21: First stable release with reliable SNe Ia and BAO calculations (AI assistant)
 - 2025-06-21: Legacy DEV NOTE headers removed from source files and notes migrated to `CHANGELOG.md` (AI assistant)
 - 2025-06-22: Plugin now exposes model equations and filename (AI assistant)
+- 2025-06-22: Plugin filename stored during JSON loading (AI assistant)
 ## Version 1.5.1 (Development Release)
 - 2025-06-21: Added CHANGELOG template and updated docs to reference it (AI assistant)
 - Removed ``initial_guess`` from JSON models; parameter guesses now computed

--- a/copernican.py
+++ b/copernican.py
@@ -235,7 +235,10 @@ def main_workflow():
         cache_dir = os.path.join(models_dir, 'cache')
         cache_path = model_parser.parse_model_json(json_path, cache_dir)
         func_dict, parsed = model_coder.generate_callables(cache_path)
-        return engine_interface.build_plugin(parsed, func_dict)
+        plugin = engine_interface.build_plugin(parsed, func_dict)
+        # Record the original model filename for downstream modules and logs.
+        plugin.MODEL_FILENAME = os.path.basename(json_path)
+        return plugin
 
     global lcdm
     lcdm = _load_lcdm_from_json()
@@ -278,6 +281,8 @@ def main_workflow():
                 try:
                     func_dict, parsed = model_coder.generate_callables(cache_path)
                     alt_model_plugin = engine_interface.build_plugin(parsed, func_dict)
+                    # Keep track of which JSON file produced this plugin.
+                    alt_model_plugin.MODEL_FILENAME = os.path.basename(json_path)
                     logger.info(f"Loaded JSON model: {parsed.get('model_name')}")
                 except Exception as e:
                     logger.error(f"Error generating model from JSON: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- track original json filename for both ΛCDM and alternative plugins
- log changelog entry

## Testing
- `python -m py_compile copernican.py scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6857e759e47c832f958360b13695d00a