### PR TITLE
Release 1.6.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current stable release is **version 1.6**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current stable release is **version 1.6.1**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Example:
 - 2025-06-22: Plugin now exposes model equations and filename (AI assistant)
 - 2025-06-22: Plugin filename stored during JSON loading (AI assistant)
 - 2025-06-22: Plots now include a timestamped footer with comparison details (AI assistant)
+## Version 1.6.1 (Patch Release)
+- Restored model equations in plot info boxes.
+- Added standardized plot footer with run metadata.
+- start.command cleaned up.
+
 ## Version 1.5.1 (Development Release)
 - 2025-06-21: Added CHANGELOG template and updated docs to reference it (AI assistant)
 - Removed ``initial_guess`` from JSON models; parameter guesses now computed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.6
+**Version:** 1.6.1
 **Last Updated:** 2025-06-21
 engines/          - Computational backends (SciPy CPU by default; optional Numba acceleration with fallback)
 

--- a/copernican.py
+++ b/copernican.py
@@ -27,7 +27,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.6"
+COPERNICAN_VERSION = "1.6.1"
 
 def show_splash_screen():
     """Displays the startup banner once at launch."""


### PR DESCRIPTION
## Summary
- bump version strings to 1.6.1
- document 1.6.1 patch release in CHANGELOG

## Testing
- `python -m py_compile copernican.py`
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6857edfcdc88832f99e89b6d1eff684c