### PR TITLE
Clarify when minor or patch increment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Example:
 - Added standardized plot footer with run metadata.
 - start.command cleaned up.
 - 2025-06-22: Documented stable plotting style and algorithms (AI assistant)
+- 2025-06-22: Clarified when MINOR vs PATCH increments occur in README (AI assistant)
 
 ## Version 1.5.1 (Development Release)
 - 2025-06-21: Added CHANGELOG template and updated docs to reference it (AI assistant)

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ listed as `MAJOR.MINOR.PATCH`, where breaking changes increment `MAJOR`, new
 features increment `MINOR` and bug fixes increment `PATCH`. Package builds use
 `setuptools_scm` to derive the version from Git tags.
 
+The `MINOR` value only increases when the suite gains a new data type or a
+similarly significant feature, such as introducing CMB support or a new engine.
+Routine bug fixes and small feature restorations bump the `PATCH` value without
+altering `MAJOR.MINOR`.
+
 ## 4. Workflow Overview
 
 1.  **Dependency Check**: `copernican.py` scans for missing packages and


### PR DESCRIPTION
## Summary
- expand README's Versioning Policy to clarify when minor vs patch increments occur
- log the documentation update in CHANGELOG

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6857f0cc6fac832fac5e3964973e464d