### PR TITLE
Populate ΛCDM equations and bump to 1.6.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current stable release is **version 1.6.1**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current stable release is **version 1.6.2**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Example:
 - 2025-06-22: Plugin now exposes model equations and filename (AI assistant)
 - 2025-06-22: Plugin filename stored during JSON loading (AI assistant)
 - 2025-06-22: Plots now include a timestamped footer with comparison details (AI assistant)
+## Version 1.6.2 (Patch Release)
+- 2025-06-24: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)
 - Restored model equations in plot info boxes.
 - 2025-06-23: Fixed plot crashes when model equations used display-mode dollar signs (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.6.1
+**Version:** 1.6.2
 **Last Updated:** 2025-06-21
 engines/          - Computational backends (SciPy CPU by default; optional Numba acceleration with fallback)
 

--- a/copernican.py
+++ b/copernican.py
@@ -27,7 +27,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.6.1"
+COPERNICAN_VERSION = "1.6.2"
 
 def show_splash_screen():
     """Displays the startup banner once at launch."""

--- a/models/cosmo_model_lcdm.json
+++ b/models/cosmo_model_lcdm.json
@@ -1,7 +1,8 @@
 {
   "model_name": "LambdaCDM",
   "version": "1.0",
-  "Hz_expression": "H0*sympy.sqrt(Omega_m0*(1+z)**3 + (1 - Omega_m0))",
+  "description": "Uses H(z)=H0*sqrt(Omega_m0(1+z)^3+Omega_Lambda0). Luminosity distance integrates c/H. BAO scale DV uses angular distance and H(z).",
+  "abstract": "LambdaCDM model describes a flat universe dominated by cold dark matter and a cosmological constant serving as the reference model",
   "parameters": [
     {
       "name": "H0",
@@ -53,10 +54,20 @@
       ]
     }
   ],
-  "equations": {},
-  "rs_expression": "147.0",
+  "Hz_expression": "H0*sympy.sqrt(Omega_m0*(1+z)**3 + (1 - Omega_m0))",
+  "equations": {
+    "sne": [
+      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
+      "$$\\mu(z) = 5\\log_{10}[d_L(z)/{\\rm Mpc}] + 25$$"
+    ],
+    "bao": [
+      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
+      "$$D_H(z) = \\frac{c}{H(z)}$$",
+      "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+    ]
+  },
+  "rs_expression": "44.5*sympy.log(9.83/(Omega_m0*(H0/100)**2))/sympy.sqrt(1 + 10*(Omega_b0*(H0/100)**2)**0.75)",
   "predicts_bao": true,
-  "abstract": "LambdaCDM model describes a flat universe dominated by cold dark matter and a cosmological constant serving as the reference model",
-  "description": "Uses H(z)=H0*sqrt(Omega_m0(1+z)^3+Omega_Lambda0). Luminosity distance integrates c/H. BAO scale DV uses angular distance and H(z).",
   "notes": "Additional notes available."
 }
+


### PR DESCRIPTION
## Summary
- add explicit ΛCDM SN and BAO equations
- derive LCDM sound horizon expression
- reorder LCDM model keys per guide
- bump docs and code version to 1.6.2

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from scripts import model_parser
model_parser.parse_model_json('models/cosmo_model_lcdm.json','models/cache')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6857f79159b4832f9bf5edd9177a6865