### PR TITLE
Populate ΛCDM equations and bump to 1.6.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current stable release is **version 1.6.1**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current stable release is **version 1.6.3**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Example:
 - 2025-06-22: Plugin now exposes model equations and filename (AI assistant)
 - 2025-06-22: Plugin filename stored during JSON loading (AI assistant)
 - 2025-06-22: Plots now include a timestamped footer with comparison details (AI assistant)
+## Version 1.6.2 (Patch Release)
+- 2025-06-24: Added LCDM equations and sound horizon formula (AI assistant)
+## Version 1.6.3 (Patch Release)
+- 2025-06-24: Restored `pyproject.toml` and silenced Pandas whitespace warning (AI assistant)
 ## Version 1.6.1 (Patch Release)
 - Restored model equations in plot info boxes.
 - 2025-06-23: Fixed plot crashes when model equations used display-mode dollar signs (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.6.1
-**Last Updated:** 2025-06-21
+**Version:** 1.6.3
+**Last Updated:** 2025-06-24
 engines/          - Computational backends (SciPy CPU by default; optional Numba acceleration with fallback)
 
 The Copernican Suite is a Python toolkit for testing cosmological models against

--- a/copernican.py
+++ b/copernican.py
@@ -27,7 +27,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.6.1"
+COPERNICAN_VERSION = "1.6.3"
 
 def show_splash_screen():
     """Displays the startup banner once at launch."""

--- a/data/sne/pantheon/cosmo_parser_pantheon.py
+++ b/data/sne/pantheon/cosmo_parser_pantheon.py
@@ -18,7 +18,7 @@ def parse_pantheon_plus_mu_cov_h2(data_dir, **kwargs):
     cov_filepath = os.path.join(data_dir, "Pancm.cov")
 
     try:
-        temp_df = pd.read_csv(filepath, delim_whitespace=True, comment='#')
+        temp_df = pd.read_csv(filepath, sep='\s+', engine='python', comment='#')
         data_df = pd.DataFrame()
         col_map = {
             'Name': ['CID','SNID','ID','NAME'],

--- a/models/cosmo_model_lcdm.json
+++ b/models/cosmo_model_lcdm.json
@@ -1,7 +1,8 @@
 {
   "model_name": "LambdaCDM",
   "version": "1.0",
-  "Hz_expression": "H0*sympy.sqrt(Omega_m0*(1+z)**3 + (1 - Omega_m0))",
+  "description": "Uses H(z)=H0*sqrt(Omega_m0(1+z)^3+Omega_Lambda0). Luminosity distance integrates c/H. BAO scale DV uses angular distance and H(z).",
+  "abstract": "LambdaCDM model describes a flat universe dominated by cold dark matter and a cosmological constant serving as the reference model",
   "parameters": [
     {
       "name": "H0",
@@ -53,10 +54,20 @@
       ]
     }
   ],
-  "equations": {},
-  "rs_expression": "147.0",
+  "Hz_expression": "H0*sympy.sqrt(Omega_m0*(1+z)**3 + (1 - Omega_m0))",
+  "equations": {
+    "sne": [
+      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
+      "$$\\mu(z) = 5\\log_{10}[d_L(z)/{\\rm Mpc}] + 25$$"
+    ],
+    "bao": [
+      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
+      "$$D_H(z) = \\frac{c}{H(z)}$$",
+      "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+    ]
+  },
+  "rs_expression": "44.5*sympy.log(9.83/(Omega_m0*(H0/100)**2))/sympy.sqrt(1 + 10*(Omega_b0*(H0/100)**2)**0.75)",
   "predicts_bao": true,
-  "abstract": "LambdaCDM model describes a flat universe dominated by cold dark matter and a cosmological constant serving as the reference model",
-  "description": "Uses H(z)=H0*sqrt(Omega_m0(1+z)^3+Omega_Lambda0). Luminosity distance integrates c/H. BAO scale DV uses angular distance and H(z).",
   "notes": "Additional notes available."
 }
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,120 +1,31 @@
-{
-  "model_name": "QESF",
-  "version": "1.0",
-  "predicts_bao": true,
-  "Hz_expression": "H_A*(p_inf + Delta_p*exp(-beta*z))/(p_inf + Delta_p)",
-  "parameters": [
-    {
-      "name": "H_A",
-      "python_var": "H_A",
-      "bounds": [50.0, 100.0],
-      "unit": "",
-      "latex_name": "$H_A$"
-    },
-    {
-      "name": "p_inf",
-      "python_var": "p_inf",
-      "bounds": [0.0, 2.0],
-      "unit": "",
-      "latex_name": "$p_{\\infty}$"
-    },
-    {
-      "name": "Delta_p",
-      "python_var": "Delta_p",
-      "bounds": [0.0, 2.0],
-      "unit": "",
-      "latex_name": "$\\Delta p$"
-    },
-    {
-      "name": "beta",
-      "python_var": "beta",
-      "bounds": [0.1, 5.0],
-      "unit": "",
-      "latex_name": "$\\beta$"
-    },
-    {
-      "name": "delta0",
-      "python_var": "delta0",
-      "bounds": [0.0, 0.2],
-      "unit": "",
-      "latex_name": "$\\delta_0$"
-    },
-    {
-      "name": "gamma",
-      "python_var": "gamma",
-      "bounds": [0.1, 5.0],
-      "unit": "",
-      "latex_name": "$\\gamma$"
-    },
-    {
-      "name": "V0",
-      "python_var": "V0",
-      "bounds": [1e-50, 1e-44],
-      "unit": "GeV^4",
-      "latex_name": "$V_0$"
-    },
-    {
-      "name": "V1",
-      "python_var": "V1",
-      "bounds": [1e-50, 1e-46],
-      "unit": "GeV^4",
-      "latex_name": "$V_1$"
-    },
-    {
-      "name": "kappa",
-      "python_var": "kappa",
-      "bounds": [0.1, 10.0],
-      "unit": "",
-      "latex_name": "$\\kappa$"
-    },
-    {
-      "name": "lambda",
-      "python_var": "lam",
-      "bounds": [0.1, 10.0],
-      "unit": "",
-      "latex_name": "$\\lambda$"
-    },
-    {
-      "name": "xi",
-      "python_var": "xi",
-      "bounds": [0.0, 0.1],
-      "unit": "",
-      "latex_name": "$\\xi$"
-    },
-    {
-      "name": "Ob",
-      "python_var": "Ob",
-      "bounds": [0.01, 0.1]
-    },
-    {
-      "name": "Og",
-      "python_var": "Og",
-      "bounds": [1e-05, 0.0001]
-    },
-    {
-      "name": "z_recomb",
-      "python_var": "z_recomb",
-      "bounds": [1000, 1200]
-    }
-  ],
-  "equations": {
-    "sne": [
-      "$$1+z = \\frac{\\alpha(t_e)}{\\alpha(t_0)}$$",
-      "$$r = \\int_{t_e}^{t_0} \\frac{c}{\\alpha(t')}\\,dt'$$",
-      "$$d_L(z) = |r| \\cdot (1+z)^2 \\cdot \\frac{70.0}{H_A}$$",
-      "$$\\mu = 5 \\log_{10}(d_L) + 25$$"
-    ],
-    "bao": [
-      "$$D_A(z) = |r| \\cdot \\frac{70.0}{H_A}$$",
-      "$$H(z) = H_A\\,(p_{\\infty} + \\Delta p\\,e^{-\\beta z})/(p_{\\infty} + \\Delta p)$$",
-      "$$D_V(z) = \\left[ (1+z)^2\\,D_A(z)^2\\,\\frac{c\\,z}{H(z)} \\right]^{1/3}$$",
-      "$$r_s = \\int_{z_{\\rm rec}}^{\\infty} \\frac{c_s(z')}{H(z')}\\,dz'$$"
-    ]
-  },
-  "abstract": "The Quantum–Environmental Shrinkage Field (QESF) cosmology introduces a light scalar φ whose redshift-dependent index p(z)=p_inf+Δp e^{−βz} and environmental modulation δ(z) modify local rulers. Both distances and the sound horizon r_s are computed self-consistently, yielding improved SNe Ia and BAO fits and a clear path toward quantum unification via φ–F² coupling.",
-  "description": "### 1. Effective Scale Factor\nDefine $$\\alpha(z)=[a_{bg}(z)]^{p(z)}[1+\\delta(z)],$$ with\n$$p(z)=p_{\\infty}+\\Delta p\\,e^{-\\beta z},\\quad\\delta(z)=\\delta_0\\frac{\\rho_{loc}(z)}{\\bar\\rho(z)}[1-e^{-\\gamma z}].$$\n\n### 2. Scalar-Field Dynamics\nLagrangian:\n$$\\mathcal{L}=-\\tfrac12(\\partial\\varphi)^2 - V(\\varphi) - \\tfrac14B(\\varphi)F_{\\mu\\nu}F^{\\mu\\nu} - \\sum_\\psi\\bar\\psi\\gamma^\\mu D_\\mu\\psi,$$\nwith\n$$V(\\varphi)=V_0[1-e^{-\\kappa\\varphi}]^2 + V_1e^{-\\lambda\\varphi},\\quad B(\\varphi)=e^{\\xi\\varphi}.$$\n\n### 3. Sound Horizon\nCompute\n$$r_s=\\int_{z_{\\rm rec}}^{\\infty}\\frac{c_s(z')}{H(z')}dz',\\quad c_s(z)=\\frac{c}{\\sqrt{3[1+R(z)]}},\\;R=\\frac{3\\rho_b}{4\\rho_\\gamma e^{\\xi\\varphi}}.$$",
-  "notes": "Schema-compliant QESF model based on USMFv2 template; analytic H(z) ensuring H(0)=H_A; δ(z) enters integrals but omitted from Hz_expression for tractability.",
-  "title": "Quantum–Environmental Shrinkage Field Cosmology",
-  "date": "2025-06-21",
-  "example_results": "- **Dataset:** UniStra_SNe+BAO\n- **Best-fit χ²_SNe:** 1208.5\n- **Best-fit χ²_BAO:** 133.2"
-}
+# DEV NOTE (v1.5.0): Added setuptools_scm for Git-based versioning.
+# DEV NOTE (v1.5g): Added packaging metadata and entry point.
+[build-system]
+requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "copernican-suite"
+description = "Evaluate cosmological models using observational data."
+dynamic = ["version"]
+authors = [{name = "Copernican Developers"}]
+license = {file = "LICENSE.md"}
+dependencies = [
+    "numpy",
+    "scipy",
+    "matplotlib",
+    "pandas",
+    "sympy",
+    "jsonschema",
+]
+
+[project.scripts]
+copernican = "copernican:main_workflow"
+
+[tool.setuptools]
+packages = ["scripts", "engines"]
+py-modules = ["copernican"]
+
+
+[tool.setuptools_scm]
+version_scheme = "no-guess-dev"


### PR DESCRIPTION
## Summary
- restore pyproject metadata and delete accidental content
- bump docs and codebase to version 1.6.3
- fix deprecated whitespace parsing in Pantheon+ loader

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from scripts import model_parser
model_parser.parse_model_json('models/cosmo_model_lcdm.json','models/cache')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6857f79159b4832f9bf5edd9177a6865