### PR TITLE
Add numeric Integral handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current stable release is **version 1.6.3**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current stable release is **version 1.6.4**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Add one line for each substantive commit or pull request directly under the late
 
 Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
+## Version 1.6.4 (Patch Release)
+- 2025-06-23: Added numerical quadrature support for Integral expressions (AI assistant)
 ## Version 1.6.3 (Patch Release)
 - 2025-06-22: Restored `pyproject.toml` and silenced Pandas whitespace warning (AI assistant)
 - 2025-06-22: Declared Python 3.13.1+ requirement in pyproject and README (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.6.3
-**Last Updated:** 2025-06-22
+**Version:** 1.6.4
+**Last Updated:** 2025-06-23
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia) and Baryon Acoustic Oscillation (BAO) data. Future
@@ -114,7 +114,9 @@ See `cosmo_model_guide.json` for a detailed template.
 4. Optionally provide an `rs_expression` for the sound horizon at recombination
    or include the parameters `Ob`, `Og` and `z_recomb`. The suite will then
    derive `r_s` automatically using a numerical integral.
-5. Parameter initial guesses are calculated automatically as the midpoint of
+5. Expressions may include `Integral(...)` terms. These are evaluated
+   numerically with SciPy's `quad` when the model is loaded.
+6. Parameter initial guesses are calculated automatically as the midpoint of
    each parameter's bounds.
 The suite validates the JSON, stores a sanitized copy under `models/cache/`, and
 auto-generates the necessary Python functions.

--- a/copernican.py
+++ b/copernican.py
@@ -27,7 +27,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.6.3"
+COPERNICAN_VERSION = "1.6.4"
 
 def show_splash_screen():
     """Displays the startup banner once at launch."""

--- a/scripts/model_coder.py
+++ b/scripts/model_coder.py
@@ -6,7 +6,32 @@ import sympy as sp
 import numpy as np
 from scipy.integrate import quad
 import logging
+from sympy.printing.numpy import NumPyPrinter
 from . import error_handler
+
+
+class QuadPrinter(NumPyPrinter):
+    """NumPy printer that expands ``Integral`` nodes into ``scipy`` quad calls."""
+
+    def _print_Integral(self, expr):
+        # Currently support single-variable integrals of the form (var, a, b).
+        var, a, b = expr.limits[0]
+        integrand = expr.function
+        var_code = self._print(var)
+        a_code = self._print(a)
+        b_code = self._print(b)
+        integrand_code = self._print(integrand)
+        return f"quad(lambda {var_code}: {integrand_code}, {a_code}, {b_code})[0]"
+
+
+def _compile_sympy_expr(sym_expr, args):
+    """Compile a SymPy expression into a callable handling ``Integral`` nodes."""
+    if sym_expr.atoms(sp.Integral):
+        printer = QuadPrinter({'strict': False})
+        code = printer.doprint(sym_expr)
+        lambda_src = f"lambda {', '.join(str(a) for a in args)}: {code}"
+        return eval(lambda_src, {'np': np, 'quad': quad})
+    return sp.lambdify(args, sym_expr, 'numpy')
 
 
 def generate_callables(cache_path):
@@ -49,7 +74,7 @@ def generate_callables(cache_path):
                 raise ValueError(
                     "Parameter '" + "', '".join(missing) + "' used in Hz_expression is not defined in model parameters."
                 )
-            hz_fn = sp.lambdify((z, *param_syms), hz_sym, 'numpy')
+            hz_fn = _compile_sympy_expr(hz_sym, (z, *param_syms))
             funcs['get_Hz_per_Mpc'] = hz_fn
             code_dict['get_Hz_per_Mpc'] = str(hz_sym)
             model_data['valid_for_distance_metrics'] = True
@@ -113,7 +138,7 @@ def generate_callables(cache_path):
                         raise ValueError(
                             "Parameter '" + "', '".join(missing_rs) + "' used in rs_expression is not defined in model parameters."
                         )
-                    rs_fn_sym = sp.lambdify(tuple(param_syms), rs_sym, 'numpy')
+                    rs_fn_sym = _compile_sympy_expr(rs_sym, tuple(param_syms))
                     funcs['get_sound_horizon_rs_Mpc'] = lambda *p: float(rs_fn_sym(*p))
                     code_dict['get_sound_horizon_rs_Mpc'] = str(rs_sym)
                     model_data['valid_for_bao'] = True
@@ -170,7 +195,7 @@ def generate_callables(cache_path):
             continue
         try:
             sym_expr = sp.sympify(expr, locals=local_dict)
-            fn = sp.lambdify((z, *param_syms), sym_expr, 'numpy')
+            fn = _compile_sympy_expr(sym_expr, (z, *param_syms))
             # Quick sanity evaluation using midpoints of parameter bounds
             try:
                 mid_params = tuple(sum(p['bounds']) / 2.0 for p in model_data['parameters'])


### PR DESCRIPTION
## Summary
- add QuadPrinter and _compile_sympy_expr to turn Integral nodes into `scipy.integrate.quad` calls
- update README version and document Integral support
- bump version to 1.6.4 across docs and constants
- note new feature in CHANGELOG

## Testing
- `python -m py_compile scripts/model_coder.py copernican.py`
- `python - <<'EOF'
from scripts import model_coder
import sympy as sp
z=sp.symbols('z'); H0=sp.symbols('H0')
expr=sp.Integral(z,(z,0,1))+H0
fn=model_coder._compile_sympy_expr(expr,(z,H0))
print(fn(0,70))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6859a8c1c564832f937a78d10c0284d7