### PR TITLE
Implement Planck2018 lite parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Example:
 ## Version 1.6.3 (Patch Release)
 - 2025-06-22: Restored `pyproject.toml` and silenced Pandas whitespace warning (AI assistant)
 - 2025-06-22: Declared Python 3.13.1+ requirement in pyproject and README (AI assistant)
+- 2025-07-05: Implemented Planck 2018 lite CMB parser (AI assistant)
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)

--- a/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
+++ b/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
@@ -1,10 +1,53 @@
+"""Planck 2018 lite CMB parser."""
+
 import os
 import logging
+import numpy as np
+import pandas as pd
+
 from scripts.data_loaders import register_cmb_parser
 
-@register_cmb_parser("cmb_placeholder_v1", "Placeholder CMB parser.", data_dir=os.path.dirname(__file__))
-def parse_cmb_placeholder(data_dir, **kwargs):
-    """Stub parser that logs a message and returns None."""
+
+@register_cmb_parser(
+    "planck2018lite_v1",
+    "Planck 2018 lite TT spectrum.",
+    data_dir=os.path.dirname(__file__),
+)
+def parse_planck2018lite(data_dir, **kwargs):
+    """Parse Planck 2018 lite power spectrum and covariance."""
+
     logger = logging.getLogger()
-    logger.info(f"CMB parser placeholder invoked in {data_dir}. Feature not implemented.")
-    return None
+    cl_path = os.path.join(data_dir, "cl_cmb_plik_v22.dat")
+    cov_path = os.path.join(data_dir, "c_matrix_plik_v22.dat")
+
+    try:
+        df = pd.read_csv(
+            cl_path,
+            sep=r"\s+",
+            header=None,
+            usecols=[0, 1],
+            names=["ell", "Dl_obs"],
+        )
+        n = len(df)
+        cov_arr = np.fromfile(
+            cov_path, dtype=np.float64, offset=4, count=n * n
+        )
+        if cov_arr.size != n * n:
+            logger.error(
+                f"Covariance matrix size mismatch: expected {n*n} values, got {cov_arr.size}"
+            )
+            return None
+        cov_matrix = cov_arr.reshape(n, n)
+        try:
+            cov_inv = np.linalg.inv(cov_matrix)
+        except np.linalg.LinAlgError:
+            logger.error("Planck2018lite covariance matrix is singular.")
+            return None
+
+        df.attrs["covariance_matrix_inv"] = cov_inv
+        df.attrs["dataset_name_attr"] = "CMB_Planck2018lite"
+        df.attrs["is_cmb"] = True
+        return df
+    except Exception as e:
+        logger.error(f"Error parsing Planck2018lite data: {e}", exc_info=True)
+        return None


### PR DESCRIPTION
## Summary
- implement Planck 2018 lite CMB parser
- register parser under unique key `planck2018lite_v1`
- load spectrum and covariance matrix and return DataFrame
- document the addition in CHANGELOG

## Testing
- `python -m py_compile data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py`
- `python - <<'PY'
from scripts.data_loaders import CMB_PARSERS
func = CMB_PARSERS['planck2018lite_v1']['function']
df = func(CMB_PARSERS['planck2018lite_v1']['data_dir'])
print(len(df), df.attrs['covariance_matrix_inv'].shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6868799b7b68832f8ac83c2d992fa58f