### PR TITLE
Add CMB plugin flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,13 @@ automatically; no manual Python implementation is required.
 The parser keeps unknown keys intact, ensuring the DSL stays backward
 compatible as new fields are introduced.
 
+### 4.2 Dataset compatibility flags
+
+Generated model plugins include boolean attributes `valid_for_distance_metrics`,
+`valid_for_bao` and `valid_for_cmb`. All default to `True` and signal which
+datasets the model supports. When `valid_for_cmb` is `False` the engine does not
+require the optional `compute_cmb_spectrum` function during validation.
+
 ## 6. Development Protocol
 To keep the project maintainable all contributors, human or AI, must follow these rules:
 1. **Summarize every change in `CHANGELOG.md`.** Use the template `- YYYY-MM-DD: short summary (author)` for each entry. Legacy `dev_note` headers should be migrated to the changelog when touched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Example:
 - 2025-06-22: Restored `pyproject.toml` and silenced Pandas whitespace warning (AI assistant)
 - 2025-06-22: Declared Python 3.13.1+ requirement in pyproject and README (AI assistant)
 - 2025-07-05: Implemented Planck 2018 lite CMB parser (AI assistant)
+- 2025-07-05: Added `valid_for_cmb` flag and updated plugin validation (AI assistant)
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)

--- a/scripts/engine_interface.py
+++ b/scripts/engine_interface.py
@@ -13,6 +13,7 @@ REQUIRED_FUNCTIONS = [
     "get_Hz_per_Mpc",
     "get_DV_Mpc",
     "get_sound_horizon_rs_Mpc",
+    "compute_cmb_spectrum",
 ]
 
 REQUIRED_ATTRIBUTES = [
@@ -42,6 +43,7 @@ def build_plugin(model_data, func_dict):
     plugin.FIXED_PARAMS = {}
     plugin.valid_for_distance_metrics = model_data.get('valid_for_distance_metrics', True)
     plugin.valid_for_bao = model_data.get('valid_for_bao', True)
+    plugin.valid_for_cmb = model_data.get('valid_for_cmb', True)
     def sanitize_equation(eq_line: str) -> str:
         """Return a Matplotlib-friendly LaTeX string."""
         if not isinstance(eq_line, str):
@@ -71,7 +73,7 @@ def validate_plugin(plugin):
         logger.error(f"Plugin validation failed. Missing attributes: {missing_attrs}")
         return False
 
-    required_funcs = REQUIRED_FUNCTIONS
+    required_funcs = list(REQUIRED_FUNCTIONS)
     if getattr(plugin, 'valid_for_distance_metrics', True) is False:
         required_funcs = ['distance_modulus_model']
     elif getattr(plugin, 'valid_for_bao', True) is False:
@@ -83,6 +85,8 @@ def validate_plugin(plugin):
             'get_Hz_per_Mpc',
             'get_DV_Mpc',
         ]
+    if getattr(plugin, 'valid_for_cmb', True) is False and 'compute_cmb_spectrum' in required_funcs:
+        required_funcs.remove('compute_cmb_spectrum')
 
     for fname in required_funcs:
         func = getattr(plugin, fname, None)


### PR DESCRIPTION
## Summary
- extend `build_plugin` with `valid_for_cmb`
- enforce `compute_cmb_spectrum` in plugin validation when applicable
- document new flag
- note change in CHANGELOG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68687b044670832f9af157a7fc6d4e3c