### PR TITLE
Enable basic CMB chi² evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Example:
 - 2025-06-22: Declared Python 3.13.1+ requirement in pyproject and README (AI assistant)
 - 2025-07-05: Implemented Planck 2018 lite CMB parser (AI assistant)
 - 2025-07-05: Added `valid_for_cmb` flag and updated plugin validation (AI assistant)
+- 2025-07-05: Added CAMB-based CMB analysis and chi-squared routines (AI assistant)
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)

--- a/README.md
+++ b/README.md
@@ -62,10 +62,9 @@ Under the hood the program follows a clear pipeline:
 
 ## Dependencies
 This project requires **Python 3.13.1 or later** and relies on `numpy`, `scipy`, `matplotlib`,
-`pandas`, `sympy` and `jsonschema`. If any of these are missing the dependency check
-will print the full installation command `pip install numpy scipy matplotlib
-pandas sympy jsonschema`. Future engines may also depend on `numba` or
-GPU libraries.
+`pandas`, `sympy`, `jsonschema` and `camb`. If any of these are missing the dependency check
+will print the full installation command `pip install numpy scipy matplotlib pandas sympy jsonschema camb`.
+Future engines may also depend on `numba` or GPU libraries.
  
 ## Building & Installation
 Run `pip install .` from the repository root to build and install the `copernican` command. Use `pip install -e .` for editable installs.
@@ -77,6 +76,7 @@ models/           - JSON model definitions containing all theory text and
                     summaries but are not required.
 engines/          - Computational backends (SciPy CPU and Numba with automatic fallback)
 data/             - Observation data organized as ``data/<type>/<source>/``
+  cmb/planck2018lite/ - Planck 2018 lite TT power spectrum parser and files
 output/           - All generated results
 AGENTS.md         - Development specification and contributor rules
 CHANGELOG.md      - Release history
@@ -92,9 +92,9 @@ should not be modified by AI-driven code changes.
 
 ## Using the Suite
 - The program discovers available models from `models/cosmo_model_*.json`.
-- Data sources for SNe and BAO are chosen interactively. Once a source is
-  selected, its parser and files are loaded automatically from
-  `data/<type>/<source>/`. Future datasets will follow the same structure.
+ - Data sources for SNe, BAO and CMB are chosen interactively. Once a source is
+   selected, its parser and files are loaded automatically from
+   `data/<type>/<source>/`. Future datasets will follow the same structure.
 - Engines are selected interactively from the `engines/` directory. Parsers are
   discovered automatically when their source folders are imported.
 - After each run you may choose to evaluate another model or exit. Cache files


### PR DESCRIPTION
## Summary
- implement CAMB-based CMB power spectrum calculation
- compute χ² for CMB data using covariance matrix
- integrate CMB analysis into main workflow
- document Planck2018 data folder and new `camb` dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68687c1252e4832fad9064b7e14d3df4