### PR TITLE
Add CMB parameter map metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,9 @@ Generated model plugins include boolean attributes `valid_for_distance_metrics`,
 `valid_for_bao` and `valid_for_cmb`. All default to `True` and signal which
 datasets the model supports. When `valid_for_cmb` is `False` the engine does not
 require the optional `compute_cmb_spectrum` function during validation.
+Models that can compute a CMB power spectrum should also define a `cmb.param_map`
+object describing how standard CAMB parameters such as `H0` and `ombh2` are
+derived from the model's variables or constants.
 
 ## 6. Development Protocol
 To keep the project maintainable all contributors, human or AI, must follow these rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Example:
 - 2025-07-05: Implemented Planck 2018 lite CMB parser (AI assistant)
 - 2025-07-05: Added `valid_for_cmb` flag and updated plugin validation (AI assistant)
 - 2025-07-05: Added CAMB-based CMB analysis and chi-squared routines (AI assistant)
+- 2025-07-05: Added cmb.param_map metadata to models and documentation (AI assistant)
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,17 @@ The schema requires `model_name`, `version`, `parameters`, `equations`, `abstrac
   "equations": {
     "distance_modulus_model": "5*sympy.log(1+z,10)*H0"
   },
-  "cmb": {},
+  "valid_for_cmb": true,
+  "cmb": {
+    "param_map": {
+      "H0": "H0",
+      "ombh2": "Ob * (H0/100)**2",
+      "omch2": "(Om - Ob) * (H0/100)**2",
+      "tau": 0.054,
+      "As": 2.1e-9,
+      "ns": 0.965
+    }
+  },
   "gravitational_waves": {},
   "standard_sirens": {},
   "abstract": "short overview text",

--- a/cosmo_model_guide.json
+++ b/cosmo_model_guide.json
@@ -2,7 +2,7 @@
   "guide_title": "Copernican Suite cosmo_model_*.json Definition Guide",
   "guide_version": "1.0",
   "overview": "This guide explains how to write valid cosmo_model JSON files for the Copernican Suite.  Each cosmo_model_*.json defines a cosmological model by declaring metadata, parameters, H(z) and r_s expressions, and display equations for SNe Ia and BAO.",
-  "requirements": "Every cosmo_model JSON must include these top-level keys: model_name (string), version (string), description (string), abstract (string), parameters (array), equations (object).  If you supply r_s, include rs_expression (string) and set predicts_bao to true.",
+  "requirements": "Every cosmo_model JSON must include these top-level keys: model_name (string), version (string), description (string), abstract (string), parameters (array), equations (object). If you supply r_s, include rs_expression (string) and set predicts_bao to true. Add a cmb.param_map object to translate variables into CAMB parameters, or set valid_for_cmb to false if unsupported.",
   "parameter_definition": "The parameters array contains objects with these fields: name (human-readable string), python_var (valid Python identifier), bounds ([min, max]), and optional unit (string) and latex_name (string).  All symbols used in Hz_expression and rs_expression must be declared here.  To define a fixed constant (e.g. c), give identical bounds.",
   "expressions": {
     "Hz_expression": "A Python-syntax string for H(z), referencing only declared parameters and the variable z.  Use numeric operations and functions exp(), cos(), log(), sqrt().  Do not use Python lists or comments.",
@@ -59,6 +59,17 @@
       ]
     },
     "rs_expression": "rs0*(1 + B*z_recomb*exp(-gamma*z_recomb))",
-    "predicts_bao": true
+    "predicts_bao": true,
+    "valid_for_cmb": true,
+    "cmb": {
+      "param_map": {
+        "H0": "H0",
+        "ombh2": "Ob * (H0/100)**2",
+        "omch2": "(Omega_m0 - Ob) * (H0/100)**2",
+        "tau": 0.054,
+        "As": 2.1e-9,
+        "ns": 0.965
+      }
+    }
   }
 }

--- a/models/cosmo_model_cfsc.json
+++ b/models/cosmo_model_cfsc.json
@@ -36,5 +36,6 @@
     ]
   },
   "rs_expression": "rs0*(1 + B*z_recomb*exp(-gamma*z_recomb) + C*log(1+z_recomb))",
-  "predicts_bao": true
+  "predicts_bao": true,
+  "valid_for_cmb": false
 }

--- a/models/cosmo_model_lcdm.json
+++ b/models/cosmo_model_lcdm.json
@@ -68,6 +68,17 @@
   },
   "rs_expression": "44.5*sympy.log(9.83/(Omega_m0*(H0/100)**2))/sympy.sqrt(1 + 10*(Omega_b0*(H0/100)**2)**0.75)",
   "predicts_bao": true,
+  "valid_for_cmb": true,
+  "cmb": {
+    "param_map": {
+      "H0": "H0",
+      "ombh2": "Omega_b0 * (H0/100)**2",
+      "omch2": "(Omega_m0 - Omega_b0) * (H0/100)**2",
+      "tau": 0.054,
+      "As": 2.1e-9,
+      "ns": 0.965
+    }
+  },
   "notes": "Additional notes available."
 }
 

--- a/models/cosmo_model_pfsc.json
+++ b/models/cosmo_model_pfsc.json
@@ -28,5 +28,6 @@
     ]
   },
   "rs_expression": "rs0*(1 + B*z_recomb*exp(-Gamma*z_recomb))",
-  "predicts_bao": true
+  "predicts_bao": true,
+  "valid_for_cmb": false
 }

--- a/models/cosmo_model_qauc.json
+++ b/models/cosmo_model_qauc.json
@@ -95,5 +95,16 @@
   },
   "rs_expression": "rs",
   "predicts_bao": true,
+  "valid_for_cmb": true,
+  "cmb": {
+    "param_map": {
+      "H0": "H0",
+      "ombh2": "Omega_b0 * (H0/100)**2",
+      "omch2": "(Omega_m0 - Omega_b0) * (H0/100)**2",
+      "tau": 0.054,
+      "As": 2.1e-9,
+      "ns": 0.965
+    }
+  },
   "abstract": "A scalar-tensor model with an exponential attractor envelope and oscillatory modulation in the dark-energy sector, designed to fit both SNe Ia and BAO while opening a portal to quantum topological couplings."
 }

--- a/models/cosmo_model_smf.json
+++ b/models/cosmo_model_smf.json
@@ -67,5 +67,6 @@
     ]
   },
   "rs_expression": "rs",
-  "predicts_bao": true
+  "predicts_bao": true,
+  "valid_for_cmb": false
 }

--- a/models/cosmo_model_smf2.json
+++ b/models/cosmo_model_smf2.json
@@ -33,5 +33,6 @@
     ]
   },
   "rs_expression": "rs0*(1 + B*z_recomb*exp(-gamma*z_recomb))",
-  "predicts_bao": true
+  "predicts_bao": true,
+  "valid_for_cmb": false
 }

--- a/models/cosmo_model_usmf2.json
+++ b/models/cosmo_model_usmf2.json
@@ -136,5 +136,6 @@
   "notes": "Detailed theory embedded in this JSON.",
   "title": "The Unified Shrinking Matter Framework (USMF) Version 2",
   "date": "2025-05-26",
-  "example_results": "-   **Dataset:** UniStra_FixedNuis_h1\n-   **Best-fit $\\chi^2$:** 1662.54"
+  "example_results": "-   **Dataset:** UniStra_FixedNuis_h1\n-   **Best-fit $\\chi^2$:** 1662.54",
+  "valid_for_cmb": false
 }


### PR DESCRIPTION
## Summary
- document `cmb.param_map` in AGENTS and the model guide
- show CAMB parameter map example in README
- mark which models can compute a CMB spectrum and supply mappings
- document the update in CHANGELOG

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686882b41f1c832fa49e31c1e19c9e77