### PR TITLE
Add CAMB param names to Planck 2018 parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Example:
 - 2025-07-05: Added `valid_for_cmb` flag and updated plugin validation (AI assistant)
 - 2025-07-05: Added CAMB-based CMB analysis and chi-squared routines (AI assistant)
 - 2025-07-05: Added cmb.param_map metadata to models and documentation (AI assistant)
+- 2025-07-05: Stored CAMB parameter order in Planck 2018 parser (AI assistant)
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)

--- a/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
+++ b/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
@@ -47,6 +47,15 @@ def parse_planck2018lite(data_dir, **kwargs):
         df.attrs["covariance_matrix_inv"] = cov_inv
         df.attrs["dataset_name_attr"] = "CMB_Planck2018lite"
         df.attrs["is_cmb"] = True
+        # Map the order of CAMB parameters used by the engine
+        df.attrs["param_names"] = [
+            "H0",
+            "ombh2",
+            "omch2",
+            "tau",
+            "As",
+            "ns",
+        ]
         return df
     except Exception as e:
         logger.error(f"Error parsing Planck2018lite data: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- store CAMB parameter names in the Planck 2018 parser
- update changelog

## Testing
- `python -m py_compile data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_686887824c7c832fa8a61c87e4618e4c