### PR TITLE
Add CAMB parameter mapping helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Example:
 - 2025-07-05: Added CAMB-based CMB analysis and chi-squared routines (AI assistant)
 - 2025-07-05: Added cmb.param_map metadata to models and documentation (AI assistant)
 - 2025-07-05: Stored CAMB parameter order in Planck 2018 parser (AI assistant)
+- 2025-07-05: Added automatic CMB wrapper and parameter mapping helper (AI assistant)
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ The schema requires `model_name`, `version`, `parameters`, `equations`, `abstrac
 }
 ```
 Initial guesses are derived automatically from each parameter's bounds.
+When a `cmb.param_map` object is provided, the mapping is stored on the plugin
+as `CMB_PARAM_MAP`. Call `plugin.get_camb_params(values)` to convert a list of
+cosmological parameters into a dictionary for CAMB. Models without a custom
+`compute_cmb_spectrum` automatically use this mapping with the default engine.
 `model_parser.py` accepts unknown keys and simply copies them to the sanitized
 cache. This allows the domain-specific JSON language to evolve while remaining
 compatible with older models.


### PR DESCRIPTION
## Summary
- expand plugin building to load `cmb.param_map`
- create `get_camb_params` helper for CAMB
- auto-wrap missing CMB spectra function
- tweak plugin validation for default wrapper
- document new helper in README
- log change in changelog

## Testing
- `python -m py_compile scripts/engine_interface.py`

------
https://chatgpt.com/codex/tasks/task_e_6868885ffb60832fa2ed10405f9647f4