### PR TITLE
Fix CMB parameter mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Example:
 - 2025-07-05: Added cmb.param_map metadata to models and documentation (AI assistant)
 - 2025-07-05: Stored CAMB parameter order in Planck 2018 parser (AI assistant)
 - 2025-07-05: Added automatic CMB wrapper and parameter mapping helper (AI assistant)
+- 2025-07-05: run_cmb_analysis now converts fitted parameters with get_camb_params (AI assistant)
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)

--- a/copernican.py
+++ b/copernican.py
@@ -353,8 +353,15 @@ def main_workflow():
             """Run CMB analysis for a given model."""
             if cmb_df is None or cmb_df.empty:
                 return {'chi2_cmb': np.inf, 'theory_spectrum': None}
-            theory = cosmo_engine_selected.compute_cmb_spectrum(cosmo_params, cmb_df['ell'].values)
-            chi2_val = cosmo_engine_selected.chi_squared_cmb(cosmo_params, cmb_df)
+
+            # Convert the fitted cosmological parameters to CAMB's expected
+            # dictionary format using the helper provided by the model plugin.
+            camb_params = model_plugin.get_camb_params(cosmo_params)
+
+            theory = cosmo_engine_selected.compute_cmb_spectrum(
+                camb_params, cmb_df['ell'].values
+            )
+            chi2_val = cosmo_engine_selected.chi_squared_cmb(camb_params, cmb_df)
             logger.info(f"{model_plugin.MODEL_NAME} CMB chi2 = {chi2_val:.2f}")
             return {'chi2_cmb': chi2_val, 'theory_spectrum': theory}
 


### PR DESCRIPTION
## Summary
- map fitted cosmological parameters to CAMB format in `run_cmb_analysis`
- log this update in the changelog

## Testing
- `python -m py_compile copernican.py`
- `python -m py_compile engines/cosmo_engine_1_4b.py scripts/engine_interface.py`

------
https://chatgpt.com/codex/tasks/task_e_68688aaa7258832fbe577b4b4d7cd91e