### PR TITLE
Skip CMB when unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Example:
 - 2025-07-05: Stored CAMB parameter order in Planck 2018 parser (AI assistant)
 - 2025-07-05: Added automatic CMB wrapper and parameter mapping helper (AI assistant)
 - 2025-07-05: run_cmb_analysis now converts fitted parameters with get_camb_params (AI assistant)
+- 2025-07-05: Skip CMB evaluation when model sets valid_for_cmb=false (AI assistant)
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)
@@ -114,3 +115,4 @@ Example:
 - Removed GPU code for stability.
 - Implemented robust multiprocessing using `psutil`.
 - Added test mode and cache cleanup loop.
+

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ When a `cmb.param_map` object is provided, the mapping is stored on the plugin
 as `CMB_PARAM_MAP`. Call `plugin.get_camb_params(values)` to convert a list of
 cosmological parameters into a dictionary for CAMB. Models without a custom
 `compute_cmb_spectrum` automatically use this mapping with the default engine.
+When `valid_for_cmb` is `false` the suite logs a message and skips the CMB
+evaluation stage for that model.
 `model_parser.py` accepts unknown keys and simply copies them to the sanitized
 cache. This allows the domain-specific JSON language to evolve while remaining
 compatible with older models.

--- a/copernican.py
+++ b/copernican.py
@@ -351,6 +351,16 @@ def main_workflow():
 
         def run_cmb_analysis(cmb_df, model_plugin, cosmo_params):
             """Run CMB analysis for a given model."""
+            # Skip the CMB step entirely when the model declares it is invalid
+            # for such data. This prevents misleading chi-squared calculations
+            # and ensures plugin validation does not fail for missing CMB
+            # functions.
+            if getattr(model_plugin, 'valid_for_cmb', True) is False:
+                logger.info(
+                    f"{model_plugin.MODEL_NAME} does not support CMB; skipping analysis."
+                )
+                return {'chi2_cmb': np.inf, 'theory_spectrum': None}
+
             if cmb_df is None or cmb_df.empty:
                 return {'chi2_cmb': np.inf, 'theory_spectrum': None}
 


### PR DESCRIPTION
## Summary
- skip CMB evaluation if a model has `valid_for_cmb` set to `false`
- document this behaviour in README
- note the change in CHANGELOG

## Testing
- `python -m py_compile copernican.py scripts/*.py engines/*.py`
- `python - <<'PY'
from scripts import model_parser, model_coder, engine_interface
cache=model_parser.parse_model_json('models/cosmo_model_cfsc.json','models/cache')
funcs, parsed=model_coder.generate_callables(cache)
plugin=engine_interface.build_plugin(parsed, funcs)
print('valid_for_cmb', plugin.valid_for_cmb)
print('validation:', engine_interface.validate_plugin(plugin))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68688ba83868832f81727e94e97aba27