### PR TITLE
Add CMB plotting and CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Example:
 - 2025-07-05: Added automatic CMB wrapper and parameter mapping helper (AI assistant)
 - 2025-07-05: run_cmb_analysis now converts fitted parameters with get_camb_params (AI assistant)
 - 2025-07-05: Skip CMB evaluation when model sets valid_for_cmb=false (AI assistant)
+- 2025-07-05: Implemented CMB spectrum plotting (AI assistant)
+- 2025-07-05: Added CMB residual CSV export (AI assistant)
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)

--- a/copernican.py
+++ b/copernican.py
@@ -402,6 +402,17 @@ def main_workflow():
                 sne_data_df,
                 plot_dir=OUTPUT_DIR,
             )
+        if cmb_data_df is not None:
+            plotter.plot_cmb_spectrum(
+                cmb_data_df,
+                lcdm_cmb,
+                alt_cmb,
+                lcdm_sne_fit_results,
+                alt_model_sne_fit_results,
+                lcdm,
+                alt_model_plugin,
+                plot_dir=OUTPUT_DIR,
+            )
         
         # The call to the redundant summary CSV has been removed.
         # csv_writer.save_sne_fit_results_csv(...)
@@ -421,6 +432,14 @@ def main_workflow():
                 bao_data_df,
                 lcdm_full_results,
                 alt_model_full_results,
+                alt_model_name=alt_model_plugin.MODEL_NAME,
+                csv_dir=OUTPUT_DIR,
+            )
+        if cmb_data_df is not None:
+            csv_writer.save_cmb_results_csv(
+                cmb_data_df,
+                lcdm_cmb,
+                alt_cmb,
                 alt_model_name=alt_model_plugin.MODEL_NAME,
                 csv_dir=OUTPUT_DIR,
             )


### PR DESCRIPTION
## Summary
- plot CMB TT spectrum with theory curves and residuals
- export detailed CMB spectrum CSV
- integrate new plotting and CSV steps into main workflow
- document new features in CHANGELOG

## Testing
- `python -m py_compile scripts/plotter.py scripts/csv_writer.py copernican.py`

------
https://chatgpt.com/codex/tasks/task_e_68688d004704832fa36ed3a2f4354a10