### PR TITLE
Document cmb.param_map usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Example:
 - 2025-07-05: Skip CMB evaluation when model sets valid_for_cmb=false (AI assistant)
 - 2025-07-05: Implemented CMB spectrum plotting (AI assistant)
 - 2025-07-05: Added CMB residual CSV export (AI assistant)
+- 2025-07-05: Documented cmb.param_map usage and parser param_names attribute (AI assistant)
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 ## Version 1.6.1 (Patch Release)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ cosmological parameters into a dictionary for CAMB. Models without a custom
 `compute_cmb_spectrum` automatically use this mapping with the default engine.
 When `valid_for_cmb` is `false` the suite logs a message and skips the CMB
 evaluation stage for that model.
+CMB data parsers attach a `param_names` attribute to the returned DataFrame
+listing the CAMB parameter order. The engine combines this list with
+`get_camb_params` to evaluate the power spectrum and chi-squared.
 `model_parser.py` accepts unknown keys and simply copies them to the sanitized
 cache. This allows the domain-specific JSON language to evolve while remaining
 compatible with older models.


### PR DESCRIPTION
## Summary
- document cmb.param_map mapping, DataFrame param_names attribute and usage
- summarize cmb evaluation support in the changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68688e899230832fbede620cc74e31b6