### PR TITLE
Fix CMB spectrum units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Example:
 - 2025-07-05: Bumped version to 1.7.0 and reorganized changelog (AI assistant)
 - 2025-07-05: Removed obsolete CMB placeholder parser and dataset (AI assistant)
 - 2025-07-05: Added CAMB dependency to pyproject and updated docs (AI assistant)
+- 2025-07-05: Corrected CMB spectrum units and Planck parser to use D_l (AI assistant)
 
 ## Version 1.6.3 (Patch Release)
 - 2025-06-22: Restored `pyproject.toml` and silenced Pandas whitespace warning (AI assistant)

--- a/engines/cosmo_engine_1_4b.py
+++ b/engines/cosmo_engine_1_4b.py
@@ -237,10 +237,14 @@ def compute_cmb_spectrum(param_dict, ells):
     params.set_for_lmax(int(np.max(ells)) + 300, lens_potential_accuracy=0)
     try:
         results = camb.get_results(params)
-        powers = results.get_cmb_power_spectra(params, lmax=int(np.max(ells)))
-        cl_tt = powers['total'][:, 0]
+        powers = results.get_cmb_power_spectra(
+            params, lmax=int(np.max(ells)), CMB_unit="muK"
+        )
+        cl_tt = powers["total"][:, 0]
         ell_arr = np.asarray(ells, dtype=int)
-        dl = ell_arr * (ell_arr + 1) * cl_tt[ell_arr] / (2 * np.pi)
+        # CAMB already returns D_ell = ell(ell+1) C_ell / (2pi) when raw_cl=False
+        # (the default). Simply index the array without applying the factor again.
+        dl = cl_tt[ell_arr]
         return dl
     except Exception as exc:
         logger.error(f"(compute_cmb_spectrum): CAMB failed: {exc}")


### PR DESCRIPTION
## Summary
- correct CAMB call to output D_ℓ in µK²
- convert Planck 2018 lite C_ℓ to D_ℓ and scale covariance
- document change in CHANGELOG

## Testing
- `python -m pip check`
- `python copernican.py <<'EOF'
8
1
1
1
1
no
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6868e2ae07b8832f9c16c98d18044118