### PR TITLE
Bump docs to 1.7.1-beta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.7.0-beta**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.7.1-beta**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Add one line for each substantive commit or pull request directly under the late
 
 Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
-## Version 1.7.0-beta (Development Release)
+## Version 1.7.1-beta (Development Release)
+- 2025-07-05: Updated version references to 1.7.1-beta (AI assistant)
 - 2025-07-05: Implemented Planck 2018 lite CMB parser (AI assistant)
 - 2025-07-05: Added `valid_for_cmb` flag and updated plugin validation (AI assistant)
 - 2025-07-05: Added CAMB-based CMB analysis and chi-squared routines (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.7.0-beta
+**Version:** 1.7.1-beta
 **Last Updated:** 2025-07-05
 
 The Copernican Suite is a Python toolkit for testing cosmological models against


### PR DESCRIPTION
## Summary
- update version in README, AGENTS and CHANGELOG to 1.7.1-beta
- log the version bump in CHANGELOG

## Testing
- `python3 -m py_compile copernican.py`
- `python3 -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6868e43bded0832f9cfd17929b54efce