### PR TITLE
Fix Planck parser binary fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Example:
 ## Version 1.7.2-beta (Development Release)
 - 2025-07-05: Fixed Planck covariance parser using np.loadtxt (AI assistant)
 - 2025-07-05: Added default CAMB parameter mapping from SNe fits (AI assistant)
+- 2025-07-05: Handled binary Planck covariance matrix fallback (AI assistant)
 ## Version 1.7.1-beta (Development Release)
 - 2025-07-05: Updated version references to 1.7.1-beta (AI assistant)
 - 2025-07-05: Implemented Planck 2018 lite CMB parser (AI assistant)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ models/           - JSON model definitions containing all theory text and
 engines/          - Computational backends (SciPy CPU and Numba with automatic fallback)
 data/             - Observation data organized as ``data/<type>/<source>/``
   cmb/planck2018lite/ - Planck 2018 lite TT power spectrum parser and files
+                         (covariance matrix may be binary Fortran or ASCII)
 output/           - All generated results
 AGENTS.md         - Development specification and contributor rules
 CHANGELOG.md      - Release history

--- a/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
+++ b/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
@@ -33,14 +33,23 @@ def parse_planck2018lite(data_dir, **kwargs):
         df["Dl_obs"] = ell_arr * (ell_arr + 1) * df["Cl_obs"] / (2 * np.pi)
         n = len(df)
 
-        # The covariance file is distributed as plain ASCII. ``np.fromfile`` was
-        # previously used but mis-interpreted the binary layout, leading to a
-        # malformed array. ``np.loadtxt`` correctly reads the text data even when
-        # an extra header row is present.
-        cov_arr = np.loadtxt(cov_path)
-        if cov_arr.size != n * n:
-            # Some releases prepend a single header line; try again skipping it
-            cov_arr = np.loadtxt(cov_path, skiprows=1)
+        # Newer releases ship the covariance matrix as a Fortran binary
+        # record while older versions provide plain ASCII. Attempt to load
+        # the text format first; if that fails, fall back to reading the
+        # binary record and stripping the 4-byte header/footer used by
+        # Fortran unformatted writes.
+        try:
+            cov_arr = np.loadtxt(cov_path)
+            if cov_arr.size != n * n:
+                # Some text releases prepend a header row; skip it and retry
+                cov_arr = np.loadtxt(cov_path, skiprows=1)
+            if cov_arr.size != n * n:
+                raise ValueError("size mismatch")
+        except Exception:
+            with open(cov_path, "rb") as fh:
+                # Skip the leading 4-byte record marker used by Fortran
+                fh.seek(4)
+                cov_arr = np.fromfile(fh, dtype="<f8")
         if cov_arr.size != n * n:
             logger.error(
                 f"Covariance matrix size mismatch: expected {n*n} values, got {cov_arr.size}"


### PR DESCRIPTION
## Summary
- handle Planck covariance matrix distributed as binary Fortran record
- document binary format handling
- note parser update in changelog

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 - <<'EOF'
from data.cmb.planck2018lite.cosmo_parser_cmb_planck2018lite import parse_planck2018lite
import logging
logging.basicConfig(level=logging.INFO)
df=parse_planck2018lite('data/cmb/planck2018lite')
print('df shape', df.shape)
print('cov shape', df.attrs['covariance_matrix_inv'].shape)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686906bd61e0832f93c74c73a8a7d0b9