### PR TITLE
Fix binary Planck covariance reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
 ## Version 1.7.3-beta (Development Release)
 - 2025-07-05: Fixed Planck covariance reader for ASCII data and ensured CMB parameters use SNe best-fit values (AI assistant)
+- 2025-07-05: Corrected Planck covariance parsing for binary Fortran record (AI assistant)
 ## Version 1.7.2-beta (Development Release)
 - 2025-07-05: Fixed Planck covariance parser using np.loadtxt (AI assistant)
 - 2025-07-05: Added default CAMB parameter mapping from SNe fits (AI assistant)


### PR DESCRIPTION
## Summary
- correctly read Planck covariance matrix stored as Fortran binary record
- document change in CHANGELOG

## Testing
- `pip install -e .` *(fails: Package 'copernican-suite' requires a different Python: 3.11.12 not in '>=3.13.1')*

------
https://chatgpt.com/codex/tasks/task_e_68690f598da4832f92b2c4a694e2befa