### PR TITLE
Restore Integral evaluation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Example:
 ## Version 1.7.3-beta (Development Release)
 - 2025-07-05: Fixed Planck covariance reader for ASCII data and ensured CMB parameters use SNe best-fit values (AI assistant)
 - 2025-07-05: Corrected Planck covariance parsing for binary Fortran record (AI assistant)
+- 2025-07-05: Re-added integral expression support using numerical quadrature (AI assistant)
 ## Version 1.7.2-beta (Development Release)
 - 2025-07-05: Fixed Planck covariance parser using np.loadtxt (AI assistant)
 - 2025-07-05: Added default CAMB parameter mapping from SNe fits (AI assistant)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ See `cosmo_model_guide.json` for a detailed template.
 4. Optionally provide an `rs_expression` for the sound horizon at recombination
    or include the parameters `Ob`, `Og` and `z_recomb`. The suite will then
    derive `r_s` automatically using a numerical integral.
-5. Parameter initial guesses are calculated automatically as the midpoint of
+5. Expressions may include `Integral(...)` terms. These are evaluated
+   numerically with SciPy's `quad` when the model is loaded.
+6. Parameter initial guesses are calculated automatically as the midpoint of
    each parameter's bounds.
 The suite validates the JSON, stores a sanitized copy under `models/cache/`, and
 auto-generates the necessary Python functions.


### PR DESCRIPTION
## Summary
- reintroduce QuadPrinter and `_compile_sympy_expr`
- compile Hz, r_s, and general equations with integral support
- document Integrals in model instructions
- note integration support in the changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68691532baac832fb7ce3420da7b1591