### PR TITLE
Remove test mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Add one line for each substantive commit or pull request directly under the late
 
 Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
+## Version 1.7.5-beta (Development Release)
+- YYYY-MM-DD: Removed test mode from model selection workflow (AI assistant)
 ## Version 1.7.4-beta (Development Release)
 - 2025-07-05: Fixed unit conversion (K\u00b2 \u2192 \u03bcK\u00b2) by applying a 1e12 scale factor (AI assistant)
 - 2025-07-05: Added neutrino density mapping (`omnuh2`) to the \u039bCDM parameter map (AI assistant)

--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ altering `MAJOR.MINOR`.
     instructs you to run a `pip install` command if any are absent.
 2.  **Initialization**: The script starts and creates the `./output/` directory for all results.
 3.  **Configuration**: The user specifies the file paths for the model and data files.
-    -   **Test Mode**: A user can enter `test` to run ΛCDM against itself, providing a quick way to test the full analysis pipeline.
 4.  **SNe Ia Fitting**: The `cosmo_engine` fits the parameters of both the ΛCDM model and the alternative model to the SNe Ia data.
 5.  **BAO Analysis**: Using the best-fit parameters, the engine calculates BAO observables for each model.
 6.  **Output Generation**: `plotter`, `csv_writer` and `logger` save plots, tables and logs using a consistent format.


### PR DESCRIPTION
## Summary
- drop special keyword support in `get_user_input_filepath`
- remove test mode option from model selection
- always load selected model instead of branching on `'test'`
- delete workflow note about test mode
- log the removal in the 1.7.5-beta changelog section

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68694b520758832fb126fccd11c24ddb