### PR TITLE
Add startup functional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Example:
 ## Version 1.7.5-beta (Development Release)
 - 2025-07-05: Removed test mode from model selection workflow (AI assistant)
 - 2025-07-05: Updated BAO summary header to "BAO Fit Results" (AI assistant)
+- 2025-07-05: Added functional tests and automatic startup test runner (AI assistant)
 ## Version 1.7.4-beta (Development Release)
 - 2025-07-05: Fixed unit conversion (K\u00b2 \u2192 \u03bcK\u00b2) by applying a 1e12 scale factor (AI assistant)
 - 2025-07-05: Added neutrino density mapping (`omnuh2`) to the \u039bCDM parameter map (AI assistant)

--- a/README.md
+++ b/README.md
@@ -224,12 +224,14 @@ altering `MAJOR.MINOR`.
 
 1.  **Dependency Check**: `copernican.py` scans for missing packages and
     instructs you to run a `pip install` command if any are absent.
-2.  **Initialization**: The script starts and creates the `./output/` directory for all results.
-3.  **Configuration**: The user specifies the file paths for the model and data files.
-4.  **SNe Ia Fitting**: The `cosmo_engine` fits the parameters of both the ΛCDM model and the alternative model to the SNe Ia data.
-5.  **BAO Analysis**: Using the best-fit parameters, the engine calculates BAO observables for each model.
-6.  **Output Generation**: `plotter`, `csv_writer` and `logger` save plots, tables and logs using a consistent format.
-7.  **Loop or Exit**: The user is prompted to run another evaluation or exit.
+2.  **Startup Tests**: A small test suite verifies that the LCDM model and
+    data parsers work as expected.
+3.  **Initialization**: The script starts and creates the `./output/` directory for all results.
+4.  **Configuration**: The user specifies the file paths for the model and data files.
+5.  **SNe Ia Fitting**: The `cosmo_engine` fits the parameters of both the ΛCDM model and the alternative model to the SNe Ia data.
+6.  **BAO Analysis**: Using the best-fit parameters, the engine calculates BAO observables for each model.
+7.  **Output Generation**: `plotter`, `csv_writer` and `logger` save plots, tables and logs using a consistent format.
+8.  **Loop or Exit**: The user is prompted to run another evaluation or exit.
 
 ---
 

--- a/copernican.py
+++ b/copernican.py
@@ -29,6 +29,18 @@ data_loaders = None
 
 COPERNICAN_VERSION = "1.7.4-beta"
 
+def run_startup_tests():
+    """Execute functional tests using the standard unittest runner."""
+    import unittest
+    try:
+        tests = importlib.import_module('tests.functional')
+    except Exception as exc:
+        print(f"Error importing startup tests: {exc}")
+        return False
+    suite = unittest.defaultTestLoader.loadTestsFromModule(tests)
+    result = unittest.TextTestRunner(verbosity=1).run(suite)
+    return result.wasSuccessful()
+
 def show_splash_screen():
     """Displays the startup banner once at launch."""
     banner = [
@@ -206,6 +218,9 @@ def cleanup_cache(base_dir):
 def main_workflow():
     """Main workflow for the Copernican Suite."""
     check_dependencies()
+    if not run_startup_tests():
+        print("Startup tests failed. Exiting.")
+        return
 
     # Import optional third-party packages after confirming they are installed
     global np, plt, mp, model_parser, model_coder, engine_interface, data_loaders, plotter, csv_writer, log_mod, logger

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -1,0 +1,57 @@
+import unittest
+import importlib
+from pathlib import Path
+import numpy as np
+
+from scripts import model_parser, model_coder, engine_interface, data_loaders
+import engines.cosmo_engine_1_4b as engine
+
+
+class FunctionalTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        base = Path(__file__).resolve().parents[1]
+        models_dir = base / 'models'
+        json_path = models_dir / 'cosmo_model_lcdm.json'
+        cache_dir = models_dir / 'cache'
+        cache_path = model_parser.parse_model_json(json_path, cache_dir)
+        funcs, parsed = model_coder.generate_callables(cache_path)
+        cls.plugin = engine_interface.build_plugin(parsed, funcs)
+        engine_interface.validate_plugin(cls.plugin)
+
+    def test_plugin_validation(self):
+        self.assertTrue(hasattr(self.plugin, 'distance_modulus_model'))
+
+    def test_engine_routines(self):
+        sne_df = data_loaders.load_sne_data('University of Strassbourg dataset')
+        self.assertIsNotNone(sne_df)
+        sne_df = sne_df.head(3)
+
+        bao_df = data_loaders.load_bao_data('Basic BAO testing dataset')
+        self.assertIsNotNone(bao_df)
+        bao_df = bao_df.head(3)
+
+        cmb_df = data_loaders.load_cmb_data('planck2018lite_v1')
+        self.assertIsNotNone(cmb_df)
+
+        params = self.plugin.INITIAL_GUESSES
+        chi2_sne = engine.chi_squared_sne_h1_fixed_nuisance(
+            params,
+            self.plugin.distance_modulus_model,
+            sne_df
+        )
+        self.assertTrue(np.isfinite(chi2_sne))
+
+        pred_df, rs_mpc, _ = engine.calculate_bao_observables(bao_df, self.plugin, params)
+        chi2_bao = engine.chi_squared_bao(bao_df, self.plugin, params, rs_mpc)
+        self.assertTrue(np.isfinite(chi2_bao))
+
+        camb_params = self.plugin.get_camb_params(params)
+        chi2_cmb = engine.chi_squared_cmb(camb_params, cmb_df)
+        spec = engine.compute_cmb_spectrum(camb_params, cmb_df['ell'].values)
+        self.assertTrue(np.isfinite(chi2_cmb))
+        self.assertEqual(len(spec), len(cmb_df))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create a new functional test suite verifying LCDM parsing and engine routines
- execute this test suite automatically with `run_startup_tests`
- mention the new step in the workflow overview
- document the addition in the changelog

## Testing
- `python3 -m unittest tests.functional`

------
https://chatgpt.com/codex/tasks/task_e_68694db1db88832f9935fd9b8a741bb7