### PR TITLE
Support TE/EE spectra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
 ## Version 1.7.6-beta (Development Release)
 - 2025-07-05: Bumped COPERNICAN_VERSION and docs to 1.7.6-beta. (AI assistant)
+- 2025-07-06: Added TE/EE spectrum handling in parser, engine and plotter. (AI assistant)
 ## Version 1.7.5-beta (Development Release)
 - 2025-07-05: Removal of user-selectable test mode. (AI assistant)
 - 2025-07-05: Automatic functional tests run at startup. (AI assistant)

--- a/copernican.py
+++ b/copernican.py
@@ -375,8 +375,14 @@ def main_workflow():
             # dictionary format using the helper provided by the model plugin.
             camb_params = model_plugin.get_camb_params(cosmo_params)
 
+            components = ["TT"]
+            if "Dl_te_obs" in cmb_df.columns:
+                components.append("TE")
+            if "Dl_ee_obs" in cmb_df.columns:
+                components.append("EE")
+
             theory = cosmo_engine_selected.compute_cmb_spectrum(
-                camb_params, cmb_df['ell'].values
+                camb_params, cmb_df['ell'].values, spectra=tuple(components)
             )
             chi2_val = cosmo_engine_selected.chi_squared_cmb(camb_params, cmb_df)
             logger.info(f"{model_plugin.MODEL_NAME} CMB chi2 = {chi2_val:.2f}")

--- a/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
+++ b/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
@@ -21,16 +21,22 @@ def parse_planck2018lite(data_dir, **kwargs):
     cov_path = os.path.join(data_dir, "c_matrix_plik_v22.dat")
 
     try:
-        df = pd.read_csv(
-            cl_path,
-            sep=r"\s+",
-            header=None,
-            usecols=[0, 1],
-            names=["ell", "Cl_obs"],
-        )
-        # Convert the provided C_ell (in \mu K^2) to D_ell for comparison
+        raw = pd.read_csv(cl_path, sep=r"\s+", header=None)
+        col_map = {0: "ell", 1: "Cl_obs"}
+        if raw.shape[1] >= 3:
+            col_map[2] = "Cl_te_obs"
+        if raw.shape[1] >= 4:
+            col_map[3] = "Cl_ee_obs"
+
+        raw.rename(columns=col_map, inplace=True)
+        df = raw[list(col_map.values())]
+
         ell_arr = df["ell"].values
         df["Dl_obs"] = ell_arr * (ell_arr + 1) * df["Cl_obs"] / (2 * np.pi)
+        if "Cl_te_obs" in df.columns:
+            df["Dl_te_obs"] = ell_arr * (ell_arr + 1) * df["Cl_te_obs"] / (2 * np.pi)
+        if "Cl_ee_obs" in df.columns:
+            df["Dl_ee_obs"] = ell_arr * (ell_arr + 1) * df["Cl_ee_obs"] / (2 * np.pi)
         n = len(df)
 
         # The covariance matrix file is stored as a Fortran unformatted

--- a/engines/cosmo_engine_1_4b.py
+++ b/engines/cosmo_engine_1_4b.py
@@ -217,8 +217,26 @@ def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
     return total_chi2 if np.isfinite(total_chi2) else np.inf
 
 
-def compute_cmb_spectrum(param_dict, ells):
-    """Return the theoretical D_ell spectrum using CAMB."""
+def compute_cmb_spectrum(param_dict, ells, spectra=("TT",)):
+    """Return theoretical D_ell spectra using CAMB.
+
+    Parameters
+    ----------
+    param_dict : dict
+        Dictionary of CAMB parameters.
+    ells : array-like
+        Multipole moments to evaluate.
+    spectra : tuple of str, optional
+        Which spectra to return. Options include ``"TT"``, ``"TE"`` and
+        ``"EE"``. The default is ``("TT",)`` for backward compatibility.
+
+    Returns
+    -------
+    array or dict
+        If ``spectra`` contains a single entry, a NumPy array for that
+        component is returned. Otherwise a dictionary mapping component name
+        to its array is returned.
+    """
     logger = logging.getLogger()
     try:
         H0 = float(param_dict.get("H0", 67.0))
@@ -248,10 +266,23 @@ def compute_cmb_spectrum(param_dict, ells):
         for key in powers:
             powers[key] *= 1.0e12  # convert from K^2 to \u03bcK^2
 
-        cl_tt = powers["total"][:, 0]
         ell_arr = np.asarray(ells, dtype=int)
-        dl = cl_tt[ell_arr] * (ell_arr * (ell_arr + 1) / (2 * np.pi))
-        return dl
+        factors = ell_arr * (ell_arr + 1) / (2 * np.pi)
+
+        result = {}
+        if "TT" in spectra:
+            cl_tt = powers["total"][:, 0]
+            result["TT"] = cl_tt[ell_arr] * factors
+        if "EE" in spectra:
+            cl_ee = powers["total"][:, 1]
+            result["EE"] = cl_ee[ell_arr] * factors
+        if "TE" in spectra:
+            cl_te = powers["total"][:, 3]
+            result["TE"] = cl_te[ell_arr] * factors
+
+        if len(result) == 1:
+            return next(iter(result.values()))
+        return result
     except Exception as exc:
         logger.error(f"(compute_cmb_spectrum): CAMB failed: {exc}")
         return np.full_like(ells, np.nan, dtype=float)
@@ -270,7 +301,7 @@ def chi_squared_cmb(cosmo_params, cmb_data_df):
     ells = cmb_data_df['ell'].values
     obs = cmb_data_df['Dl_obs'].values
     param_dict = {name: val for name, val in zip(cmb_data_df.attrs.get('param_names', []), cosmo_params)} if isinstance(cosmo_params, (list, tuple)) else cosmo_params
-    th = compute_cmb_spectrum(param_dict, ells)
+    th = compute_cmb_spectrum(param_dict, ells, spectra=("TT",))
     if th.shape != obs.shape or np.any(~np.isfinite(th)):
         return np.inf
 

--- a/scripts/csv_writer.py
+++ b/scripts/csv_writer.py
@@ -105,23 +105,60 @@ def save_cmb_results_csv(
         return
 
     df_out = cmb_data_df[["ell", "Dl_obs"]].copy()
+    if "Dl_te_obs" in cmb_data_df.columns:
+        df_out["Dl_te_obs"] = cmb_data_df["Dl_te_obs"]
+    if "Dl_ee_obs" in cmb_data_df.columns:
+        df_out["Dl_ee_obs"] = cmb_data_df["Dl_ee_obs"]
 
     if lcdm_results and lcdm_results.get("theory_spectrum") is not None:
         th_lcdm = lcdm_results["theory_spectrum"]
-        df_out["Dl_lcdm"] = th_lcdm
-        df_out["residual_lcdm"] = df_out["Dl_obs"] - th_lcdm
+        if isinstance(th_lcdm, dict):
+            if "TT" in th_lcdm:
+                df_out["Dl_lcdm_tt"] = th_lcdm["TT"]
+                df_out["residual_lcdm_tt"] = df_out["Dl_obs"] - th_lcdm["TT"]
+            if "TE" in th_lcdm and "Dl_te_obs" in df_out.columns:
+                df_out["Dl_lcdm_te"] = th_lcdm["TE"]
+                df_out["residual_lcdm_te"] = df_out["Dl_te_obs"] - th_lcdm["TE"]
+            if "EE" in th_lcdm and "Dl_ee_obs" in df_out.columns:
+                df_out["Dl_lcdm_ee"] = th_lcdm["EE"]
+                df_out["residual_lcdm_ee"] = df_out["Dl_ee_obs"] - th_lcdm["EE"]
+        else:
+            df_out["Dl_lcdm"] = th_lcdm
+            df_out["residual_lcdm"] = df_out["Dl_obs"] - th_lcdm
     else:
-        df_out["Dl_lcdm"] = np.nan
-        df_out["residual_lcdm"] = np.nan
+        df_out[[
+            col
+            for col in ["Dl_lcdm", "residual_lcdm", "Dl_lcdm_tt", "residual_lcdm_tt",
+                        "Dl_lcdm_te", "residual_lcdm_te", "Dl_lcdm_ee", "residual_lcdm_ee"]
+            if col not in df_out.columns
+        ]] = np.nan
 
     alt_name_safe = alt_model_name.replace(" ", "_").replace(".", "")
     if alt_model_results and alt_model_results.get("theory_spectrum") is not None:
         th_alt = alt_model_results["theory_spectrum"]
-        df_out[f"Dl_{alt_name_safe}"] = th_alt
-        df_out[f"residual_{alt_name_safe}"] = df_out["Dl_obs"] - th_alt
+        if isinstance(th_alt, dict):
+            if "TT" in th_alt:
+                df_out[f"Dl_{alt_name_safe}_tt"] = th_alt["TT"]
+                df_out[f"residual_{alt_name_safe}_tt"] = df_out["Dl_obs"] - th_alt["TT"]
+            if "TE" in th_alt and "Dl_te_obs" in df_out.columns:
+                df_out[f"Dl_{alt_name_safe}_te"] = th_alt["TE"]
+                df_out[f"residual_{alt_name_safe}_te"] = df_out["Dl_te_obs"] - th_alt["TE"]
+            if "EE" in th_alt and "Dl_ee_obs" in df_out.columns:
+                df_out[f"Dl_{alt_name_safe}_ee"] = th_alt["EE"]
+                df_out[f"residual_{alt_name_safe}_ee"] = df_out["Dl_ee_obs"] - th_alt["EE"]
+        else:
+            df_out[f"Dl_{alt_name_safe}"] = th_alt
+            df_out[f"residual_{alt_name_safe}"] = df_out["Dl_obs"] - th_alt
     else:
-        df_out[f"Dl_{alt_name_safe}"] = np.nan
-        df_out[f"residual_{alt_name_safe}"] = np.nan
+        df_out[[
+            col
+            for col in [
+                f"Dl_{alt_name_safe}", f"residual_{alt_name_safe}",
+                f"Dl_{alt_name_safe}_tt", f"residual_{alt_name_safe}_tt",
+                f"Dl_{alt_name_safe}_te", f"residual_{alt_name_safe}_te",
+                f"Dl_{alt_name_safe}_ee", f"residual_{alt_name_safe}_ee",
+            ] if col not in df_out.columns
+        ]] = np.nan
 
     dataset_name = cmb_data_df.attrs.get("dataset_name_attr", "CMB_data")
     model_comparison_name = f"LCDM-vs-{alt_name_safe}"

--- a/scripts/plotter.py
+++ b/scripts/plotter.py
@@ -448,80 +448,118 @@ def plot_cmb_spectrum(
     else:
         diag_errors_plot = np.full_like(dl_obs, 1.0)
 
-    fig, axs = plt.subplots(2, 1, figsize=(17, 12), sharex=True, gridspec_kw={"height_ratios": [3, 1.5], "hspace": 0.05})
+    components = ["TT"]
+    if "Dl_te_obs" in cmb_data_df.columns:
+        components.append("TE")
+    if "Dl_ee_obs" in cmb_data_df.columns:
+        components.append("EE")
+
+    fig, axs = plt.subplots(
+        len(components) * 2,
+        1,
+        figsize=(17, 6 * len(components)),
+        sharex=True,
+        gridspec_kw={"height_ratios": [3, 1.5] * len(components), "hspace": 0.05},
+    )
     plt.subplots_adjust(left=0.08, bottom=0.08, right=0.75, top=0.92)
     try:
         plt.style.use("seaborn-v0_8-darkgrid")
     except Exception:
         logger.warning("Seaborn-v0_8-darkgrid style not found, using default.")
 
-    axs[0].errorbar(
-        ells,
-        dl_obs,
-        yerr=diag_errors_plot,
-        fmt=".",
-        color="darkgray",
-        alpha=0.6,
-        label=f"{dataset_name}",
-        elinewidth=1,
-        capsize=2,
-        ms=5,
-        ecolor="lightgray",
-        zorder=1,
-    )
-
-    if lcdm_cmb_results and lcdm_cmb_results.get("theory_spectrum") is not None:
-        th_lcdm = lcdm_cmb_results["theory_spectrum"]
-        chi2_lcdm = f"{lcdm_cmb_results.get('chi2_cmb', np.nan):.2f}"
-        axs[0].plot(ells, th_lcdm, color="red", ls="-", lw=2.0, label=fr"$\Lambda$CDM ($\chi^2$={chi2_lcdm})")
-        res_lcdm = dl_obs - th_lcdm
-        axs[1].errorbar(
-            ells,
-            res_lcdm,
-            yerr=diag_errors_plot,
-            fmt=".",
-            color="red",
-            alpha=0.5,
-            label=r"$\Lambda$CDM Res.",
-            elinewidth=1,
-            capsize=2,
-            ms=4,
-        )
+    lcdm_theory = None
+    alt_theory = None
+    if lcdm_cmb_results:
+        lcdm_theory = lcdm_cmb_results.get("theory_spectrum")
+    if alt_cmb_results:
+        alt_theory = alt_cmb_results.get("theory_spectrum")
 
     alt_name_raw = getattr(alt_model_plugin, "MODEL_NAME", "AltModel")
     alt_name_latex = alt_name_raw.replace("_", r"\_")
-    if alt_cmb_results and alt_cmb_results.get("theory_spectrum") is not None:
-        th_alt = alt_cmb_results["theory_spectrum"]
-        chi2_alt = f"{alt_cmb_results.get('chi2_cmb', np.nan):.2f}"
-        axs[0].plot(ells, th_alt, color="blue", ls="--", lw=2.0, label=fr"{alt_name_latex} ($\chi^2$={chi2_alt})")
-        res_alt = dl_obs - th_alt
-        axs[1].errorbar(
+
+    for i, comp in enumerate(components):
+        idx_main = i * 2
+        idx_res = idx_main + 1
+        obs_key = "Dl_obs" if comp == "TT" else f"Dl_{comp.lower()}_obs"
+        obs = cmb_data_df[obs_key].values
+        err = diag_errors_plot if comp == "TT" else np.full_like(obs, 1.0)
+
+        axs[idx_main].errorbar(
             ells,
-            res_alt,
-            yerr=diag_errors_plot,
+            obs,
+            yerr=err,
             fmt=".",
-            mfc="none",
-            mec="blue",
-            ecolor="lightblue",
-            alpha=0.5,
-            label=fr"{alt_name_latex} Res.",
+            color="darkgray",
+            alpha=0.6,
+            label=f"{dataset_name}",
             elinewidth=1,
             capsize=2,
-            ms=4,
+            ms=5,
+            ecolor="lightgray",
+            zorder=1,
         )
 
-    axs[0].set_ylabel(r"$D_\ell\ (\mu K^2)$", fontsize=font_sizes["label"])
-    axs[0].legend(fontsize=font_sizes["legend"], loc="best")
-    axs[0].set_title(f"CMB TT Power Spectrum: {dataset_name}", fontsize=font_sizes["title"])
-    axs[0].minorticks_on()
-    axs[0].tick_params(axis="both", which="major", labelsize=font_sizes["ticks"])
+        if lcdm_theory is not None:
+            th = lcdm_theory.get(comp) if isinstance(lcdm_theory, dict) else (
+                lcdm_theory if comp == "TT" else None
+            )
+            if th is not None:
+                chi2_lcdm = f"{lcdm_cmb_results.get('chi2_cmb', np.nan):.2f}" if comp == "TT" else ""
+                label = r"$\Lambda$CDM" + (f" ($\chi^2$={chi2_lcdm})" if chi2_lcdm else "")
+                axs[idx_main].plot(ells, th, color="red", ls="-", lw=2.0, label=label)
+                res = obs - th
+                axs[idx_res].errorbar(
+                    ells,
+                    res,
+                    yerr=err,
+                    fmt=".",
+                    color="red",
+                    alpha=0.5,
+                    label=r"$\Lambda$CDM Res.",
+                    elinewidth=1,
+                    capsize=2,
+                    ms=4,
+                )
 
-    axs[1].axhline(0, color="black", ls="--", lw=1)
-    axs[1].set_xlabel(r"Multipole $\ell$", fontsize=font_sizes["label"])
-    axs[1].set_ylabel(r"$D_\ell^{obs} - D_\ell^{th}$", fontsize=font_sizes["label"])
-    axs[1].legend(fontsize=font_sizes["legend"], loc="best")
-    axs[1].minorticks_on()
-    axs[1].tick_params(axis="both", which="major", labelsize=font_sizes["ticks"])
+        if alt_theory is not None:
+            th = alt_theory.get(comp) if isinstance(alt_theory, dict) else (
+                alt_theory if comp == "TT" else None
+            )
+            if th is not None:
+                chi2_alt = f"{alt_cmb_results.get('chi2_cmb', np.nan):.2f}" if comp == "TT" else ""
+                label = fr"{alt_name_latex}" + (f" ($\chi^2$={chi2_alt})" if chi2_alt else "")
+                axs[idx_main].plot(ells, th, color="blue", ls="--", lw=2.0, label=label)
+                res = obs - th
+                axs[idx_res].errorbar(
+                    ells,
+                    res,
+                    yerr=err,
+                    fmt=".",
+                    mfc="none",
+                    mec="blue",
+                    ecolor="lightblue",
+                    alpha=0.5,
+                    label=fr"{alt_name_latex} Res.",
+                    elinewidth=1,
+                    capsize=2,
+                    ms=4,
+                )
+
+        axs[idx_main].set_ylabel(r"$D_\ell\ (\mu K^2)$", fontsize=font_sizes["label"])
+        axs[idx_main].legend(fontsize=font_sizes["legend"], loc="best")
+        axs[idx_main].set_title(
+            f"CMB {comp} Power Spectrum: {dataset_name}", fontsize=font_sizes["title"]
+        )
+        axs[idx_main].minorticks_on()
+        axs[idx_main].tick_params(axis="both", which="major", labelsize=font_sizes["ticks"])
+
+        axs[idx_res].axhline(0, color="black", ls="--", lw=1)
+        if i == len(components) - 1:
+            axs[idx_res].set_xlabel(r"Multipole $\ell$", fontsize=font_sizes["label"])
+        axs[idx_res].set_ylabel(r"$D_\ell^{obs} - D_\ell^{th}$", fontsize=font_sizes["label"])
+        axs[idx_res].legend(fontsize=font_sizes["legend"], loc="best")
+        axs[idx_res].minorticks_on()
+        axs[idx_res].tick_params(axis="both", which="major", labelsize=font_sizes["ticks"])
 
     bbox_lcdm = dict(boxstyle="round,pad=0.5", fc="#FFEEEE", ec="darkred", alpha=0.8)
     bbox_alt = dict(boxstyle="round,pad=0.5", fc="#EEF2FF", ec="darkblue", alpha=0.8)


### PR DESCRIPTION
## Summary
- allow CAMB engine to return TT/TE/EE spectra
- parse optional TE and EE columns from Planck 2018 lite data
- plot TT, TE and EE spectra separately with well scaled residuals
- export TE/EE results in CMB CSV output
- document new feature in CHANGELOG

## Testing
- `pytest tests/functional.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a2246872c832f874398504743b598