### PR TITLE
Improve Planck lite parser covariance checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Example:
 ## Version 1.7.6-beta (Development Release)
 - 2025-07-05: Bumped COPERNICAN_VERSION and docs to 1.7.6-beta. (AI assistant)
 - 2025-07-06: Added TE/EE spectrum handling in parser, engine and plotter. (AI assistant)
+- 2025-07-06: Improved Planck lite parser covariance checks with fallback warnings. (AI assistant)
 ## Version 1.7.5-beta (Development Release)
 - 2025-07-05: Removal of user-selectable test mode. (AI assistant)
 - 2025-07-05: Automatic functional tests run at startup. (AI assistant)

--- a/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
+++ b/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
@@ -59,13 +59,30 @@ def parse_planck2018lite(data_dir, **kwargs):
         # the same ell(ell+1)/(2pi) factors applied above.
         factors = ell_arr * (ell_arr + 1) / (2 * np.pi)
         cov_matrix = cov_matrix * np.outer(factors, factors)
+
+        # Pre-compute diagonal errors for plotting or fallback usage
+        diag_errors = np.sqrt(np.diag(cov_matrix))
+
         try:
             cov_inv = np.linalg.inv(cov_matrix)
-        except np.linalg.LinAlgError:
-            logger.error("Planck2018lite covariance matrix is singular.")
-            return None
+            # Check for NaNs or infinities after inversion
+            if not np.all(np.isfinite(cov_inv)):
+                raise ValueError(
+                    "Inverted Planck2018lite covariance contains non-finite values."
+                )
+
+            cond_num = np.linalg.cond(cov_matrix)
+            if not np.isfinite(cond_num) or cond_num > 1e12:
+                raise ValueError(
+                    f"Planck2018lite covariance matrix ill-conditioned (cond={cond_num:.2e})."
+                )
+        except (np.linalg.LinAlgError, ValueError) as e:
+            # Fall back to diagonal errors if inversion fails or matrix is bad
+            logger.warning(f"{e} Falling back to diagonal errors.")
+            cov_inv = None
 
         df.attrs["covariance_matrix_inv"] = cov_inv
+        df.attrs["diag_errors_for_plot"] = diag_errors
         df.attrs["dataset_name_attr"] = "CMB_Planck2018lite"
         df.attrs["is_cmb"] = True
         # Map the order of CAMB parameters used by the engine


### PR DESCRIPTION
## Summary
- add NaN and ill-conditioning checks when inverting the Planck 2018 lite covariance matrix
- warn and fall back to diagonal errors when inversion fails
- document the change in `CHANGELOG.md`

## Testing
- `python -m pytest -q tests/functional.py`

------
https://chatgpt.com/codex/tasks/task_e_686a270afbe4832fa2de5c37c2c39517