### PR TITLE
Fix chi2 label warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Example:
 - 2025-07-05: Bumped COPERNICAN_VERSION and docs to 1.7.6-beta. (AI assistant)
 - 2025-07-06: Added TE/EE spectrum handling in parser, engine and plotter. (AI assistant)
 - 2025-07-06: Improved Planck lite parser covariance checks with fallback warnings. (AI assistant)
+- 2025-07-06: Fixed chi-squared label formatting warnings in plotter. (AI assistant)
 ## Version 1.7.5-beta (Development Release)
 - 2025-07-05: Removal of user-selectable test mode. (AI assistant)
 - 2025-07-05: Automatic functional tests run at startup. (AI assistant)

--- a/scripts/plotter.py
+++ b/scripts/plotter.py
@@ -505,7 +505,7 @@ def plot_cmb_spectrum(
             )
             if th is not None:
                 chi2_lcdm = f"{lcdm_cmb_results.get('chi2_cmb', np.nan):.2f}" if comp == "TT" else ""
-                label = r"$\Lambda$CDM" + (f" ($\chi^2$={chi2_lcdm})" if chi2_lcdm else "")
+                label = r"$\Lambda$CDM" + (rf" ($\chi^2$={chi2_lcdm})" if chi2_lcdm else "")
                 axs[idx_main].plot(ells, th, color="red", ls="-", lw=2.0, label=label)
                 res = obs - th
                 axs[idx_res].errorbar(
@@ -527,7 +527,7 @@ def plot_cmb_spectrum(
             )
             if th is not None:
                 chi2_alt = f"{alt_cmb_results.get('chi2_cmb', np.nan):.2f}" if comp == "TT" else ""
-                label = fr"{alt_name_latex}" + (f" ($\chi^2$={chi2_alt})" if chi2_alt else "")
+                label = fr"{alt_name_latex}" + (rf" ($\chi^2$={chi2_alt})" if chi2_alt else "")
                 axs[idx_main].plot(ells, th, color="blue", ls="--", lw=2.0, label=label)
                 res = obs - th
                 axs[idx_res].errorbar(


### PR DESCRIPTION
## Summary
- escape LaTeX chi-squared labels in the plotter
- update changelog

## Testing
- `pytest tests/functional.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a29d9f230832f9d2048c2d1f2c939