### PR TITLE
Fix CMB spectrum computation with CAMB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.7.6-beta**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.7.7-beta**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Add one line for each substantive commit or pull request directly under the late
 
 Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
+
+## Version 1.7.7-beta (Development Release)
+- 2025-07-06: Bumped COPERNICAN_VERSION and documentation to 1.7.7-beta. (AI assistant)
+- 2025-07-06: CMB spectrum now computed with CAMB and plots use logarithmic scale. (AI assistant)
+
 ## Version 1.7.6-beta (Development Release)
 - 2025-07-05: Bumped COPERNICAN_VERSION and docs to 1.7.6-beta. (AI assistant)
 - 2025-07-06: Added TE/EE spectrum handling in parser, engine and plotter. (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.7.6-beta
-**Last Updated:** 2025-07-05
+**Version:** 1.7.7-beta
+**Last Updated:** 2025-07-06
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia) and Baryon Acoustic Oscillation (BAO) data. Future

--- a/copernican.py
+++ b/copernican.py
@@ -27,7 +27,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.7.6-beta"
+COPERNICAN_VERSION = "1.7.7-beta"
 
 def run_startup_tests():
     """Execute functional tests using the standard unittest runner."""

--- a/engines/cosmo_engine_1_4b.py
+++ b/engines/cosmo_engine_1_4b.py
@@ -218,7 +218,12 @@ def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
 
 
 def compute_cmb_spectrum(param_dict, ells, spectra=("TT",)):
-    """Return theoretical D_ell spectra using CAMB.
+    """Return theoretical :math:`D_\ell` spectra using CAMB.
+
+    The input cosmological parameters are mapped to CAMB's ``CAMBparams``
+    object. The raw temperature and polarization :math:`C_\ell` values
+    returned by CAMB are converted to
+    :math:`D_\ell = \ell(\ell+1)C_\ell / 2\pi` in :math:`\mu K^2` units.
 
     Parameters
     ----------
@@ -252,19 +257,19 @@ def compute_cmb_spectrum(param_dict, ells, spectra=("TT",)):
 
     params = camb.CAMBparams()
     params.set_cosmology(H0=H0, ombh2=ombh2, omch2=omch2, tau=tau)
-    # CAMB does not accept ``omnuh2`` directly in ``set_cosmology`` so assign
-    # it explicitly on the params object after calling the routine.
+    # CAMB does not accept ``omnuh2`` directly in ``set_cosmology`` so assign it
+    # explicitly on the params object after calling the routine.
     params.omnuh2 = omnuh2
     params.InitPower.set_params(As=As, ns=ns)
-    params.set_for_lmax(int(np.max(ells)) + 300, lens_potential_accuracy=0)
+    lmax = int(np.max(ells))
+    # Request additional multipoles so that the lensed spectrum is reliable
+    params.set_for_lmax(lmax + 300, lens_potential_accuracy=0)
     try:
         results = camb.get_results(params)
-        # Retrieve raw C_ell spectra in Kelvin^2 then convert to microKelvin^2
+        # Retrieve raw C_ell spectra directly in \u03bcK^2 units
         powers = results.get_cmb_power_spectra(
-            params, lmax=int(np.max(ells)), raw_cl=True, CMB_unit="K"
+            params, lmax=lmax, raw_cl=True, CMB_unit="muK"
         )
-        for key in powers:
-            powers[key] *= 1.0e12  # convert from K^2 to \u03bcK^2
 
         ell_arr = np.asarray(ells, dtype=int)
         factors = ell_arr * (ell_arr + 1) / (2 * np.pi)

--- a/scripts/plotter.py
+++ b/scripts/plotter.py
@@ -546,6 +546,7 @@ def plot_cmb_spectrum(
                 )
 
         axs[idx_main].set_ylabel(r"$D_\ell\ (\mu K^2)$", fontsize=font_sizes["label"])
+        axs[idx_main].set_yscale("log")
         axs[idx_main].legend(fontsize=font_sizes["legend"], loc="best")
         axs[idx_main].set_title(
             f"CMB {comp} Power Spectrum: {dataset_name}", fontsize=font_sizes["title"]


### PR DESCRIPTION
## Summary
- bump version to 1.7.7-beta
- compute CMB power spectrum using CAMB and document the conversion to D_ell
- show CMB power spectrum on a log scale for readability

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_686a3604af28832f8ecd362e21c51fba