### PR TITLE
Refactor CMB pipeline with Planck parser and plot improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.7.6-beta**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.7.7-beta**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Add one line for each substantive commit or pull request directly under the late
 
 Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
+## Version 1.7.7-beta (Development Release)
+- 2025-07-06: Overhauled Planck parser with µK² conversion and TE/EE support (AI assistant)
+- 2025-07-06: Redesigned CMB plot with log scaling and variance shading (AI assistant)
+- 2025-07-06: Documentation updates and version bump to 1.7.7-beta (AI assistant)
 ## Version 1.7.6-beta (Development Release)
 - 2025-07-05: Bumped COPERNICAN_VERSION and docs to 1.7.6-beta. (AI assistant)
 - 2025-07-06: Added TE/EE spectrum handling in parser, engine and plotter. (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.7.6-beta
-**Last Updated:** 2025-07-05
+**Version:** 1.7.7-beta
+**Last Updated:** 2025-07-06
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia) and Baryon Acoustic Oscillation (BAO) data. Future
@@ -76,8 +76,8 @@ models/           - JSON model definitions containing all theory text and
                     summaries but are not required.
 engines/          - Computational backends (SciPy CPU and Numba with automatic fallback)
 data/             - Observation data organized as ``data/<type>/<source>/``
-  cmb/planck2018lite/ - Planck 2018 lite TT power spectrum parser and files
-                         (covariance matrix may be binary Fortran or ASCII)
+  cmb/planck2018lite/ - Planck 2018 lite TT/TE/EE spectra and covariance
+                         (binary Fortran matrix)
 output/           - All generated results
 AGENTS.md         - Development specification and contributor rules
 CHANGELOG.md      - Release history
@@ -95,7 +95,9 @@ should not be modified by AI-driven code changes.
 - The program discovers available models from `models/cosmo_model_*.json`.
  - Data sources for SNe, BAO and CMB are chosen interactively. Once a source is
    selected, its parser and files are loaded automatically from
-   `data/<type>/<source>/`. Future datasets will follow the same structure.
+   `data/<type>/<source>/`. The CMB loader now understands TT, TE and EE
+   spectra with full covariance so additional datasets can be dropped in with
+   minimal effort.
 - Engines are selected interactively from the `engines/` directory. Parsers are
   discovered automatically when their source folders are imported.
 - After each run you may choose to evaluate another model or exit. Cache files
@@ -176,6 +178,9 @@ evaluation stage for that model.
 CMB data parsers attach a `param_names` attribute to the returned DataFrame
 listing the CAMB parameter order. The engine combines this list with
 `get_camb_params` to evaluate the power spectrum and chi-squared.
+The CMB plotter now draws separate TT, TE and EE panels with residuals,
+uses a logarithmic scale for temperature and $E$-mode spectra and shows
+cosmic-variance and observational uncertainty bands.
 `model_parser.py` accepts unknown keys and simply copies them to the sanitized
 cache. This allows the domain-specific JSON language to evolve while remaining
 compatible with older models.

--- a/copernican.py
+++ b/copernican.py
@@ -27,7 +27,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.7.6-beta"
+COPERNICAN_VERSION = "1.7.7-beta"
 
 def run_startup_tests():
     """Execute functional tests using the standard unittest runner."""

--- a/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
+++ b/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
@@ -1,4 +1,4 @@
-"""Planck 2018 lite CMB parser."""
+"""Parse the Planck 2018 lite TT/TE/EE spectra with covariance."""
 
 import os
 import logging
@@ -10,7 +10,7 @@ from scripts.data_loaders import register_cmb_parser
 
 @register_cmb_parser(
     "planck2018lite_v1",
-    "Planck 2018 lite TT spectrum.",
+    "Planck 2018 lite TT/TE/EE spectra.",
     data_dir=os.path.dirname(__file__),
 )
 def parse_planck2018lite(data_dir, **kwargs):
@@ -30,6 +30,10 @@ def parse_planck2018lite(data_dir, **kwargs):
 
         raw.rename(columns=col_map, inplace=True)
         df = raw[list(col_map.values())]
+
+        # The Planck 2018 lite files store raw C_ell values in K^2.
+        # Convert to \u03bcK^2 before forming D_ell.
+        df[[c for c in df.columns if c.startswith("Cl")]] *= 1.0e12
 
         ell_arr = df["ell"].values
         df["Dl_obs"] = ell_arr * (ell_arr + 1) * df["Cl_obs"] / (2 * np.pi)
@@ -55,10 +59,9 @@ def parse_planck2018lite(data_dir, **kwargs):
             return None
 
         cov_matrix = cov_arr.reshape(n, n)
-        # The covariance matrix is supplied for C_ell. Scale to D_ell using
-        # the same ell(ell+1)/(2pi) factors applied above.
+        # Convert from K^2 to \u03bcK^2 and transform C_ell covariance to D_ell.
         factors = ell_arr * (ell_arr + 1) / (2 * np.pi)
-        cov_matrix = cov_matrix * np.outer(factors, factors)
+        cov_matrix = cov_matrix * (1.0e12 ** 2) * np.outer(factors, factors)
 
         # Pre-compute diagonal errors for plotting or fallback usage
         diag_errors = np.sqrt(np.diag(cov_matrix))

--- a/scripts/plotter.py
+++ b/scripts/plotter.py
@@ -499,6 +499,15 @@ def plot_cmb_spectrum(
             zorder=1,
         )
 
+        axs[idx_main].fill_between(
+            ells,
+            obs - err,
+            obs + err,
+            color="lightgray",
+            alpha=0.3,
+            label="Data ±1σ",
+        )
+
         if lcdm_theory is not None:
             th = lcdm_theory.get(comp) if isinstance(lcdm_theory, dict) else (
                 lcdm_theory if comp == "TT" else None
@@ -507,6 +516,15 @@ def plot_cmb_spectrum(
                 chi2_lcdm = f"{lcdm_cmb_results.get('chi2_cmb', np.nan):.2f}" if comp == "TT" else ""
                 label = r"$\Lambda$CDM" + (rf" ($\chi^2$={chi2_lcdm})" if chi2_lcdm else "")
                 axs[idx_main].plot(ells, th, color="red", ls="-", lw=2.0, label=label)
+                cv = np.sqrt(2.0 / (2 * ells + 1.0)) * th
+                axs[idx_main].fill_between(
+                    ells,
+                    th - cv,
+                    th + cv,
+                    color="red",
+                    alpha=0.1,
+                    label="Cosmic var.",
+                )
                 res = obs - th
                 axs[idx_res].errorbar(
                     ells,
@@ -546,6 +564,8 @@ def plot_cmb_spectrum(
                 )
 
         axs[idx_main].set_ylabel(r"$D_\ell\ (\mu K^2)$", fontsize=font_sizes["label"])
+        if comp in ("TT", "EE"):
+            axs[idx_main].set_yscale("log")
         axs[idx_main].legend(fontsize=font_sizes["legend"], loc="best")
         axs[idx_main].set_title(
             f"CMB {comp} Power Spectrum: {dataset_name}", fontsize=font_sizes["title"]


### PR DESCRIPTION
## Summary
- bump version to 1.7.7-beta
- improve Planck 2018 CMB parser with µK² conversion and TE/EE handling
- redesign CMB plotting with log scaling and variance shading
- document new CMB pipeline and update AGENTS version

## Testing
- `pytest tests/functional.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a65ee3554832fa3f6322bab5ae034