### PR TITLE
Implement separate CMB stage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.7.7-beta**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.7.8-beta**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Add one line for each substantive commit or pull request directly under the late
 
 Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
+## Version 1.7.8-beta (Development Release)
+- 2025-07-06: Added dedicated CMB analysis stage with verbose logging (AI assistant)
+- 2025-07-06: Updated documentation and version bump to 1.7.8-beta (AI assistant)
 ## Version 1.7.7-beta (Development Release)
 - 2025-07-06: Overhauled Planck parser with µK² conversion and TE/EE support (AI assistant)
 - 2025-07-06: Redesigned CMB plot with log scaling and variance shading (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.7.7-beta
+**Version:** 1.7.8-beta
 **Last Updated:** 2025-07-06
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
@@ -42,13 +42,14 @@ Under the hood the program follows a clear pipeline:
 2. **Initialization** – the output directory is created and logging begins.
 3. **Configuration** – the user chooses a model, an engine from `./engines/`,
   and data parsers for SNe Ia and BAO. Models are discovered from
-  `cosmo_model_*.json` files which are converted into Python code on the fly.
+ `cosmo_model_*.json` files which are converted into Python code on the fly.
 4. **SNe Ia Fitting** – the selected engine estimates cosmological parameters
    for both the ΛCDM reference and the alternative model.
 5. **BAO Analysis** – using the best-fit parameters the engine predicts BAO
    observables and computes chi-squared statistics.
-6. **Output Generation** – `scripts/logger.py`, `scripts/plotter.py` and `scripts/csv_writer.py` handle logs, plots and tables.
-7. **Loop or Exit** – the user may evaluate another model or quit, at which
+6. **CMB Analysis** – the pipeline computes CMB power spectra and chi-squared values.
+7. **Output Generation** – `scripts/logger.py`, `scripts/plotter.py` and `scripts/csv_writer.py` handle logs, plots and tables.
+8. **Loop or Exit** – the user may evaluate another model or quit, at which
    point temporary cache files are cleaned automatically.
 
 ## Quick Start
@@ -236,8 +237,9 @@ altering `MAJOR.MINOR`.
 4.  **Configuration**: The user specifies the file paths for the model and data files.
 5.  **SNe Ia Fitting**: The `cosmo_engine` fits the parameters of both the ΛCDM model and the alternative model to the SNe Ia data.
 6.  **BAO Analysis**: Using the best-fit parameters, the engine calculates BAO observables for each model.
-7.  **Output Generation**: `plotter`, `csv_writer` and `logger` save plots, tables and logs using a consistent format.
-8.  **Loop or Exit**: The user is prompted to run another evaluation or exit.
+7.  **CMB Analysis**: Each model's CMB spectrum is evaluated against the selected dataset.
+8.  **Output Generation**: `plotter`, `csv_writer` and `logger` save plots, tables and logs using a consistent format.
+9.  **Loop or Exit**: The user is prompted to run another evaluation or exit.
 
 ---
 

--- a/copernican.py
+++ b/copernican.py
@@ -27,7 +27,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.7.7-beta"
+COPERNICAN_VERSION = "1.7.8-beta"
 
 def run_startup_tests():
     """Execute functional tests using the standard unittest runner."""
@@ -391,10 +391,20 @@ def main_workflow():
         lcdm_full_results = run_bao_analysis(lcdm, lcdm_sne_fit_results, z_plot_smooth)
         alt_model_full_results = run_bao_analysis(alt_model_plugin, alt_model_sne_fit_results, z_plot_smooth)
 
-        lcdm_cmb = run_cmb_analysis(cmb_data_df, lcdm, list(lcdm_sne_fit_results['fitted_cosmological_params'].values()))
-        alt_cmb = run_cmb_analysis(cmb_data_df, alt_model_plugin, list(alt_model_sne_fit_results['fitted_cosmological_params'].values()))
+        logger.info("\n--- Stage 4: CMB Analysis ---")
 
-        logger.info("\n--- Stage 4: Generating Outputs ---")
+        lcdm_cmb = run_cmb_analysis(
+            cmb_data_df,
+            lcdm,
+            list(lcdm_sne_fit_results['fitted_cosmological_params'].values()),
+        )
+        alt_cmb = run_cmb_analysis(
+            cmb_data_df,
+            alt_model_plugin,
+            list(alt_model_sne_fit_results['fitted_cosmological_params'].values()),
+        )
+
+        logger.info("\n--- Stage 5: Generating Outputs ---")
         logger.info(f"{lcdm.MODEL_NAME} CMB chi2 = {lcdm_cmb['chi2_cmb']:.2f}")
         logger.info(f"{alt_model_plugin.MODEL_NAME} CMB chi2 = {alt_cmb['chi2_cmb']:.2f}")
         plotter.plot_hubble_diagram(


### PR DESCRIPTION
## Summary
- treat CMB calculations as its own pipeline stage
- bump version to 1.7.8-beta
- document the new stage and update instructions

## Testing
- `PYTHONPATH=. python tests/functional.py`

------
https://chatgpt.com/codex/tasks/task_e_686a6eebbee4832f9f062a5960f310bd