### PR TITLE
Implement TE/EE parsing and plotting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.7.11-beta**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.7.12-beta**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Example:
 - 2025-07-06: Fixed Planck 2018 lite parser and trimmed covariance to TT block (AI assistant)
 - 2025-07-06: Bumped version to 1.7.11-beta (AI assistant)
 
+## Version 1.7.12-beta (Development Release)
+ - 2025-07-06: Added TE/EE spectrum handling and improved cosmic variance plotting (AI assistant)
+ - 2025-07-06: Bumped version to 1.7.12-beta (AI assistant)
+
 ## Version 1.7.9-beta (Development Release)
 - 2025-07-06: Fixed Planck lite scaling and covariance endianness (AI assistant)
 - 2025-07-06: Enhanced default CMB wrapper and engine spectra output (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.7.11-beta
+**Version:** 1.7.12-beta
 **Last Updated:** 2025-07-06
 
 The Copernican Suite is a Python toolkit for testing cosmological models against

--- a/copernican.py
+++ b/copernican.py
@@ -27,7 +27,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.7.11-beta"
+COPERNICAN_VERSION = "1.7.12-beta"
 
 def run_startup_tests():
     """Execute functional tests using the standard unittest runner."""

--- a/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
+++ b/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
@@ -38,20 +38,32 @@ def parse_planck2018lite(data_dir, **kwargs):
         block_te = raw.iloc[idx_tt:idx_te].reset_index(drop=True)
         block_ee = raw.iloc[idx_te:].reset_index(drop=True)
 
-        ell_arr = block_tt[0].values.astype(int)
-        df = pd.DataFrame({"ell": ell_arr})
-        df["Dl_obs"] = ell_arr * (ell_arr + 1) * block_tt[1].values / (2 * np.pi)
+        ell_tt = block_tt[0].values.astype(int)
+        df = pd.DataFrame({"ell": ell_tt})
+        df["Dl_obs"] = ell_tt * (ell_tt + 1) * block_tt[1].values / (2 * np.pi)
 
-        if len(block_te) == len(ell_arr):
-            df["Dl_te_obs"] = (
-                ell_arr * (ell_arr + 1) * block_te[1].values / (2 * np.pi)
-            )
-        if len(block_ee) == len(ell_arr):
-            df["Dl_ee_obs"] = (
-                ell_arr * (ell_arr + 1) * block_ee[1].values / (2 * np.pi)
-            )
+        # Build TE and EE columns aligned to the TT ell grid. Where the TE/EE
+        # block does not provide a value (the high-\ell tail), NaN is used.
+        ell_te = block_te[0].values.astype(int)
+        ell_ee = block_ee[0].values.astype(int)
+        te_map = ell_te * (ell_te + 1) * block_te[1].values / (2 * np.pi)
+        te_err = ell_te * (ell_te + 1) * block_te[2].values / (2 * np.pi)
+        ee_map = ell_ee * (ell_ee + 1) * block_ee[1].values / (2 * np.pi)
+        ee_err = ell_ee * (ell_ee + 1) * block_ee[2].values / (2 * np.pi)
 
-        n = len(ell_arr)
+        df["Dl_te_obs"] = np.full_like(ell_tt, np.nan, dtype=float)
+        df["Dl_ee_obs"] = np.full_like(ell_tt, np.nan, dtype=float)
+        df["e_te_obs"] = np.full_like(ell_tt, np.nan, dtype=float)
+        df["e_ee_obs"] = np.full_like(ell_tt, np.nan, dtype=float)
+
+        idx_te = np.searchsorted(ell_tt, ell_te)
+        idx_ee = np.searchsorted(ell_tt, ell_ee)
+        df.loc[idx_te, "Dl_te_obs"] = te_map
+        df.loc[idx_te, "e_te_obs"] = te_err
+        df.loc[idx_ee, "Dl_ee_obs"] = ee_map
+        df.loc[idx_ee, "e_ee_obs"] = ee_err
+
+        n = len(ell_tt)
 
         # The covariance matrix file is stored as a Fortran unformatted binary
         # record. Determine the endianness from the leading 4-byte header and
@@ -87,7 +99,7 @@ def parse_planck2018lite(data_dir, **kwargs):
 
         cov_matrix = cov_arr.reshape(n_full, n_full)[:n, :n]
         # Convert covariance from $C_\ell$ to $D_\ell$ in $\mu K^2$.
-        factors = ell_arr * (ell_arr + 1) / (2 * np.pi)
+        factors = ell_tt * (ell_tt + 1) / (2 * np.pi)
         cov_matrix = cov_matrix * np.outer(factors, factors)
 
         # Pre-compute diagonal errors for plotting or fallback usage

--- a/scripts/plotter.py
+++ b/scripts/plotter.py
@@ -482,7 +482,10 @@ def plot_cmb_spectrum(
         idx_res = idx_main + 1
         obs_key = "Dl_obs" if comp == "TT" else f"Dl_{comp.lower()}_obs"
         obs = cmb_data_df[obs_key].values
-        err = diag_errors_plot if comp == "TT" else np.full_like(obs, 1.0)
+        if comp == "TT":
+            err = diag_errors_plot
+        else:
+            err = cmb_data_df.get(f"e_{comp.lower()}_obs", np.full_like(obs, 1.0))
 
         axs[idx_main].errorbar(
             ells,
@@ -517,13 +520,15 @@ def plot_cmb_spectrum(
                 label = r"$\Lambda$CDM" + (rf" ($\chi^2$={chi2_lcdm})" if chi2_lcdm else "")
                 axs[idx_main].plot(ells, th, color="red", ls="-", lw=2.0, label=label)
                 cv = np.sqrt(2.0 / (2 * ells + 1.0)) * th
+                lower = np.clip(th - cv, 1e-8, None)
                 axs[idx_main].fill_between(
                     ells,
-                    th - cv,
+                    lower,
                     th + cv,
                     color="red",
                     alpha=0.1,
                     label="Cosmic var.",
+                    zorder=0,
                 )
                 res = obs - th
                 axs[idx_res].errorbar(


### PR DESCRIPTION
## Summary
- parse Planck lite TE/EE spectra and store errors
- plot TE/EE with proper error bars and visible cosmic variance
- bump version to 1.7.12-beta
- update docs and changelog

## Testing
- `PYTHONPATH=. python tests/functional.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a9c4c8734832f91036fa5be8b216b