### PR TITLE
Fix CMB chi-squared API, bump version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.8.3-beta**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.8.4-beta**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia and BAO data. Support for
@@ -17,7 +17,7 @@ sources. Parsers reside alongside their data. Results are saved under
 The default engine is `engines/cosmo_engine_1_4b.py`. All model plugins are validated
 through `scripts/engine_interface.py` before being passed to the engine. This
 ensures the expected functions are present and callable. Starting with
-version 1.8.3-beta the test suite no longer runs automatically. Execute
+version 1.8.4-beta the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify that
 the reference LCDM model and data parsers operate correctly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Add one line for each substantive commit or pull request directly under the late
 Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
 
+## Version 1.8.4-beta (Development Release)
+- 2025-07-07: Restored compatibility of chi_squared_cmb with plugin interface (AI assistant)
+- 2025-07-07: Bumped development version and updated documentation (AI assistant)
+
 ## Version 1.8.3-beta (Development Release)
 - 2025-07-06: Rewrote combined engine for true joint optimisation (AI assistant)
 - 2025-07-06: Fixed CMB chi-squared interface and allowed fitting of CAMB

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.8.3-beta
-**Last Updated:** 2025-07-06
+**Version:** 1.8.4-beta
+**Last Updated:** 2025-07-07
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia) and Baryon Acoustic Oscillation (BAO) data. Future

--- a/copernican.py
+++ b/copernican.py
@@ -28,7 +28,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.8.3-beta"
+COPERNICAN_VERSION = "1.8.4-beta"
 
 def run_startup_tests():
     """Execute functional tests using the standard unittest runner."""

--- a/engines/cosmo_engine_1_4b.py
+++ b/engines/cosmo_engine_1_4b.py
@@ -282,8 +282,21 @@ def compute_cmb_spectrum(param_dict, ells, spectra=("TT",)):
         return np.full_like(ells, np.nan, dtype=float)
 
 
-def chi_squared_cmb(cosmo_params, cmb_data_df):
-    """Calculate chi-squared for CMB data using full covariance."""
+def chi_squared_cmb(cosmo_params, cmb_data_df, plugin=None, extra_params=None):
+    """Calculate chi-squared for CMB data using full covariance.
+
+    Parameters
+    ----------
+    cosmo_params : sequence or dict
+        Cosmological parameter vector or direct CAMB parameter dictionary.
+    cmb_data_df : DataFrame
+        Observed CMB spectrum with inverse covariance attached.
+    plugin : object, optional
+        Model plugin providing ``get_camb_params``.  When ``None`` the
+        ``cosmo_params`` argument must already be a CAMB parameter mapping.
+    extra_params : dict, optional
+        Additional CAMB parameters to merge into the evaluation.
+    """
     logger = logging.getLogger()
     if cmb_data_df is None or cmb_data_df.empty:
         logger.error("(chi2_cmb): CMB data is empty.")
@@ -294,7 +307,23 @@ def chi_squared_cmb(cosmo_params, cmb_data_df):
 
     ells = cmb_data_df['ell'].values
     obs = cmb_data_df['Dl_obs'].values
-    param_dict = {name: val for name, val in zip(cmb_data_df.attrs.get('param_names', []), cosmo_params)} if isinstance(cosmo_params, (list, tuple)) else cosmo_params
+
+    if plugin is not None:
+        try:
+            param_dict = plugin.get_camb_params(cosmo_params)
+        except Exception as exc:
+            logger.error(f"(chi2_cmb): failed to map parameters: {exc}")
+            return np.inf
+    else:
+        if isinstance(cosmo_params, dict):
+            param_dict = dict(cosmo_params)
+        else:
+            names = cmb_data_df.attrs.get('param_names', [])
+            param_dict = {n: v for n, v in zip(names, cosmo_params)}
+
+    if extra_params:
+        param_dict.update(extra_params)
+
     th = compute_cmb_spectrum(param_dict, ells, spectra=("TT",))
     if th.shape != obs.shape or np.any(~np.isfinite(th)):
         return np.inf

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -48,7 +48,7 @@ class FunctionalTestCase(unittest.TestCase):
         self.assertTrue(np.isfinite(chi2_bao))
 
         camb_params = self.plugin.get_camb_params(params)
-        chi2_cmb = engine.chi_squared_cmb(camb_params, cmb_df)
+        chi2_cmb = engine.chi_squared_cmb(params, cmb_df, self.plugin)
         spec = engine.compute_cmb_spectrum(
             camb_params, cmb_df['ell'].values, spectra=("TT", "TE", "EE")
         )


### PR DESCRIPTION
## Summary
- update the development version to 1.8.4-beta
- patch `cosmo_engine_1_4b.chi_squared_cmb` to accept plugin-based parameter mapping
- adjust tests for the updated interface
- refresh documentation and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b71376d44832f83132863c8fd7e27