### PR TITLE
Fix test discovery logic and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ through `scripts/engine_interface.py` before being passed to the engine. This
 ensures the expected functions are present and callable. Starting with
 version 1.8.4-beta the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify that
-the reference LCDM model and data parsers operate correctly.
+the reference LCDM model and data parsers operate correctly. The `--run-tests`
+flag now uses Python's built-in discovery to gather all tests from the `tests`
+package and will exit cleanly even when Matplotlib has not yet been imported.
 
 ## 2. Directory Layout
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Example:
 - 2025-07-07: Bumped development version and updated documentation (AI assistant)
 - 2025-07-07: Documented engine-plugin architecture and updated JSON example (AI assistant)
 - 2025-07-07: Revised AGENTS overview and expanded README with developer guide (AI assistant)
+- 2025-07-07: Fixed test discovery and matplotlib cleanup in run-tests mode (AI assistant)
 
 ## Version 1.8.3-beta (Development Release)
 - 2025-07-06: Rewrote combined engine for true joint optimisation (AI assistant)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Under the hood the program follows a clear pipeline:
 2. Run `python3 copernican.py` and follow the prompts to choose a model,
    preferred data sources and computation engine.
 3. Execute `python3 copernican.py --run-tests` or run `python -m unittest discover`
-   to verify the reference model and parsers.
+   to verify the reference model and parsers. The `--run-tests` flag now leverages
+   unittest discovery to gather all modules under `tests/`.
 4. Plots and CSV results will appear in the `output/` folder when the run
    completes.
 
@@ -239,7 +240,7 @@ Run the tests with either command:
 
 ```bash
 python -m unittest discover
-python copernican.py --run-tests
+python copernican.py --run-tests  # uses unittest discovery internally
 ```
 
 New models are described entirely by JSON. Copy an existing file from `models/`
@@ -280,7 +281,7 @@ altering `MAJOR.MINOR`.
     instructs you to run a `pip install` command if any are absent.
 2.  **Optional Tests**: Run `copernican.py --run-tests` to execute the
     functional test suite and verify that the LCDM model and data parsers work
-    as expected.
+    as expected. This flag performs unittest discovery over the `tests` package.
 3.  **Initialization**: The script starts and creates the `./output/` directory for all results.
 4.  **Configuration**: The user specifies the file paths for the model and data files.
 5.  **SNe Ia Fitting**: The `cosmo_engine` fits the parameters of both the ΛCDM model and the alternative model to the SNe Ia data.

--- a/copernican.py
+++ b/copernican.py
@@ -31,14 +31,13 @@ data_loaders = None
 COPERNICAN_VERSION = "1.8.4-beta"
 
 def run_startup_tests():
-    """Execute functional tests using the standard unittest runner."""
+    """Discover and execute functional tests within the ``tests`` package."""
     import unittest
     try:
-        tests = importlib.import_module('tests.functional')
+        suite = unittest.defaultTestLoader.discover('tests')
     except Exception as exc:
-        print(f"Error importing startup tests: {exc}")
+        print(f"Error discovering startup tests: {exc}")
         return False
-    suite = unittest.defaultTestLoader.loadTestsFromModule(tests)
     result = unittest.TextTestRunner(verbosity=1).run(suite)
     return result.wasSuccessful()
 
@@ -531,7 +530,7 @@ if __name__ == "__main__":
             traceback.print_exc()
     finally:
         # Ensure that any generated plot windows are displayed at the very end
-        if plt.get_fignums():
+        if plt is not None and hasattr(plt, "get_fignums") and plt.get_fignums():
             print("\nDisplaying plot(s). Close plot window(s) to exit script fully.")
             try:
                 plt.show(block=True)


### PR DESCRIPTION
## Summary
- fix `--run-tests` to use unittest discovery
- avoid matplotlib error when tests exit early
- document new behavior in README and AGENTS
- log changes in CHANGELOG

## Testing
- `python3 copernican.py --run-tests`

------
https://chatgpt.com/codex/tasks/task_e_686ba3f634a4832f8dfdbe21edda7b60