### PR TITLE
Ensure clean multiprocessing startup and main-only JSON validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.8.4-beta**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.8.5-beta**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia, BAO and CMB data.
@@ -17,7 +17,7 @@ sources. Parsers reside alongside their data. Results are saved under
 The default engine is `engines/cosmo_engine_1_4b.py`. All model plugins are validated
 through `scripts/engine_interface.py` before being passed to the engine. This
 ensures the expected functions are present and callable. Starting with
-version 1.8.4-beta the test suite no longer runs automatically. Execute
+version 1.8.5-beta the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify that
 the reference LCDM model and data parsers operate correctly. The `--run-tests`
 flag now uses Python's built-in discovery to gather all tests from the `tests`
@@ -37,6 +37,12 @@ Files in `data/` are read-only and must not be modified by AI-driven changes.
 
 The current plotting style and algorithms are considered stable. Do not alter
 them without explicit instruction.
+
+Multiprocessing is enabled across several engines. To guarantee a clean
+environment for each worker, the program sets Python's multiprocessing start
+method to `spawn` at entry. Model JSON files are validated via `jsonschema`
+**only** in the main process; child processes read the sanitized cache without
+re-validating to prevent occasional plugin failures under multiprocessing.
 
 ## 3. Dependency Installation
 `copernican.py` scans all project files for imported modules. If any required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Add one line for each substantive commit or pull request directly under the late
 Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
 
+## Version 1.8.5-beta (Development Release)
+- 2025-07-07: Enforced spawn start method and restricted JSON validation to main process (AI assistant)
+
 ## Version 1.8.4-beta (Development Release)
 - 2025-07-07: Restored compatibility of chi_squared_cmb with plugin interface (AI assistant)
 - 2025-07-07: Bumped development version and updated documentation (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.8.4-beta
+**Version:** 1.8.5-beta
 **Last Updated:** 2025-07-07
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
@@ -242,6 +242,11 @@ Run the tests with either command:
 python -m unittest discover
 python copernican.py --run-tests  # uses unittest discovery internally
 ```
+
+Multiprocessing is used by several engines. The program enforces the `spawn`
+start method when it launches so that each worker process begins with a fresh
+Python interpreter. Model JSON files are validated with `jsonschema` only in the
+main process; child processes simply read the sanitized cache.
 
 New models are described entirely by JSON. Copy an existing file from `models/`
 and consult `cosmo_model_guide.json` for the full schema. Additional engines may

--- a/copernican.py
+++ b/copernican.py
@@ -28,7 +28,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.8.4-beta"
+COPERNICAN_VERSION = "1.8.5-beta"
 
 def run_startup_tests():
     """Discover and execute functional tests within the ``tests`` package."""
@@ -515,9 +515,18 @@ def main_workflow():
         cleanup_cache(SCRIPT_DIR)
 
 if __name__ == "__main__":
-    # This is essential for multiprocessing to work correctly on all platforms.
+    # Multiprocessing start method must be 'spawn' so that each child process
+    # inherits a pristine interpreter state. This avoids subtle issues when
+    # worker processes import project modules that expect to run only once.
     import multiprocessing as _mp
     _mp.freeze_support()
+    try:
+        _mp.set_start_method("spawn", force=True)
+    except RuntimeError:
+        # The start method was already set (e.g. by another library). Using
+        # 'force=True' above normally prevents this, but wrap in try/except for
+        # absolute safety.
+        pass
     try:
         main_workflow()
     except Exception:

--- a/scripts/model_parser.py
+++ b/scripts/model_parser.py
@@ -3,6 +3,7 @@
 import json
 from jsonschema import validate, ValidationError
 from pathlib import Path
+import multiprocessing as _mp
 from . import error_handler
 
 MODEL_SCHEMA = {
@@ -47,6 +48,9 @@ MODEL_SCHEMA = {
 def parse_model_json(path, cache_dir):
     """Validate ``path`` and write cleaned JSON to ``cache_dir``.
 
+    Validation is performed only in the main process. Worker processes simply
+    read the sanitized file produced during program startup.
+
     Parameters
     ----------
     path : str or Path
@@ -67,11 +71,20 @@ def parse_model_json(path, cache_dir):
         error_handler.report_error(f"Failed to read model JSON '{path}': {e}")
         raise
 
-    try:
-        validate(instance=data, schema=MODEL_SCHEMA)
-    except ValidationError as e:
-        error_handler.report_error(f"Model JSON validation error: {e.message}")
-        raise ValueError(f"Model JSON validation error: {e.message}") from e
+    # Only validate in the main process to avoid random failures when
+    # worker processes import this module under multiprocessing. The
+    # sanitized file produced here is shared by child processes, so
+    # repeated validation is unnecessary.
+    if _mp.current_process().name == "MainProcess":
+        try:
+            validate(instance=data, schema=MODEL_SCHEMA)
+        except ValidationError as e:
+            error_handler.report_error(
+                f"Model JSON validation error: {e.message}"
+            )
+            raise ValueError(
+                f"Model JSON validation error: {e.message}"
+            ) from e
 
     cache_dir = Path(cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- force 'spawn' multiprocessing start method at program launch
- validate model JSON only in the main process
- document multiprocessing and validation behaviour
- bump development version to 1.8.5-beta

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_686bbc184378832fb58f53900fe3acbc