### PR TITLE
Refactor engines to use shared optimizer and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.8.5-beta**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.9.0-beta**.
 
 ## 1. Program Overview
 The suite evaluates cosmological models against SNe Ia, BAO and CMB data.
@@ -17,7 +17,7 @@ sources. Parsers reside alongside their data. Results are saved under
 The default engine is `engines/cosmo_engine_1_4b.py`. All model plugins are validated
 through `scripts/engine_interface.py` before being passed to the engine. This
 ensures the expected functions are present and callable. Starting with
-version 1.8.5-beta the test suite no longer runs automatically. Execute
+version 1.9.0-beta the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify that
 the reference LCDM model and data parsers operate correctly. The `--run-tests`
 flag now uses Python's built-in discovery to gather all tests from the `tests`
@@ -32,6 +32,7 @@ data/             - Observation files under ``data/<type>/<source>/``
 output/           - Generated plots and CSV tables (created automatically)
 AGENTS.md         - Development specification and contributor rules
 CHANGELOG.md      - Release history
+scripts/optim_utils.py - Shared optimisation helpers used by engines
 ```
 Files in `data/` are read-only and must not be modified by AI-driven changes.
 
@@ -43,6 +44,10 @@ environment for each worker, the program sets Python's multiprocessing start
 method to `spawn` at entry. Model JSON files are validated via `jsonschema`
 **only** in the main process; child processes read the sanitized cache without
 re-validating to prevent occasional plugin failures under multiprocessing.
+
+All engines should remain purely computational. Shared utilities such as
+evaluation counters now live in ``scripts/optim_utils.py`` and are imported
+by the engines instead of being reimplemented inside each backend.
 
 ## 3. Dependency Installation
 `copernican.py` scans all project files for imported modules. If any required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Add one line for each substantive commit or pull request directly under the late
 Example:
 `- 2025-07-15: Improved BAO solver stability (Alice Doe)`
 
+## Version 1.9.0-beta (Development Release)
+- 2025-07-07: Centralized optimization wrappers and updated documentation (AI assistant)
+
 ## Version 1.8.5-beta (Development Release)
 - 2025-07-07: Enforced spawn start method and restricted JSON validation to main process (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.8.5-beta
+**Version:** 1.9.0-beta
 **Last Updated:** 2025-07-07
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
@@ -97,6 +97,7 @@ scripts/          - Helper modules
   csv_writer.py     - CSV output helpers
   data_loaders.py   - Data loading utilities
   utils.py          - Common helpers
+  optim_utils.py    - Shared optimisation wrappers used by engines
 ```
 **Note:** Files in `data/` are treated as read-only reference datasets and
 should not be modified by AI-driven code changes.
@@ -247,6 +248,8 @@ Multiprocessing is used by several engines. The program enforces the `spawn`
 start method when it launches so that each worker process begins with a fresh
 Python interpreter. Model JSON files are validated with `jsonschema` only in the
 main process; child processes simply read the sanitized cache.
+All engines import progress helpers from `scripts/optim_utils.py` so that
+evaluation counting and reporting remain consistent across backends.
 
 New models are described entirely by JSON. Copy an existing file from `models/`
 and consult `cosmo_model_guide.json` for the full schema. Additional engines may

--- a/copernican.py
+++ b/copernican.py
@@ -28,7 +28,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.8.5-beta"
+COPERNICAN_VERSION = "1.9.0-beta"
 
 def run_startup_tests():
     """Discover and execute functional tests within the ``tests`` package."""

--- a/engines/cosmo_engine_1_4b.py
+++ b/engines/cosmo_engine_1_4b.py
@@ -5,13 +5,12 @@ Relies on SciPy/NumPy for all computations.
 """
 
 import numpy as np
-from scipy.optimize import minimize
 from scipy.linalg import LinAlgError
 import camb
 import sys
-import time
 import logging
 from scripts import engine_interface
+from scripts.optim_utils import minimize_with_progress
 
 # --- Constants for SNe H2-style (SALT2 nuisance parameter fitting) ---
 SALT2_NUISANCE_PARAMS_INIT = {
@@ -400,50 +399,28 @@ def fit_sne_parameters(sne_data_df, model_plugin):
         return {'success': False, 'message': message, 'chi2_min': np.inf, 'model_name': model_name_str}
 
     options = {'maxiter': 2000, 'disp': False, 'ftol': 1e-10, 'gtol': 1e-7, 'eps': 1e-9}
-    
-    eval_count = {'count': 0}
-    best_chi2_so_far = [np.inf]
-    best_params_so_far = [list(current_initial_params)]
-    
-    start_time = time.time()
 
-    def chi2_wrapper_for_minimize(params_to_test, *args_passed):
-        """Wrapper to count evaluations and track best result for robust failure handling."""
-        eval_count['count'] += 1
-        current_chi2_val = chi2_function_to_call(params_to_test, *args_passed)
-        
-        if not np.isfinite(current_chi2_val): current_chi2_val = np.inf
-        
-        if current_chi2_val < best_chi2_so_far[0]:
-            best_chi2_so_far[0] = float(current_chi2_val)
-            best_params_so_far[0] = list(params_to_test) 
-        
-        elapsed_time = time.time() - start_time
-        speed_str = f"{(eval_count['count'] / elapsed_time):.1f} evals/s" if elapsed_time > 1e-6 else "--- evals/s"
-        
-        print(f"  SNe Fit Evals: {eval_count['count']:<5} | Best Chi2: {best_chi2_so_far[0]:.4f} | Speed: {speed_str:<15}", end='\r', file=sys.stderr)
-        
-        return current_chi2_val if np.isfinite(current_chi2_val) else 1e12 
+    logger.info(
+        f"Starting SNe optimization for {model_name_str} using {len(current_initial_params)} parameters..."
+    )
 
-    logger.info(f"Starting SNe optimization for {model_name_str} using {len(current_initial_params)} parameters...")
-    result_obj = None
-    try:
-        result_obj = minimize(chi2_wrapper_for_minimize, current_initial_params, args=args_for_chi2_func,
-                              method='L-BFGS-B', bounds=current_param_bounds, options=options)
-    except Exception as e_min:
-        logger.error(f"\nException during SNe minimize call for {model_name_str}: {e_min}", exc_info=True)
-    finally:
-        print(" " * 80, end='\r', file=sys.stderr)
-        logger.info(f"SNe Optimization for {model_name_str} finished. Total evals: {eval_count['count']}.")
+    result_obj, eval_total, best_chi2_so_far, best_params_so_far = minimize_with_progress(
+        chi2_function_to_call,
+        current_initial_params,
+        bounds=current_param_bounds,
+        args=args_for_chi2_func,
+        options=options,
+        label="SNe Fit",
+    )
 
     if result_obj and result_obj.success and np.isfinite(result_obj.fun):
         final_params = result_obj.x
         final_chi2 = result_obj.fun
         message = result_obj.message
         success_flag = True
-    else: 
-        final_params = np.array(best_params_so_far[0])
-        final_chi2 = best_chi2_so_far[0]
+    else:
+        final_params = np.array(best_params_so_far)
+        final_chi2 = best_chi2_so_far
         message = "Optimizer failed or did not improve; using best parameters found during search."
         if result_obj and hasattr(result_obj, 'message') and result_obj.message:
              message += f" (Optimizer msg: {result_obj.message})"
@@ -491,7 +468,7 @@ def fit_sne_parameters(sne_data_df, model_plugin):
         'reduced_chi2': reduced_chi2,
         'success': success_flag and np.isfinite(final_chi2),
         'message': message,
-        'n_evals_wrapper': eval_count['count']
+        'n_evals_wrapper': eval_total
     }
 
 

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -9,14 +9,13 @@ optimisation and calculation of chi-squared values.
 """
 
 import numpy as np
-from scipy.optimize import minimize
 from scipy.linalg import LinAlgError
 import camb
 from functools import lru_cache
 import sys
-import time
 import logging
 from scripts import engine_interface
+from scripts.optim_utils import minimize_with_progress
 
 # --- Constants for SNe H2-style (SALT2 nuisance parameter fitting) ---
 SALT2_NUISANCE_PARAMS_INIT = {
@@ -483,41 +482,19 @@ def fit_sne_parameters(sne_data_df, model_plugin):
         return {'success': False, 'message': message, 'chi2_min': np.inf, 'model_name': model_name_str}
 
     options = {'maxiter': 2000, 'disp': False, 'ftol': 1e-10, 'gtol': 1e-7, 'eps': 1e-9}
-    
-    eval_count = {'count': 0}
-    best_chi2_so_far = [np.inf]
-    best_params_so_far = [list(current_initial_params)]
-    
-    start_time = time.time()
 
-    def chi2_wrapper_for_minimize(params_to_test, *args_passed):
-        """Wrapper to count evaluations and track best result for robust failure handling."""
-        eval_count['count'] += 1
-        current_chi2_val = chi2_function_to_call(params_to_test, *args_passed)
-        
-        if not np.isfinite(current_chi2_val): current_chi2_val = np.inf
-        
-        if current_chi2_val < best_chi2_so_far[0]:
-            best_chi2_so_far[0] = float(current_chi2_val)
-            best_params_so_far[0] = list(params_to_test) 
-        
-        elapsed_time = time.time() - start_time
-        speed_str = f"{(eval_count['count'] / elapsed_time):.1f} evals/s" if elapsed_time > 1e-6 else "--- evals/s"
-        
-        print(f"  SNe Fit Evals: {eval_count['count']:<5} | Best Chi2: {best_chi2_so_far[0]:.4f} | Speed: {speed_str:<15}", end='\r', file=sys.stderr)
-        
-        return current_chi2_val if np.isfinite(current_chi2_val) else 1e12 
+    logger.info(
+        f"Starting SNe optimization for {model_name_str} using {len(current_initial_params)} parameters..."
+    )
 
-    logger.info(f"Starting SNe optimization for {model_name_str} using {len(current_initial_params)} parameters...")
-    result_obj = None
-    try:
-        result_obj = minimize(chi2_wrapper_for_minimize, current_initial_params, args=args_for_chi2_func,
-                              method='L-BFGS-B', bounds=current_param_bounds, options=options)
-    except Exception as e_min:
-        logger.error(f"\nException during SNe minimize call for {model_name_str}: {e_min}", exc_info=True)
-    finally:
-        print(" " * 80, end='\r', file=sys.stderr)
-        logger.info(f"SNe Optimization for {model_name_str} finished. Total evals: {eval_count['count']}.")
+    result_obj, eval_total, best_chi2_so_far, best_params_so_far = minimize_with_progress(
+        chi2_function_to_call,
+        current_initial_params,
+        bounds=current_param_bounds,
+        args=args_for_chi2_func,
+        options=options,
+        label="SNe Fit",
+    )
 
     if result_obj and result_obj.success and np.isfinite(result_obj.fun):
         final_params = result_obj.x
@@ -525,8 +502,8 @@ def fit_sne_parameters(sne_data_df, model_plugin):
         message = result_obj.message
         success_flag = True
     else: 
-        final_params = np.array(best_params_so_far[0])
-        final_chi2 = best_chi2_so_far[0]
+        final_params = np.array(best_params_so_far)
+        final_chi2 = best_chi2_so_far
         message = "Optimizer failed or did not improve; using best parameters found during search."
         if result_obj and hasattr(result_obj, 'message') and result_obj.message:
              message += f" (Optimizer msg: {result_obj.message})"
@@ -574,7 +551,7 @@ def fit_sne_parameters(sne_data_df, model_plugin):
         'reduced_chi2': reduced_chi2,
         'success': success_flag and np.isfinite(final_chi2),
         'message': message,
-        'n_evals_wrapper': eval_count['count']
+        'n_evals_wrapper': eval_total
     }
 
 def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin):
@@ -624,16 +601,14 @@ def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin)
                 param_names.append(key)
     num_cmb_extra = len(cmb_extra_names)
 
-    # Counter for iterations so progress can be displayed in real time
-    eval_count = {'count': 0}
-    best_val = [np.inf]
-    best_params = [list(init_params)]
-    start_t = time.time()
+    logger.info(
+        f"Starting combined optimization for {model_plugin.MODEL_NAME} using {len(init_params)} parameters..."
+    )
 
-    def chi2_wrapper(p):
-        """Wrapper that tracks evaluations and prints live progress."""
-        eval_count['count'] += 1
-        chi_val = chi_squared_combined(
+    options = {'maxiter': 2000, 'disp': False}
+
+    def combined_chi2(p):
+        return chi_squared_combined(
             p,
             model_plugin,
             sne_df=sne_data_df,
@@ -644,40 +619,14 @@ def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin)
             cmb_extra_names=cmb_extra_names,
             num_nuisance=num_nuisance,
         )
-        if not np.isfinite(chi_val):
-            chi_val = np.inf
-        if chi_val < best_val[0]:
-            best_val[0] = float(chi_val)
-            best_params[0] = list(p)
-        elapsed = time.time() - start_t
-        rate = f"{eval_count['count'] / elapsed:.1f} evals/s" if elapsed > 1e-6 else "--- evals/s"
-        print(
-            f"  Combined Fit Evals: {eval_count['count']:<5} | Best Chi2: {best_val[0]:.4f} | Speed: {rate:<15}",
-            end='\r',
-            file=sys.stderr,
-        )
-        return chi_val if np.isfinite(chi_val) else 1e12
 
-    logger.info(
-        f"Starting combined optimization for {model_plugin.MODEL_NAME} using {len(init_params)} parameters..."
+    result, eval_total, best_val, best_params = minimize_with_progress(
+        combined_chi2,
+        init_params,
+        bounds=bounds,
+        options=options,
+        label="Combined Fit",
     )
-
-    options = {'maxiter': 2000, 'disp': False}
-    result = None
-    try:
-        result = minimize(
-            chi2_wrapper,
-            init_params,
-            method='L-BFGS-B',
-            bounds=bounds,
-            options=options,
-        )
-    except Exception as exc:
-        logger.error(f"Exception during combined fit: {exc}", exc_info=True)
-    finally:
-        # Clear the progress line
-        print(" " * 80, end='\r', file=sys.stderr)
-        logger.info(f"Combined optimization finished. Total evals: {eval_count['count']}.")
 
     if result and result.success and np.isfinite(result.fun):
         final_params = result.x
@@ -685,7 +634,7 @@ def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin)
         message = result.message
         success_flag = True
     else:
-        final_params = np.array(best_params[0])
+        final_params = np.array(best_params)
         chi2_tot = chi_squared_combined(
             final_params,
             model_plugin,
@@ -784,6 +733,7 @@ def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin)
         'dof': dof,
         'reduced_chi2': reduced,
         'message': message,
+        'n_evals_wrapper': eval_total,
     }
 
 

--- a/scripts/optim_utils.py
+++ b/scripts/optim_utils.py
@@ -1,0 +1,101 @@
+# optim_utils.py
+"""Optimization utilities for the Copernican Suite.
+
+This module centralizes common wrappers used during numerical
+optimisation. Engines can import these helpers to keep the engine code
+focused strictly on mathematical calculations without bookkeeping.
+"""
+
+from typing import Iterable, Tuple, Callable, Any, Optional, List
+import sys
+import time
+import logging
+from scipy.optimize import minimize
+import numpy as np
+
+
+def minimize_with_progress(
+    func: Callable[[Iterable, Any], float],
+    x0: Iterable,
+    bounds: Iterable[Tuple[float, float]],
+    args: Tuple = (),
+    options: Optional[dict] = None,
+    method: str = "L-BFGS-B",
+    label: str = "Fit",
+) -> Tuple[Optional[object], int, float, List[float]]:
+    """Run :func:`scipy.optimize.minimize` while tracking evaluations.
+
+    Parameters
+    ----------
+    func : callable
+        Objective function returning a numeric value.
+    x0 : sequence
+        Initial parameter guesses for the optimiser.
+    bounds : sequence of tuple
+        Bounds for each parameter.
+    args : tuple, optional
+        Extra positional arguments for ``func``.
+    options : dict, optional
+        Options forwarded to :func:`~scipy.optimize.minimize`.
+    method : str, optional
+        Optimisation method.  ``"L-BFGS-B"`` is used by default.
+    label : str, optional
+        Human readable label shown in the live progress display.
+
+    Returns
+    -------
+    result : OptimizeResult or ``None``
+        The object returned by ``minimize`` or ``None`` when an exception
+        occurred.
+    evals : int
+        Total number of function evaluations performed.
+    best_val : float
+        Lowest finite objective value seen during the search.
+    best_params : list of float
+        Parameter vector associated with ``best_val``.
+    """
+
+    logger = logging.getLogger()
+    eval_count = {"count": 0}
+    best_val = [np.inf]
+    best_params = [list(x0)]
+    start_time = time.time()
+
+    def wrapped(p, *wrapped_args):
+        """Internal function that records progress."""
+        eval_count["count"] += 1
+        val = func(p, *wrapped_args)
+        if not np.isfinite(val):
+            val = np.inf
+        if val < best_val[0]:
+            best_val[0] = float(val)
+            best_params[0] = list(p)
+        elapsed = time.time() - start_time
+        rate = (
+            f"{eval_count['count'] / elapsed:.1f} evals/s" if elapsed > 1e-6 else "--- evals/s"
+        )
+        print(
+            f"  {label} Evals: {eval_count['count']:<5} | Best Chi2: {best_val[0]:.4f} | Speed: {rate:<15}",
+            end="\r",
+            file=sys.stderr,
+        )
+        return val if np.isfinite(val) else 1e12
+
+    result = None
+    try:
+        result = minimize(
+            wrapped,
+            x0,
+            args=args,
+            method=method,
+            bounds=bounds,
+            options=options or {},
+        )
+    except Exception as exc:  # pragma: no cover - hard to trigger in tests
+        logger.error(f"Exception during {label.lower()} minimize call: {exc}", exc_info=True)
+    finally:
+        # Clear the progress line so subsequent prints start on a clean line
+        print(" " * 80, end="\r", file=sys.stderr)
+        logger.info(f"{label} optimization finished. Total evals: {eval_count['count']}.")
+
+    return result, eval_count["count"], best_val[0], best_params[0]


### PR DESCRIPTION
## Summary
- factor out evaluation counter logic into `scripts/optim_utils.py`
- refactor both engines to use the new helper
- bump version number to 1.9.0-beta
- document new optimisation helper in README and AGENTS
- update changelog

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_686bc8e1834c832f94c8c24727ac916f