### PR TITLE
Fix plugin mutation bug and bump version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.9.2-beta**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.9.3-beta**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.
@@ -18,7 +18,7 @@ sources. Parsers reside alongside their data. Results are saved under
 The default engine is `engines/cosmo_engine_1_4b.py`. All model plugins are validated
 through `copernican_lib/engine_interface.py` before being passed to the engine. This
 ensures the expected functions are present and callable. Starting with
-version 1.9.2-beta the test suite no longer runs automatically. Execute
+version 1.9.3-beta the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify that
 the reference LCDM model and data parsers operate correctly. The `--run-tests`
 flag now uses Python's built-in discovery to gather all tests from the `tests`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Add one line for each substantive commit or pull request directly under the late
 
 `- 2025-07-05: short summary (author)`
 
+## Version 1.9.3-beta (Development Release)
+- 2025-07-07: Fixed parameter list mutation in combined engine and bumped version (AI assistant)
+- 2025-07-07: Removed deprecated L-BFGS-B solver options to silence SciPy warnings (AI assistant)
+
 ## Version 1.9.2-beta (Development Release)
 - 2025-07-07: Bumped version to 1.9.2-beta and expanded code comments (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.9.2-beta
+**Version:** 1.9.3-beta
 **Last Updated:** 2025-07-07
 
 The Copernican Suite is a Python toolkit for testing cosmological models against

--- a/copernican.py
+++ b/copernican.py
@@ -28,7 +28,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.9.2-beta"
+COPERNICAN_VERSION = "1.9.3-beta"
 
 # The high-level workflow is broken into small helper functions below. Each
 # helper is documented in plain language so non-programmers can follow the

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.9.2-beta.  The `copernican_lib` package now collects all
+version 1.9.3-beta.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.

--- a/engines/cosmo_engine_1_4b.py
+++ b/engines/cosmo_engine_1_4b.py
@@ -401,7 +401,9 @@ def fit_sne_parameters(sne_data_df, model_plugin):
         logger.error(message)
         return {'success': False, 'message': message, 'chi2_min': np.inf, 'model_name': model_name_str}
 
-    options = {'maxiter': 2000, 'disp': False, 'ftol': 1e-10, 'gtol': 1e-7, 'eps': 1e-9}
+    # Avoid deprecated 'disp' option in SciPy 1.10+. Default settings already
+    # suppress solver output, so we omit 'disp' entirely.
+    options = {'maxiter': 2000, 'ftol': 1e-10, 'gtol': 1e-7, 'eps': 1e-9}
 
     logger.info(
         f"Starting SNe optimization for {model_name_str} using {len(current_initial_params)} parameters..."

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -483,7 +483,9 @@ def fit_sne_parameters(sne_data_df, model_plugin):
         logger.error(message)
         return {'success': False, 'message': message, 'chi2_min': np.inf, 'model_name': model_name_str}
 
-    options = {'maxiter': 2000, 'disp': False, 'ftol': 1e-10, 'gtol': 1e-7, 'eps': 1e-9}
+    # Avoid deprecated 'disp' parameter for compatibility with newer SciPy
+    # versions. Defaults already suppress output.
+    options = {'maxiter': 2000, 'ftol': 1e-10, 'gtol': 1e-7, 'eps': 1e-9}
 
     logger.info(
         f"Starting SNe optimization for {model_name_str} using {len(current_initial_params)} parameters..."
@@ -566,7 +568,10 @@ def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin)
     """
     logger = logging.getLogger()
     engine_interface.validate_plugin(model_plugin)
-    param_names = getattr(model_plugin, 'PARAMETER_NAMES', [])
+    # Copy the model's parameter list so modifications for nuisance/CMB
+    # parameters do not alter the plugin in-place. Mutating the original list
+    # caused inconsistent parameter definitions on subsequent runs.
+    param_names = list(getattr(model_plugin, 'PARAMETER_NAMES', []))
     init_params = list(getattr(model_plugin, 'INITIAL_GUESSES', []))
     bounds = list(getattr(model_plugin, 'PARAMETER_BOUNDS', []))
     if not (param_names and init_params and bounds and len(param_names) == len(init_params)):
@@ -607,7 +612,9 @@ def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin)
         f"Starting combined optimization for {model_plugin.MODEL_NAME} using {len(init_params)} parameters..."
     )
 
-    options = {'maxiter': 2000, 'disp': False}
+    # Do not pass deprecated L-BFGS-B options; default configuration already
+    # keeps the solver quiet.
+    options = {'maxiter': 2000}
 
     def combined_chi2(p):
         return chi_squared_combined(


### PR DESCRIPTION
## Summary
- prevent `PARAMETER_NAMES` mutation in combined engine
- bump version to 1.9.3-beta in docs and code
- document change in changelog
- drop deprecated L-BFGS-B options to silence SciPy warning

## Testing
- `python3 -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_686be7241cc0832f8a0d337547164f07