### PR TITLE
Improve CMB cache precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Add one line for each substantive commit or pull request directly under the late
 ## Version 1.9.3-beta (Development Release)
 - 2025-07-07: Fixed parameter list mutation in combined engine and bumped version (AI assistant)
 - 2025-07-07: Removed deprecated L-BFGS-B solver options to silence SciPy warnings (AI assistant)
+- 2025-07-07: Increased CMB cache precision to six significant digits (AI assistant)
 
 ## Version 1.9.2-beta (Development Release)
 - 2025-07-07: Bumped version to 1.9.2-beta and expanded code comments (AI assistant)

--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ Under the hood the program follows a clear pipeline:
    chi-squared statistics are reported.
 6. **CMB Analysis** – similarly, CMB power spectra are generated and the
    chi-squared contribution is calculated.
-7. **Output Generation** – `copernican_lib/logger.py`, `copernican_lib/plotter.py` and `copernican_lib/csv_writer.py` handle logs, plots and tables.
-8. **Loop or Exit** – the user may evaluate another model or quit, at which
+7. **Spectra Caching** – unlensed CAMB spectra are cached using parameter
+   keys rounded to six significant digits.
+8. **Output Generation** – `copernican_lib/logger.py`, `copernican_lib/plotter.py` and `copernican_lib/csv_writer.py` handle logs, plots and tables.
+9. **Loop or Exit** – the user may evaluate another model or quit, at which
    point temporary cache files are cleaned automatically.
 
 ## Quick Start

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -227,8 +227,9 @@ def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
 def _cached_cmb(key):
     """Return unlensed CAMB spectra for a given parameter key.
 
-    The cache key contains the model name, cosmology parameters rounded to three
-    decimals, the maximum multipole ``lmax`` and the requested spectra.
+    The cache key contains the model name, cosmology parameters rounded to six
+    significant digits using ``float(f"{float(v):.6g}")``, the maximum
+    multipole ``lmax`` and the requested spectra.
     """
     _, param_tuple, lmax, spectra = key
     param_dict = dict(param_tuple)
@@ -270,7 +271,9 @@ def compute_cmb_spectrum_from_dict(param_dict, ells, spectra=("TT",)):
     """
     logger = logging.getLogger()
     try:
-        key_tuple = tuple((k, round(float(v), 3)) for k, v in sorted(param_dict.items()))
+        key_tuple = tuple(
+            (k, float(f"{float(v):.6g}")) for k, v in sorted(param_dict.items())
+        )
         lmax = int(np.max(ells))
         cache_key = ("dict", key_tuple, lmax, tuple(sorted(spectra)))
         full = _cached_cmb(cache_key)

--- a/engines/cosmo_engine_numba.py
+++ b/engines/cosmo_engine_numba.py
@@ -1,0 +1,7 @@
+"""Placeholder Numba engine.
+
+This stub provides compatibility for older imports. It simply re-exports
+all CPU-based routines from :mod:`cosmo_engine_1_4b`.
+"""
+
+from .cosmo_engine_1_4b import *  # noqa: F401,F403

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,6 +71,12 @@ class FunctionalTestCase(unittest.TestCase):
         self.assertIn('chi2_total', result)
         self.assertTrue(np.isfinite(result['chi2_total']))
 
+    def test_chi_squared_cmb_planck2018lite(self):
+        cmb_df = data_loaders.load_cmb_data('planck2018lite_v1')
+        params = self.plugin.INITIAL_GUESSES
+        chi2 = engine_comb.chi_squared_cmb(params, cmb_df, self.plugin)
+        self.assertTrue(np.isfinite(chi2))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- use six-digit formatting for CMB cache key generation
- document updated caching approach
- test chi_squared_cmb with Planck2018lite
- add stub numba engine so tests run

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_686bf1a8c5d8832fb490df712cdc6050