### PR TITLE
Fix CMB extras and bump to 1.11.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.2**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.3**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.
@@ -18,7 +18,7 @@ sources. Parsers reside alongside their data. Results are saved under
 The default engine is `engines/cosmo_engine_1_4b.py`. All model plugins are validated
 through `copernican_lib/engine_interface.py` before being passed to the engine. This
 ensures the expected functions are present and callable. Starting with
-version 1.11.2 the test suite no longer runs automatically. Execute
+version 1.11.3 the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify that
 the reference LCDM model and data parsers operate correctly. The `--run-tests`
 flag now uses Python's built-in discovery to gather all tests from the `tests`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.11.3
+- 2025-07-07: Fixed missing extra CMB parameters in run_cmb_analysis and bumped version (AI assistant)
+
 ## Version 1.11.2
 - 2025-07-07: Moved chi-squared helpers to chi2_helper module and updated docs (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.11.2
+**Version:** 1.11.3
 **Last Updated:** 2025-07-07
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
@@ -56,8 +56,9 @@ Under the hood the program follows a clear pipeline:
 5. **BAO Analysis** – BAO observables are computed using the fitted
    parameters (from the combined fit if that engine was selected) and
    chi-squared statistics are reported.
-6. **CMB Analysis** – similarly, CMB power spectra are generated and the
-   chi-squared contribution is calculated.
+6. **CMB Analysis** – CMB power spectra are generated using the fitted
+   cosmological parameters **and** any extra CMB-specific values from a
+   combined optimisation. The chi-squared contribution is then calculated.
 7. **Spectra Caching** – unlensed CAMB spectra are cached using parameter
    keys rounded to six significant digits.
 8. **Output Generation** – `copernican_lib/logger.py`, `copernican_lib/plotter.py` and `copernican_lib/csv_writer.py` handle logs, plots and tables.

--- a/copernican.py
+++ b/copernican.py
@@ -28,7 +28,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.11.2"
+COPERNICAN_VERSION = "1.11.3"
 
 # The high-level workflow is broken into small helper functions below. Each
 # helper is documented in plain language so non-programmers can follow the
@@ -406,7 +406,7 @@ def main_workflow():
                 
             return {'sne_fit_results': sne_fit_results, 'pred_df': pred_df, 'rs_Mpc': rs_Mpc, 'chi2_bao': chi2_bao, 'smooth_predictions': smooth_preds}
 
-        def run_cmb_analysis(cmb_df, model_plugin, cosmo_params):
+        def run_cmb_analysis(cmb_df, model_plugin, cosmo_params, cmb_extras=None):
             """Run CMB analysis for a given model."""
             # Skip the CMB step entirely when the model declares it is invalid
             # for such data. This prevents misleading chi-squared calculations
@@ -424,6 +424,11 @@ def main_workflow():
             # Convert the fitted cosmological parameters to CAMB's expected
             # dictionary format using the helper provided by the model plugin.
             camb_params = model_plugin.get_camb_params(cosmo_params)
+            # Append any additional CMB parameters recovered from a combined
+            # fit so that the theoretical spectrum reflects the actual
+            # optimisation result instead of falling back to defaults.
+            if cmb_extras:
+                camb_params.update(cmb_extras)
 
             components = ["TT"]
             if "Dl_te_obs" in cmb_df.columns:
@@ -432,12 +437,15 @@ def main_workflow():
                 components.append("EE")
 
             theory = cosmo_engine_selected.compute_cmb_spectrum(
-                camb_params, cmb_df['ell'].values, spectra=tuple(components)
+                camb_params,
+                cmb_df['ell'].values,
+                spectra=tuple(components),
             )
             chi2_val = cosmo_engine_selected.chi_squared_cmb(
                 cosmo_params,
                 cmb_df,
                 model_plugin,
+                cmb_extras,
             )
             logger.info(f"{model_plugin.MODEL_NAME} CMB chi2 = {chi2_val:.2f}")
             return {'chi2_cmb': chi2_val, 'theory_spectrum': theory}
@@ -451,11 +459,13 @@ def main_workflow():
             cmb_data_df,
             lcdm,
             list(lcdm_sne_fit_results['fitted_cosmological_params'].values()),
+            lcdm_sne_fit_results.get('fitted_cmb_params'),
         )
         alt_cmb = run_cmb_analysis(
             cmb_data_df,
             alt_model_plugin,
             list(alt_model_sne_fit_results['fitted_cosmological_params'].values()),
+            alt_model_sne_fit_results.get('fitted_cmb_params'),
         )
 
         logger.info("\n--- Stage 5: Generating Outputs ---")

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.11.2.  The `copernican_lib` package now collects all
+version 1.11.3.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.


### PR DESCRIPTION
## Summary
- fix run_cmb_analysis so additional CMB fit parameters are used
- bump version to 1.11.3 across docs and code
- document that combined optimisation parameters are used for CMB

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_686c59074614832f86b93921eeee73fd