### PR TITLE
Fix CMB fit instability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.3**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.4**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.
@@ -18,7 +18,7 @@ sources. Parsers reside alongside their data. Results are saved under
 The default engine is `engines/cosmo_engine_1_4b.py`. All model plugins are validated
 through `copernican_lib/engine_interface.py` before being passed to the engine. This
 ensures the expected functions are present and callable. Starting with
-version 1.11.3 the test suite no longer runs automatically. Execute
+version 1.11.4 the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify that
 the reference LCDM model and data parsers operate correctly. The `--run-tests`
 flag now uses Python's built-in discovery to gather all tests from the `tests`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.11.4
+- 2025-07-08: Adaptive optimizer step sizes to fit CMB parameters reliably (AI assistant)
+
 ## Version 1.11.3
 - 2025-07-07: Fixed missing extra CMB parameters in run_cmb_analysis and bumped version (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.11.3
-**Last Updated:** 2025-07-07
+**Version:** 1.11.4
+**Last Updated:** 2025-07-08
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO) and Cosmic Microwave Background (CMB) data.
@@ -254,6 +254,10 @@ Python interpreter. Model JSON files are validated with `jsonschema` only in the
 main process; child processes simply read the sanitized cache.
 All engines import progress helpers from `copernican_lib/optim_utils.py` so that
 evaluation counting and reporting remain consistent across backends.
+As of version 1.11.4 the optimizer automatically scales its finite
+difference step sizes relative to each parameter value. This prevents
+instabilities when fitting small quantities such as the CMB amplitude
+`A_s`.
 
 New models are described entirely by JSON. Copy an existing file from `models/`
 and consult `cosmo_model_guide.json` for the full schema. Additional engines may

--- a/copernican_lib/optim_utils.py
+++ b/copernican_lib/optim_utils.py
@@ -87,6 +87,11 @@ def minimize_with_progress(
         return val if np.isfinite(val) else 1e12
 
     result = None
+    if options is None:
+        options = {}
+    if 'eps' not in options:
+        eps = np.maximum(1e-8, np.abs(x0) * 1e-4)
+        options['eps'] = eps
     try:
         result = minimize(
             wrapped,
@@ -94,7 +99,7 @@ def minimize_with_progress(
             args=args,
             method=method,
             bounds=bounds,
-            options=options or {},
+            options=options,
         )
     except Exception as exc:  # pragma: no cover - hard to trigger in tests
         logger.error(f"Exception during {label.lower()} minimize call: {exc}", exc_info=True)


### PR DESCRIPTION
## Summary
- tune optimizer step size based on parameter scale
- document new behaviour
- bump version to 1.11.4

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_686cd6d49870832fb73f7352d8d360fa