### PR TITLE
v1.11.4: CMB-consistent BAO scaling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.3**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.4**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.11.4
+- 2025-07-08: BAO calculations now use CAMB to derive the sound horizon when a CMB parameter map is available (AI assistant)
+
 ## Version 1.11.3
 - 2025-07-07: Fixed missing extra CMB parameters in run_cmb_analysis and bumped version (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.11.3
+**Version:** 1.11.4
 **Last Updated:** 2025-07-07
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
@@ -151,7 +151,9 @@ See `cosmo_model_guide.json` for a detailed template.
    parameters. This enables BAO and distance-based predictions.
 4. Optionally provide an `rs_expression` for the sound horizon at recombination
    or include the parameters `Ob`, `Og` and `z_recomb`. The suite will then
-   derive `r_s` automatically using a numerical integral.
+   derive `r_s` automatically using a numerical integral. When a model also
+   defines a `cmb.param_map` the BAO module evaluates `r_s` through CAMB so the
+   same physics is used for both BAO and CMB predictions.
 5. Expressions may include `Integral(...)` terms. These are evaluated
    numerically with SciPy's `quad` when the model is loaded.
 6. Parameter initial guesses are calculated automatically as the midpoint of

--- a/copernican_lib/chi2_helper.py
+++ b/copernican_lib/chi2_helper.py
@@ -8,6 +8,7 @@ NumPy, CAMB and the engine interface.
 """
 
 import logging
+from functools import lru_cache
 from typing import Sequence, Iterable, Optional, Dict
 
 import numpy as np
@@ -168,6 +169,52 @@ def chi_squared_bao(
         return np.inf
 
     return total if np.isfinite(total) else np.inf
+
+
+@lru_cache(maxsize=64)
+def compute_rs_camb(param_key: tuple) -> float:
+    """Return the sound horizon at the baryon drag epoch using CAMB.
+
+    This helper mirrors CAMB's internal calculation so BAO scaling
+    uses the same physics as the CMB spectrum generation. The parameter
+    dictionary accepts the standard CAMB keys ``H0``, ``ombh2`` and
+    ``omch2``. Optional values such as ``tau``, ``As`` and ``ns`` are
+    ignored. If CAMB fails the function returns ``np.nan``.
+    """
+
+    logger = logging.getLogger()
+    try:
+        param_dict = dict(param_key)
+        params = camb.CAMBparams()
+        params.set_cosmology(
+            H0=float(param_dict.get("H0", 67.0)),
+            ombh2=float(param_dict.get("ombh2", 0.02237)),
+            omch2=float(param_dict.get("omch2", 0.12)),
+            tau=float(param_dict.get("tau", 0.054)),
+        )
+        params.omnuh2 = float(param_dict.get("omnuh2", 0.0))
+        params.set_for_lmax(10)
+        results = camb.get_results(params)
+        return float(results.get_derived_params()["rdrag"])
+    except Exception as exc:
+        logger.error(f"(compute_rs_camb): CAMB failed: {exc}")
+        return np.nan
+
+
+def compute_rs_from_plugin(plugin, cosmo_params) -> float:
+    """Return ``r_s`` using ``plugin.get_camb_params`` if available."""
+
+    if plugin is None or not hasattr(plugin, "get_camb_params"):
+        return np.nan
+    try:
+        camb_params = plugin.get_camb_params(cosmo_params)
+    except Exception as exc:
+        logging.getLogger().error(
+            f"(compute_rs_from_plugin): failed to map parameters: {exc}"
+        )
+        return np.nan
+    key = tuple((k, float(f"{float(v):.6g}")) for k, v in sorted(camb_params.items()))
+    return compute_rs_camb(key)
 
 
 def compute_cmb_spectrum(

--- a/engines/cosmo_engine_1_4b.py
+++ b/engines/cosmo_engine_1_4b.py
@@ -19,6 +19,7 @@ from copernican_lib.chi2_helper import (
     chi_squared_bao,
     chi_squared_cmb,
     compute_cmb_spectrum,
+    compute_rs_from_plugin,
 )
 
 
@@ -118,9 +119,14 @@ def calculate_bao_observables(bao_data_df, model_plugin, cosmo_params, z_smooth=
     logger.info(f"Calculating BAO observables for {model_name} with parameters: [{param_str}]")
 
     try:
-        model_rs_Mpc = model_plugin.get_sound_horizon_rs_Mpc(*cosmo_params)
+        if getattr(model_plugin, "valid_for_cmb", True) and hasattr(model_plugin, "get_camb_params"):
+            model_rs_Mpc = compute_rs_from_plugin(model_plugin, cosmo_params)
+        else:
+            model_rs_Mpc = model_plugin.get_sound_horizon_rs_Mpc(*cosmo_params)
         if not (np.isfinite(model_rs_Mpc) and model_rs_Mpc > 0):
-            logger.warning(f"Model '{model_name}' returned invalid r_s ({model_rs_Mpc:.3f} Mpc). BAO calculations will be NaN.")
+            logger.warning(
+                f"Model '{model_name}' returned invalid r_s ({model_rs_Mpc:.3f} Mpc). BAO calculations will be NaN."
+            )
             return bao_pred_df, np.nan, None
     except Exception as e:
         logger.error(f"Failed to calculate r_s for model '{model_name}': {e}", exc_info=True)

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -24,6 +24,7 @@ from copernican_lib.chi2_helper import (
     chi_squared_bao,
     chi_squared_cmb,
     compute_cmb_spectrum,
+    compute_rs_from_plugin,
 )
 
 
@@ -197,7 +198,10 @@ def chi_squared_combined(
         chi2_total += chi_squared_sne(cosmo_params, plugin.distance_modulus_model, sne_df)
 
     if bao_df is not None and getattr(plugin, "valid_for_bao", True):
-        rs_val = plugin.get_sound_horizon_rs_Mpc(*cosmo_params)
+        if getattr(plugin, "valid_for_cmb", True) and hasattr(plugin, "get_camb_params"):
+            rs_val = compute_rs_from_plugin(plugin, cosmo_params)
+        else:
+            rs_val = plugin.get_sound_horizon_rs_Mpc(*cosmo_params)
         chi2_total += chi_squared_bao(bao_df, plugin, cosmo_params, rs_val)
 
     if cmb_df is not None and getattr(plugin, "valid_for_cmb", True):
@@ -360,7 +364,10 @@ def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin)
     chi2_bao = np.nan
     if bao_data_df is not None and getattr(model_plugin, 'valid_for_bao', True):
         cosmo_subset = final_params[:num_cosmo_params]
-        rs_val = model_plugin.get_sound_horizon_rs_Mpc(*cosmo_subset)
+        if getattr(model_plugin, 'valid_for_cmb', True) and hasattr(model_plugin, 'get_camb_params'):
+            rs_val = compute_rs_from_plugin(model_plugin, cosmo_subset)
+        else:
+            rs_val = model_plugin.get_sound_horizon_rs_Mpc(*cosmo_subset)
         chi2_bao = chi_squared_bao(bao_data_df, model_plugin, cosmo_subset, rs_val)
     chi2_cmb = np.nan
     if cmb_data_df is not None and getattr(model_plugin, 'valid_for_cmb', True):
@@ -434,9 +441,14 @@ def calculate_bao_observables(bao_data_df, model_plugin, cosmo_params, z_smooth=
     logger.info(f"Calculating BAO observables for {model_name} with parameters: [{param_str}]")
 
     try:
-        model_rs_Mpc = model_plugin.get_sound_horizon_rs_Mpc(*cosmo_params)
+        if getattr(model_plugin, "valid_for_cmb", True) and hasattr(model_plugin, "get_camb_params"):
+            model_rs_Mpc = compute_rs_from_plugin(model_plugin, cosmo_params)
+        else:
+            model_rs_Mpc = model_plugin.get_sound_horizon_rs_Mpc(*cosmo_params)
         if not (np.isfinite(model_rs_Mpc) and model_rs_Mpc > 0):
-            logger.warning(f"Model '{model_name}' returned invalid r_s ({model_rs_Mpc:.3f} Mpc). BAO calculations will be NaN.")
+            logger.warning(
+                f"Model '{model_name}' returned invalid r_s ({model_rs_Mpc:.3f} Mpc). BAO calculations will be NaN."
+            )
             return bao_pred_df, np.nan, None
     except Exception as e:
         logger.error(f"Failed to calculate r_s for model '{model_name}': {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- derive BAO sound horizon via CAMB when CMB parameters are available
- cache CAMB r_s results for speed
- document new behaviour and bump docs to version 1.11.4

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_686ce0be4678832faca525d317484a8b