### PR TITLE
Bump to 1.11.4 and enable LaTeX model expressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.3**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.4**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.
@@ -18,7 +18,7 @@ sources. Parsers reside alongside their data. Results are saved under
 The default engine is `engines/cosmo_engine_1_4b.py`. All model plugins are validated
 through `copernican_lib/engine_interface.py` before being passed to the engine. This
 ensures the expected functions are present and callable. Starting with
-version 1.11.3 the test suite no longer runs automatically. Execute
+version 1.11.4 the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify that
 the reference LCDM model and data parsers operate correctly. The `--run-tests`
 flag now uses Python's built-in discovery to gather all tests from the `tests`
@@ -67,6 +67,7 @@ file. Markdown files may mirror the JSON for readability, but models are
 distributed only as JSON. No permanent Python plugins exist in the repository.
 Models are automatically discovered
 by scanning for `cosmo_model_*.json` files in the `models/` directory.
+All expressions inside these JSON files must be written in LaTeX math form; raw Python code is not permitted.
 
 ### 4.1 JSON Model File
 The schema requires `model_name`, `version`, `parameters`, `equations`, `abstract` and `description`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.11.4
+- 2025-07-08: Expressions in all cosmo_model JSON files converted to LaTeX and parser updated (AI assistant)
+
 ## Version 1.11.3
 - 2025-07-07: Fixed missing extra CMB parameters in run_cmb_analysis and bumped version (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.11.3
+**Version:** 1.11.4
 **Last Updated:** 2025-07-07
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
@@ -147,16 +147,17 @@ See `cosmo_model_guide.json` for a detailed template.
    your theory.
 2. *(Optional)* Create `cosmo_model_name.md` if you want a human-friendly
    summary of the same content. The suite does not read this file.
-3. Include an `Hz_expression` string defining `H(z)` in terms of your model
-   parameters. This enables BAO and distance-based predictions.
-4. Optionally provide an `rs_expression` for the sound horizon at recombination
-   or include the parameters `Ob`, `Og` and `z_recomb`. The suite will then
+3. Include an `Hz_expression` written in LaTeX math form defining `H(z)` using
+   your model parameters. This enables BAO and distance-based predictions.
+4. Optionally provide an `rs_expression` in LaTeX for the sound horizon at
+ recombination or include the parameters `Ob`, `Og` and `z_recomb`. The suite will then
    derive `r_s` automatically using a numerical integral.
-5. Expressions may include `Integral(...)` terms. These are evaluated
+5. Python code must never appear in `cosmo_model_*.json`; all expressions are written in LaTeX.
+6. Expressions may include `Integral(...)` terms. These are evaluated
    numerically with SciPy's `quad` when the model is loaded.
-6. Parameter initial guesses are calculated automatically as the midpoint of
+7. Parameter initial guesses are calculated automatically as the midpoint of
    each parameter's bounds.
-7. `latex_name` values do not require `$` delimiters. Plots automatically wrap
+8. `latex_name` values do not require `$` delimiters. Plots automatically wrap
    parameter names in math mode.
 The suite validates the JSON, stores a sanitized copy under `models/cache/`, and
 auto-generates the necessary Python functions.
@@ -172,8 +173,8 @@ The required top-level keys are `model_name`, `version`, `parameters`,
     {"name": "H0", "python_var": "H0", "bounds": [50, 100], "latex_name": "H_0"},
     {"name": "Omega_m0", "python_var": "Om0", "bounds": [0.1, 0.5], "latex_name": "\\Omega_{m0}"}
   ],
-  "Hz_expression": "H0 * sympy.sqrt(Om0*(1+z)**3 + Ol0)",
-  "rs_expression": "custom_expression",
+  "Hz_expression": "$$H(z) = H_0 * \\sqrt{Om0*(1+z)^3 + Ol0}$$",
+ "rs_expression": "$$r_s = custom\_expression$$",
   "equations": {
     "sne": [
       "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
@@ -222,7 +223,7 @@ shows cosmic-variance and observational uncertainty bands.
 cache. This allows the domain-specific JSON language to evolve while remaining
 compatible with older models.
 `model_parser.py` validates this structure and `model_coder.py` translates the
-equations into NumPy-ready callables. When `Hz_expression` is present it is
+LaTeX expressions into NumPy-ready callables. When `Hz_expression` is present it is
 compiled into `get_Hz_per_Mpc` and related distance functions used by
 `engine_interface.py`. If an `rs_expression` or the parameters `Ob`, `Og` and
 `z_recomb` are provided, a callable `get_sound_horizon_rs_Mpc` is also generated.

--- a/copernican.py
+++ b/copernican.py
@@ -28,7 +28,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.11.3"
+COPERNICAN_VERSION = "1.11.4"
 
 # The high-level workflow is broken into small helper functions below. Each
 # helper is documented in plain language so non-programmers can follow the

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -5,6 +5,7 @@
 # NumPy-friendly functions.
 
 import json
+import re
 from pathlib import Path
 import sympy as sp
 import numpy as np
@@ -27,6 +28,53 @@ class QuadPrinter(NumPyPrinter):
         b_code = self._print(b)
         integrand_code = self._print(integrand)
         return f"quad(lambda {var_code}: {integrand_code}, {a_code}, {b_code})[0]"
+
+
+def _latex_to_sympy_str(expr: str) -> str:
+    """Convert a LaTeX-style expression to a SymPy-friendly string."""
+    expr = expr.strip()
+    if expr.startswith("$$") and expr.endswith("$$"):
+        expr = expr[2:-2]
+    if "=" in expr:
+        expr = expr.split("=", 1)[1]
+
+    replacements = [
+        (r"\\left", ""),
+        (r"\\right", ""),
+        (r"\\Omega_{m0}", "Omega_m0"),
+        (r"\\Omega_{b0}", "Omega_b0"),
+        (r"\\Omega_{r0}", "Omega_r0"),
+        (r"\\alpha", "alpha"),
+        (r"\\beta", "beta"),
+        (r"\\gamma", "gamma"),
+        (r"\\omega", "omega"),
+        (r"\\phi", "phi"),
+        (r"\\tau", "tau"),
+    ]
+    for pat, repl in replacements:
+        expr = re.sub(pat, repl, expr)
+
+    func_replacements = {
+        r"\\log": "log",
+        r"\\ln": "log",
+        r"\\exp": "exp",
+        r"\\sin": "sin",
+        r"\\cos": "cos",
+        r"\\tan": "tan",
+        r"\\sqrt": "sqrt",
+    }
+    for pat, repl in func_replacements.items():
+        expr = re.sub(pat, repl, expr)
+
+    while "\\frac" in expr:
+        expr = re.sub(r"\\frac\{([^{}]+)\}\{([^{}]+)\}", r"(\1)/(\2)", expr)
+
+    expr = re.sub(r"_{([^{}]+)}", r"_\1", expr)
+    expr = re.sub(r"\^\{([^{}]+)\}", r"**(\1)", expr)
+    expr = re.sub(r"\^([\w\.]+)", r"**\1", expr)
+    expr = expr.replace("\\", "")
+    expr = expr.replace("{", "(").replace("}", ")")
+    return expr.strip()
 
 
 def _compile_sympy_expr(sym_expr, args):
@@ -75,7 +123,8 @@ def generate_callables(cache_path):
     hz_expr_str = model_data.get('Hz_expression')
     if hz_expr_str:
         try:
-            hz_sym = sp.sympify(hz_expr_str, locals=local_dict)
+            parsed_hz = _latex_to_sympy_str(hz_expr_str)
+            hz_sym = sp.sympify(parsed_hz, locals=local_dict)
             used_syms = {str(s) for s in hz_sym.free_symbols if s != z}
             param_names = {p['python_var'] for p in model_data['parameters']}
             missing = used_syms - param_names
@@ -142,7 +191,8 @@ def generate_callables(cache_path):
 
             if rs_expr_str:
                 try:
-                    rs_sym = sp.sympify(rs_expr_str, locals=local_dict)
+                    parsed_rs = _latex_to_sympy_str(rs_expr_str)
+                    rs_sym = sp.sympify(parsed_rs, locals=local_dict)
                     used = {str(s) for s in rs_sym.free_symbols} - {'z'}
                     missing_rs = used - param_names
                     if missing_rs:

--- a/cosmo_model_guide.json
+++ b/cosmo_model_guide.json
@@ -5,8 +5,8 @@
   "requirements": "Every cosmo_model JSON must include these top-level keys: model_name (string), version (string), description (string), abstract (string), parameters (array), equations (object). If you supply r_s, include rs_expression (string) and set predicts_bao to true. Models that support CMB predictions must provide a cmb.param_map describing how variables map to CAMB parameters. Set valid_for_cmb to false when a CMB spectrum is unavailable.",
   "parameter_definition": "The parameters array contains objects with these fields: name (human-readable string), python_var (valid Python identifier), bounds ([min, max]), and optional unit (string) and latex_name (string).  All symbols used in Hz_expression and rs_expression must be declared here.  To define a fixed constant (e.g. c), give identical bounds. Parameter latex_name values are automatically wrapped in math mode when displayed.",
   "expressions": {
-    "Hz_expression": "A Python-syntax string for H(z), referencing only declared parameters and the variable z.  Use numeric operations and functions exp(), cos(), log(), sqrt().  Do not use Python lists or comments.",
-    "rs_expression": "A Python-syntax string for the sound horizon r_s at drag epoch.  It may reference only declared parameters (no z).  If omitted or if predicts_bao=false, BAO predictions are disabled."
+    "Hz_expression": "A LaTeX math expression for H(z). Include explicit * for multiplication and use only declared parameters and z.",
+    "rs_expression": "A LaTeX expression for the sound horizon r_s. Reference only declared parameters (no z). If omitted or predicts_bao=false, BAO predictions are disabled."
   },
   "display_equations": {
     "sne": [
@@ -46,7 +46,7 @@
         "latex_name": "\\Omega_{m0}"
       }
     ],
-    "Hz_expression": "H0 * sqrt(Omega_m0*(1+z)**3 + /* additional model terms */)",
+    "Hz_expression": "$$H(z) = H_0 * \\sqrt{\\Omega_{m0}*(1+z)^3 + /* additional model terms */}$$",
     "equations": {
       "sne": [
         "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.11.3.  The `copernican_lib` package now collects all
+version 1.11.4.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.

--- a/models/cosmo_model_cfsc.json
+++ b/models/cosmo_model_cfsc.json
@@ -3,7 +3,7 @@
   "version": "1.0",
   "description": "Conformal Stationary Field Cosmology (CSFC) is a static-universe model in which the observed redshift of light and the apparent cosmic distances arise entirely from photons interacting with a universal, stationary field—there is no spatial expansion and no dark energy or dark matter.  In CSFC, the field imparts a red-shift “rate” that combines:  (1) a small effective matter mimic \n   M_eff·(1+z)^3 (recovering Newton’s law at low redshift),  (2) simple linear and quadratic z-terms L·z + D·z^2 (further matching low-z gravity tests), and (3) two damped oscillatory modes A₁e^{–α₁z}cos(ω₁z+φ₀₁) and A₂e^{–α₂z}cos(ω₂z+φ₀₂) that reproduce the subtle wiggles seen in supernova brightness.  The same interaction also sets the BAO scale via a drag-epoch sound horizon r_s(z_drag)=rs0[1 + B·z_drag·e^{–γz_drag} + C·log(1+z_drag)], allowing a precise fit to galaxy-clustering distances.  Twelve free parameters are simultaneously optimized to match both Type Ia supernova Hubble diagrams and BAO distance ratios, all while preserving the Newtonian limit at z≪1 and doing away with any notion of cosmic expansion or unseen dark components.",
   "abstract": "CSFC replaces the Big Bang and cosmic expansion with a permanent conformal field that redshifts photons as they travel.  The effective redshift rate H_eff(z)=H₀√[M_eff(1+z)^3 + 1 + L·z + D·z^2 + A₁e^{–α₁z}cos(ω₁z+φ₀₁) + A₂e^{–α₂z}cos(ω₂z+φ₀₂)] smoothly recovers Newtonian dynamics at low z and adds two damped waves to capture supernova residuals.  The baryon acoustic scale emerges from a hybrid sound horizon r_s(z_drag)=r_{s0}[1 + B·z_drag·e^{–γz_drag} + C·ln(1+z_drag)], giving the necessary freedom to fit galaxy-clustering distances without any expansion.  CSFC thus unifies supernova and BAO observations in a single, timeless framework free of dark matter and dark energy.",
-  "Hz_expression": "H0 * sqrt(M_eff*(1+z)**3 + 1 + L*z + D*z**2 + A1*exp(-alpha1*z)*cos(omega1*z + phi01) + A2*exp(-alpha2*z)*cos(omega2*z + phi02))",
+  "Hz_expression": "$$H(z) = H0 * \\sqrt{M_eff*(1+z)^3 + 1 + L*z + D*z^2 + A1*\\exp(-alpha1*z)*\\cos(omega1*z + phi01) + A2*\\exp(-alpha2*z)*\\cos(omega2*z + phi02)}$$",
   "parameters": [
     { "name": "Hubble-scale rate",     "python_var": "H0",       "bounds": [50,  80],    "unit": "km/s/Mpc", "latex_name": "H_0"          },
     { "name": "Linear redshift term",  "python_var": "L",        "bounds": [-1,  1],    "unit": "",           "latex_name": "L"            },
@@ -35,7 +35,7 @@
       "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
     ]
   },
-  "rs_expression": "rs0*(1 + B*z_recomb*exp(-gamma*z_recomb) + C*log(1+z_recomb))",
+  "rs_expression": "$$r_s = rs0*(1 + B*z_recomb*\\exp(-gamma*z_recomb) + C*\\log(1+z_recomb))$$",
   "predicts_bao": true,
   "valid_for_cmb": false
 }

--- a/models/cosmo_model_cpc.json
+++ b/models/cosmo_model_cpc.json
@@ -75,7 +75,7 @@
       "latex_name": "c"
     }
   ],
-  "Hz_expression": "H0 * sqrt(Omega_m0*(1+z)**3 + Omega_r0*(1+z)**4 + beta*(1+z)**(-n))",
+  "Hz_expression": "$$H(z) = H0 * \\sqrt{\\Omega_{m0}*(1+z)^3 + \\Omega_{r0}*(1+z)^4 + \\beta*(1+z)^{-n}}$$",
   "equations": {
     "sne": [
       "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
@@ -87,6 +87,6 @@
       "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
     ]
   },
-  "rs_expression": "rs0",
+  "rs_expression": "$$r_s = rs0$$",
   "predicts_bao": true
 }

--- a/models/cosmo_model_lcdm.json
+++ b/models/cosmo_model_lcdm.json
@@ -54,7 +54,7 @@
       ]
     }
   ],
-  "Hz_expression": "H0*sympy.sqrt(Omega_m0*(1+z)**3 + (1 - Omega_m0))",
+  "Hz_expression": "$$H(z) = H0 * \\sqrt{\\Omega_{m0}*(1+z)^3 + (1 - \\Omega_{m0})}$$",
   "equations": {
     "sne": [
       "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
@@ -66,7 +66,7 @@
       "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
     ]
   },
-  "rs_expression": "44.5*sympy.log(9.83/(Omega_m0*(H0/100)**2))/sympy.sqrt(1 + 10*(Omega_b0*(H0/100)**2)**0.75)",
+  "rs_expression": "$$r_s = 44.5 * \\ln\\left(\\frac{9.83}{\\Omega_{m0}*(H0/100)^2}\\right) / \\sqrt{1 + 10*(\\Omega_{b0}*(H0/100)^2)^{0.75}}$$",
   "predicts_bao": true,
   "valid_for_cmb": true,
   "cmb": {

--- a/models/cosmo_model_qauc.json
+++ b/models/cosmo_model_qauc.json
@@ -2,7 +2,7 @@
   "model_name": "QuantumAttractorUnifiedCosmology",
   "version": "1.0",
   "description": "Quantum Attractor Unified Cosmology (QAUC) enhances ΛCDM with a scalar–tensor attractor whose exponential envelope and sinusoidal modulation alter the dark-energy sector. Ordinary matter and radiation follow their standard evolution while the oscillating dark-energy wave hints at a link between acceleration and quantum topology.",
-  "Hz_expression": "H0 * sqrt(Omega_m0*(1+z)**3 + Omega_r0*(1+z)**4 + (1 - Omega_m0 - Omega_r0)*(1 + A*exp(-alpha*z)*cos(omega*z + phi0)))",
+  "Hz_expression": "$$H(z) = H0 * \\sqrt{\\Omega_{m0}*(1+z)^3 + \\Omega_{r0}*(1+z)^4 + (1 - \\Omega_{m0} - \\Omega_{r0})*(1 + A*\\exp(-alpha*z)*\\cos(omega*z + phi0))}$$",
   "parameters": [
     {
       "name": "Hubble constant",
@@ -93,7 +93,7 @@
       "$$D_V(z) = \\bigl[D_M(z)^2 \\tfrac{c\\,z}{H(z)}\\bigr]^{1/3}$$"
     ]
   },
-  "rs_expression": "rs",
+  "rs_expression": "$$r_s = rs$$",
   "predicts_bao": true,
   "valid_for_cmb": true,
   "cmb": {

--- a/models/cosmo_model_usmf2.json
+++ b/models/cosmo_model_usmf2.json
@@ -83,7 +83,7 @@
       "bounds": [1000, 1200]
     }
   ],
-  "Hz_expression": "H_A*(1+z)",
+  "Hz_expression": "$$H(z) = H_A*(1+z)$$",
   "equations": {
     "sne": [
       "$$1+z = \\frac{\\alpha(t_e)}{\\alpha(t_0)}$$",


### PR DESCRIPTION
## Summary
- convert Hz_expression and rs_expression in all models to LaTeX
- allow model_coder to parse LaTeX strings
- document that model JSONs never contain Python code
- bump version to 1.11.4 in docs and code

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_686ce7d07d10832fbd567fdf2c6111be