### PR TITLE
Lower Python requirement to 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Add one line for each substantive commit or pull request directly under the late
 
 ## Version 1.11.5
 - 2025-07-08: Added SNe pre-fit step to combined engine to improve convergence and updated documentation (AI assistant)
+- 2025-07-08: Updated minimum Python version to 3.12 and synced README (AI assistant)
 
 ## Version 1.11.3
 - 2025-07-07: Fixed missing extra CMB parameters in run_cmb_analysis and bumped version (AI assistant)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Under the hood the program follows a clear pipeline:
    point temporary cache files are cleaned automatically.
 
 ## Quick Start
-1. Ensure Python 3.13.1 or later is available. The suite requires `numpy`, `scipy`,
+1. Ensure Python 3.12 or later is available. The suite requires `numpy`, `scipy`,
    `matplotlib`, `pandas`, `sympy` and `jsonschema`. If any package is
    missing the program will print the command to install them.
 2. Run `python3 copernican.py` and follow the prompts to choose a model,
@@ -78,7 +78,7 @@ Under the hood the program follows a clear pipeline:
    completes.
 
 ## Dependencies
-This project requires **Python 3.13.1 or later** and relies on `numpy`, `scipy`, `matplotlib`,
+This project requires **Python 3.12 or later** and relies on `numpy`, `scipy`, `matplotlib`,
 `pandas`, `sympy`, `jsonschema` and `camb`. If any of these are missing the dependency check
 will print the full installation command `pip install numpy scipy matplotlib pandas sympy jsonschema camb`.
 Future engines may also depend on `numba` or GPU libraries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Evaluate cosmological models using observational data."
 dynamic = ["version"]
 authors = [{name = "Copernican Developers"}]
 license = {file = "LICENSE.md"}
-requires-python = ">=3.13.1"
+requires-python = ">=3.12"
 dependencies = [
     "numpy",
     "scipy",


### PR DESCRIPTION
## Summary
- require Python >=3.12 in `pyproject.toml`
- update Quick Start and Dependencies sections in the README
- document Python version change

## Testing
- `python3 copernican.py --run-tests`

------
https://chatgpt.com/codex/tasks/task_e_686d8b2dfb78832f9e5499c1531e3b63