### PR TITLE
Add runtime interpreter check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Add one line for each substantive commit or pull request directly under the late
 ## Version 1.11.5
 - 2025-07-08: Added SNe pre-fit step to combined engine to improve convergence and updated documentation (AI assistant)
 - 2025-07-08: Updated minimum Python version to 3.12 and synced README (AI assistant)
+- 2025-07-08: Added runtime check for Python version and documented exit behavior (AI assistant)
 
 ## Version 1.11.3
 - 2025-07-07: Fixed missing extra CMB parameters in run_cmb_analysis and bumped version (AI assistant)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Under the hood the program follows a clear pipeline:
 ## Quick Start
 1. Ensure Python 3.12 or later is available. The suite requires `numpy`, `scipy`,
    `matplotlib`, `pandas`, `sympy` and `jsonschema`. If any package is
-   missing the program will print the command to install them.
+   missing the program will print the command to install them. If you attempt
+   to run the suite with an older interpreter the launcher now prints an error
+   and exits immediately.
 2. Run `python3 copernican.py` and follow the prompts to choose a model,
    preferred data sources and computation engine.
 3. Execute `python3 copernican.py --run-tests` or run `python -m unittest discover`
@@ -81,6 +83,7 @@ Under the hood the program follows a clear pipeline:
 This project requires **Python 3.12 or later** and relies on `numpy`, `scipy`, `matplotlib`,
 `pandas`, `sympy`, `jsonschema` and `camb`. If any of these are missing the dependency check
 will print the full installation command `pip install numpy scipy matplotlib pandas sympy jsonschema camb`.
+Running under an older Python version will result in an immediate error and exit code 1.
 Future engines may also depend on `numba` or GPU libraries.
  
 ## Building & Installation

--- a/copernican.py
+++ b/copernican.py
@@ -14,6 +14,15 @@ import subprocess
 import time
 import argparse
 
+# Verify interpreter version early so users see clear feedback
+MIN_PYTHON = (3, 12)
+if sys.version_info < MIN_PYTHON:
+    print(
+        f"ERROR: Copernican Suite requires Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]} or later.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
 # Delay heavy third-party imports until after the dependency check
 np = None
 plt = None


### PR DESCRIPTION
## Summary
- enforce minimum Python 3.12 at startup
- document interpreter version check in README
- log the change in the changelog

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_686d8cd7c4fc832fac3a81c202bc0207