### PR TITLE
Improve SNe dataset naming and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.7**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.8**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.11.8
+- 2025-07-09: Added official JLA and Pantheon+ dataset names and short identifiers (AI assistant)
+- 2025-07-09: Simplified plot footers and updated documentation (AI assistant)
+
 ## Version 1.11.7
 - 2025-07-09: Renamed Pantheon+ files and made parser auto-detect dataset names (AI assistant)
 - 2025-07-09: Moved chi-squared helpers back into the engine and removed chi2_helper module (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.11.7
+**Version:** 1.11.8
 **Last Updated:** 2025-07-09
 
 The Copernican Suite is a Python toolkit for testing cosmological models against

--- a/copernican.py
+++ b/copernican.py
@@ -37,7 +37,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.11.7"
+COPERNICAN_VERSION = "1.11.8"
 
 # The high-level workflow is broken into small helper functions below. Each
 # helper is documented in plain language so non-programmers can follow the

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -223,11 +223,8 @@ def plot_hubble_diagram(
     )
 
     footer = (
-        f"\u039bCDM against {alt_model_plugin.MODEL_NAME} "
-        f"{alt_model_plugin.MODEL_FILENAME}, {dataset_name}, "
-        f"{sne_data_df.attrs.get('source_key')}, "
-        f"created with Copernican Suite {COPERNICAN_VERSION}, "
-        f"{get_timestamp()}"
+        f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | {dataset_name} | "
+        f"Copernican Suite {COPERNICAN_VERSION} | {get_timestamp()}"
     )
     fig.text(0.5, 0.02, footer, ha="center", fontsize=font_sizes["ticks"])
 
@@ -363,11 +360,8 @@ def plot_bao_observables(
     )
 
     footer = (
-        f"\u039bCDM against {alt_model_plugin.MODEL_NAME} "
-        f"{alt_model_plugin.MODEL_FILENAME}, {dataset_name}, "
-        f"{sne_data_df.attrs.get('source_key')}, "
-        f"created with Copernican Suite {COPERNICAN_VERSION}, "
-        f"{get_timestamp()}"
+        f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | {dataset_name} | "
+        f"Copernican Suite {COPERNICAN_VERSION} | {get_timestamp()}"
     )
     fig.text(0.5, 0.02, footer, ha="center", fontsize=font_sizes["ticks"])
 
@@ -612,10 +606,8 @@ def plot_cmb_spectrum(
     )
 
     footer = (
-        f"\u039bCDM against {alt_model_plugin.MODEL_NAME} "
-        f"{alt_model_plugin.MODEL_FILENAME}, {dataset_name}, "
-        f"created with Copernican Suite {COPERNICAN_VERSION}, "
-        f"{get_timestamp()}"
+        f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | {dataset_name} | "
+        f"Copernican Suite {COPERNICAN_VERSION} | {get_timestamp()}"
     )
     fig.text(0.5, 0.02, footer, ha="center", fontsize=font_sizes["ticks"])
 

--- a/data/sne/pantheon/cosmo_parser_pantheon.py
+++ b/data/sne/pantheon/cosmo_parser_pantheon.py
@@ -1,5 +1,5 @@
 
-"""Parser for the Pantheon+ supernova sample."""
+"""Parser for the Pantheon+SH0ES 2022 supernova sample."""
 
 import os
 import pandas as pd
@@ -10,8 +10,8 @@ from copernican_lib.data_loaders import register_sne_parser
 
 
 @register_sne_parser(
-    "Pantheon+ dataset (distance modulus with covariance; SALT2 fixed)",
-    "Distance moduli using the published covariance matrix and fixed SALT2 parameters.",
+    "Pantheon+ 2022 (Scolnic et al.)",
+    "Pantheon+SH0ES supernova distances with the full covariance matrix.",
     data_dir=os.path.dirname(__file__),
 )
 def parse_pantheon_plus(data_dir, **kwargs):
@@ -87,6 +87,7 @@ def parse_pantheon_plus(data_dir, **kwargs):
             logger.warning("Could not invert Pantheon+ covariance matrix. Chi2 will fallback to diagonal errors.")
             output_df.attrs['covariance_matrix_inv'] = None
             output_df.attrs['diag_errors_for_plot'] = output_df['e_mu_obs'].values
+        output_df.attrs['dataset_name_attr'] = 'PantheonPlus2022'
         return output_df
     except Exception as e:
         logger.error(f"Error processing Pantheon+ data: {e}", exc_info=True); return None

--- a/data/sne/unistra/cosmo_parser_h1_unistra.py
+++ b/data/sne/unistra/cosmo_parser_h1_unistra.py
@@ -1,5 +1,5 @@
 
-"""Parser for the University of Strasbourg SNe dataset."""
+"""Parser for the JLA supernova sample (Betoule et al. 2014)."""
 
 import os
 import pandas as pd
@@ -12,8 +12,10 @@ DEFAULT_SALT2_ALPHA_FIXED = 0.14
 DEFAULT_SALT2_BETA_FIXED = 3.1
 
 @register_sne_parser(
-    "University of Strasbourg dataset (distance modulus, diagonal errors; SALT2 fixed)",
-    "Distance moduli computed from SALT2-corrected magnitudes. No covariance matrix.",
+    "JLA Betoule+2014 (UniStra)",
+    "Joint SDSS-II and SNLS sample from Betoule et al. 2014, University of Strasbourg."
+    " Light-curve parameters are converted to distance moduli with fixed SALT2"
+    " nuisance parameters.",
     data_dir=os.path.dirname(__file__),
 )
 def parse_unistra_standard(data_dir, salt2_m_abs_fixed=DEFAULT_SALT2_M_ABS_FIXED,
@@ -67,4 +69,5 @@ def parse_unistra_standard(data_dir, salt2_m_abs_fixed=DEFAULT_SALT2_M_ABS_FIXED
     parsed_data_filtered.attrs['salt2_m_abs_fixed'] = salt2_m_abs_fixed
     parsed_data_filtered.attrs['salt2_alpha_fixed'] = salt2_alpha_fixed
     parsed_data_filtered.attrs['salt2_beta_fixed'] = salt2_beta_fixed
+    parsed_data_filtered.attrs['dataset_name_attr'] = 'UniStra2014'
     return parsed_data_filtered

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -14,3 +14,13 @@ data/
 Each subdirectory contains one or more dataset sources. A Python file named `cosmo_parser_*.py` lives inside each source folder and registers a parser function via decorators from `copernican_lib.data_loaders`.
 
 The parsers convert raw text or binary files into Pandas DataFrames with metadata stored on the `.attrs` property. These files remain read-only so that reference data is never overwritten.
+
+## Supernovae Datasets
+
+### JLA Betoule+2014 (UniStra)
+*Source:* "Improved cosmological constraints from a joint analysis of the SDSS-II and SNLS supernova samples" (Betoule et al. 2014) hosted by the Centre de Données astronomiques de Strasbourg.
+*Parser:* `cosmo_parser_h1_unistra.py` reads `tablef3.dat` and reconstructs distance moduli using fixed SALT2 nuisance parameters. Covariance matrices in `tablef4.fit` are currently ignored.
+
+### Pantheon+ 2022 (Scolnic et al.)
+*Source:* Pantheon+SH0ES data release (Scolnic et al. 2022).
+*Parser:* `cosmo_parser_pantheon.py` loads `Pantheon+SH0ES.dat` together with its full covariance matrix. The inverse covariance is stored on the returned DataFrame.

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.11.7.  The `copernican_lib` package now collects all
+version 1.11.8.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,7 +26,7 @@ class FunctionalTestCase(unittest.TestCase):
         self.assertTrue(hasattr(self.plugin, 'distance_modulus_model'))
 
     def test_engine_routines(self):
-        sne_df = data_loaders.load_sne_data('University of Strasbourg dataset (distance modulus, diagonal errors; SALT2 fixed)')
+        sne_df = data_loaders.load_sne_data('JLA Betoule+2014 (UniStra)')
         self.assertIsNotNone(sne_df)
         sne_df = sne_df.head(3)
 
@@ -59,7 +59,7 @@ class FunctionalTestCase(unittest.TestCase):
         self.assertEqual(len(spec["TT"]), len(cmb_df))
 
     def test_combined_fit(self):
-        sne_df = data_loaders.load_sne_data('University of Strasbourg dataset (distance modulus, diagonal errors; SALT2 fixed)').head(2)
+        sne_df = data_loaders.load_sne_data('JLA Betoule+2014 (UniStra)').head(2)
         bao_df = data_loaders.load_bao_data('Basic BAO testing dataset').head(2)
         cmb_df = data_loaders.load_cmb_data('planck2018lite_v1')
         cmb_df = cmb_df.head(10)


### PR DESCRIPTION
## Summary
- rename UniStra and Pantheon+ parsers with proper attributions
- set short dataset identifiers for file names
- streamline plot footers
- document datasets in `docs/data_overview.md`
- bump version to 1.11.8

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_686e4c70bd8c832facc0079a8501fd5f