### PR TITLE
Fix CAMB import errors on systems without pip-installed modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.8**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.9**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.11.9
+- 2025-07-09: Added runtime CAMB import check to avoid illegal instruction crashes (AI assistant)
+- 2025-07-09: Documented that CAMB must be installed with pip in the same environment (AI assistant)
+
 ## Version 1.11.8
 - 2025-07-09: Added official JLA and Pantheon+ dataset names and short identifiers (AI assistant)
 - 2025-07-09: Simplified plot footers and updated documentation (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.11.8
+**Version:** 1.11.9
 **Last Updated:** 2025-07-09
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
@@ -73,6 +73,11 @@ Under the hood the program follows a clear pipeline:
    missing the program will print the command to install them. If you attempt
    to run the suite with an older interpreter the launcher now prints an error
    and exits immediately.
+  The launcher also verifies that the optional `camb` library can be imported
+  in a subprocess. If this check fails (often due to missing CPU features) the
+  program will advise reinstalling CAMB from source and exit cleanly. Ensure
+  CAMB is installed using `pip` in the same environment; tools like `pipx` will
+  install it elsewhere and the suite will not find it.
 2. Run `python3 copernican.py` and follow the prompts to choose a model,
    preferred data sources and computation engine.
 3. Execute `python3 copernican.py --run-tests` or run `python -m unittest discover`
@@ -85,6 +90,12 @@ Under the hood the program follows a clear pipeline:
 This project requires **Python 3.12 or later** and relies on `numpy`, `scipy`, `matplotlib`,
 `pandas`, `sympy`, `jsonschema` and `camb`. If any of these are missing the dependency check
 will print the full installation command `pip install numpy scipy matplotlib pandas sympy jsonschema camb`.
+On some older CPUs the precompiled CAMB wheel may trigger an `Illegal instruction`
+error. The program now detects this case and advises reinstalling CAMB using
+`pip install --no-binary=:all: camb`.
+Make sure CAMB is installed in the **same Python environment** that runs the suite;
+using `pipx` places it in a separate virtual environment which the program cannot
+see.
 Running under an older Python version will result in an immediate error and exit code 1.
 Future engines may also depend on `numba` or GPU libraries.
  

--- a/copernican.py
+++ b/copernican.py
@@ -37,7 +37,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.11.8"
+COPERNICAN_VERSION = "1.11.9"
 
 # The high-level workflow is broken into small helper functions below. Each
 # helper is documented in plain language so non-programmers can follow the

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.11.8.  The `copernican_lib` package now collects all
+version 1.11.9.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -11,12 +11,46 @@ correlations are treated consistently.
 
 import numpy as np
 from scipy.linalg import LinAlgError
-import camb
 from functools import lru_cache
+import subprocess
 import sys
 import logging
 from copernican_lib import engine_interface
 from copernican_lib.optim_utils import minimize_with_progress
+
+camb = None
+
+
+def _ensure_camb():
+    """Safely import CAMB or raise a helpful error message."""
+    global camb
+    if camb is not None:
+        return camb
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", "import camb"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            if "No module named" in result.stderr:
+                raise RuntimeError(
+                    "CAMB is not installed in this Python environment. "
+                    "Install it with 'pip install camb' (avoid pipx)."
+                )
+            raise RuntimeError(
+                "CAMB failed to import. The wheel may require CPU features "
+                "not supported on this system. Reinstall from source using "
+                "'pip install --no-binary=:all: camb'."
+            )
+
+        import camb as _camb
+        camb = _camb
+    except Exception as exc:  # pragma: no cover - platform specific
+        raise RuntimeError(f"CAMB not available: {exc}") from exc
+
+    return camb
 
 
 # ==============================================================================
@@ -152,6 +186,7 @@ def _cached_cmb(key):
     significant digits using ``float(f"{float(v):.6g}")``, the maximum
     multipole ``lmax`` and the requested spectra.
     """
+    _ensure_camb()
     _, param_tuple, lmax, spectra = key
     param_dict = dict(param_tuple)
     params = camb.CAMBparams()
@@ -191,6 +226,7 @@ def compute_cmb_spectrum_from_dict(param_dict, ells, spectra=("TT",)):
         Spectra to return (``"TT"``, ``"TE"`` and/or ``"EE"``).
     """
     logger = logging.getLogger()
+    _ensure_camb()
     try:
         key_tuple = tuple(
             (k, float(f"{float(v):.6g}")) for k, v in sorted(param_dict.items())
@@ -224,6 +260,7 @@ def compute_cmb_spectrum_cached(plugin, cosmo_params, ells, spectra=("TT",)):
         Spectra to return (``"TT"``, ``"TE"`` and/or ``"EE"``).
     """
     logger = logging.getLogger()
+    _ensure_camb()
     try:
         camb_params = plugin.get_camb_params(cosmo_params)
     except Exception as exc:
@@ -235,6 +272,7 @@ def compute_cmb_spectrum_cached(plugin, cosmo_params, ells, spectra=("TT",)):
 
 def compute_cmb_spectrum(param_dict, ells, spectra=("TT",)):
     """Backward compatible wrapper expecting a CAMB parameter dictionary."""
+    _ensure_camb()
     dummy = type(
         "_Dummy", (), {"MODEL_NAME": "direct", "get_camb_params": lambda self, _: param_dict}
     )()
@@ -244,6 +282,7 @@ def compute_cmb_spectrum(param_dict, ells, spectra=("TT",)):
 def chi_squared_cmb(cosmo_params, cmb_data_df, plugin, extra_params=None):
     """Calculate chi-squared for CMB data using full covariance."""
     logger = logging.getLogger()
+    _ensure_camb()
     if cmb_data_df is None or cmb_data_df.empty:
         logger.error("(chi2_cmb): CMB data is empty.")
         return np.inf


### PR DESCRIPTION
## Summary
- refine CAMB import routine to detect missing package vs incompatible wheel
- explain that CAMB must be installed with pip in the active environment
- document the clarification in the changelog

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_686e7f730630832f806851ac8933af6d