### PR TITLE
Add auto venv setup and cross-platform launchers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.8**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.11.9**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.11.9
+- 2025-07-10: Automatic virtual environment setup and start scripts for Windows, macOS and Linux. Cancelling a run now removes its log file (AI assistant)
+
 ## Version 1.11.8
 - 2025-07-09: Added official JLA and Pantheon+ dataset names and short identifiers (AI assistant)
 - 2025-07-09: Simplified plot footers and updated documentation (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.11.8
-**Last Updated:** 2025-07-09
+**Version:** 1.11.9
+**Last Updated:** 2025-07-10
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO) and Cosmic Microwave Background (CMB) data.
@@ -68,13 +68,14 @@ Under the hood the program follows a clear pipeline:
    point temporary cache files are cleaned automatically.
 
 ## Quick Start
-1. Ensure Python 3.12 or later is available. The suite requires `numpy`, `scipy`,
-   `matplotlib`, `pandas`, `sympy` and `jsonschema`. If any package is
-   missing the program will print the command to install them. If you attempt
-   to run the suite with an older interpreter the launcher now prints an error
-   and exits immediately.
-2. Run `python3 copernican.py` and follow the prompts to choose a model,
-   preferred data sources and computation engine.
+1. Ensure Python 3.12 or later is available. Launch the suite via the `start`
+   script for your platform (`start.command`, `start.bat` or `start.sh`). On the
+   first run the program will create a local virtual environment and install all
+   required packages if they are missing. You may be prompted for your password
+   during this step. Running with an older Python version will print an error
+   and exit immediately.
+2. Follow the interactive prompts to choose a model, preferred data sources and
+   computation engine.
 3. Execute `python3 copernican.py --run-tests` or run `python -m unittest discover`
    to verify the reference model and parsers. The `--run-tests` flag now leverages
    unittest discovery to gather all modules under `tests/`.
@@ -83,10 +84,10 @@ Under the hood the program follows a clear pipeline:
 
 ## Dependencies
 This project requires **Python 3.12 or later** and relies on `numpy`, `scipy`, `matplotlib`,
-`pandas`, `sympy`, `jsonschema` and `camb`. If any of these are missing the dependency check
-will print the full installation command `pip install numpy scipy matplotlib pandas sympy jsonschema camb`.
-Running under an older Python version will result in an immediate error and exit code 1.
-Future engines may also depend on `numba` or GPU libraries.
+`pandas`, `sympy`, `jsonschema` and `camb`. Missing packages are installed automatically
+into the local virtual environment on first launch. Running under an older Python version
+results in an immediate error and exit code 1. Future engines may also depend on `numba`
+or GPU libraries.
  
 ## Building & Installation
 Run `pip install .` from the repository root to build and install the `copernican` command. Use `pip install -e .` for editable installs.

--- a/copernican.py
+++ b/copernican.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import time
 import argparse
+from getpass import getpass
 
 # Verify interpreter version early so users see clear feedback
 MIN_PYTHON = (3, 12)
@@ -37,7 +38,27 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.11.8"
+COPERNICAN_VERSION = "1.11.9"
+
+# Local virtual environment used when dependencies are missing
+VENV_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'venv')
+CURRENT_LOG_FILE = None
+
+
+def _venv_bin(name: str) -> str:
+    """Return the path to a binary inside the virtual environment."""
+    folder = 'Scripts' if os.name == 'nt' else 'bin'
+    return os.path.join(VENV_DIR, folder, name)
+
+
+def _delete_log_file(path: str) -> None:
+    """Remove the given log file if it exists."""
+    if path and os.path.isfile(path):
+        try:
+            os.remove(path)
+            print(f"Removed log file {path}")
+        except OSError:
+            pass
 
 # The high-level workflow is broken into small helper functions below. Each
 # helper is documented in plain language so non-programmers can follow the
@@ -134,22 +155,32 @@ def _gather_required_packages():
 
 
 def check_dependencies():
-    """Ensure all required packages are installed."""
-    # Before importing heavy third-party libraries we verify that everything
-    # needed by the project is available.  If something is missing the user is
-    # shown the exact ``pip install`` command to resolve it and the program
-    # exits early.
+    """Ensure all required packages are installed and activate venv if needed."""
     print("--- Running System Dependency Check ---")
     required = sorted(_gather_required_packages())
     missing = [pkg for pkg in required if importlib.util.find_spec(pkg) is None]
+
+    inside_venv = os.environ.get('COPERNICAN_VENV_ACTIVE') == '1'
+
     if missing:
-        print(f"Missing packages detected: {', '.join(missing)}")
-        print(
-            "To install all project dependencies, run:\n"
-            f"  pip install {' '.join(required)}\n"
-        )
-        sys.exit(1)
+        if not inside_venv:
+            print(f"Missing packages detected: {', '.join(missing)}")
+            print("Installing into local virtual environment. You may be asked for your password.")
+            if not os.path.isdir(VENV_DIR):
+                subprocess.check_call([sys.executable, '-m', 'venv', VENV_DIR])
+            pip_exe = _venv_bin('pip')
+            subprocess.check_call([pip_exe, 'install', *required])
+            python_exe = _venv_bin('python')
+            os.environ['COPERNICAN_VENV_ACTIVE'] = '1'
+            os.execv(python_exe, [python_exe] + sys.argv)
+        else:
+            print("Dependency installation failed inside virtual environment.")
+            sys.exit(1)
     else:
+        if not inside_venv and os.path.isdir(VENV_DIR):
+            python_exe = _venv_bin('python')
+            os.environ['COPERNICAN_VENV_ACTIVE'] = '1'
+            os.execv(python_exe, [python_exe] + sys.argv)
         print("✅ System Dependency Check Passed. Continuing...\n")
 
 
@@ -299,7 +330,9 @@ def main_workflow():
     engine_interface.validate_plugin(lcdm)
 
     while True:
+        global CURRENT_LOG_FILE
         log_file = log_mod.setup_logging(log_dir=OUTPUT_DIR)
+        CURRENT_LOG_FILE = log_file
         logger = log_mod.get_logger()
         start_ts = time.strftime("%y%m%d_%H%M%S")
         logger.info(
@@ -318,7 +351,9 @@ def main_workflow():
         ])
         selected_model = select_from_list(model_files, 'Select cosmological model')
         if not selected_model:
-            break
+            _delete_log_file(log_file)
+            cleanup_cache(SCRIPT_DIR)
+            return
         if selected_model.endswith('.json'):
             json_path = os.path.join(models_dir, selected_model)
             cache_dir = os.path.join(models_dir, 'cache')
@@ -355,7 +390,9 @@ def main_workflow():
         engine_files = sorted([f for f in os.listdir(engines_dir) if f.startswith('cosmo_engine_') and f.endswith('.py')])
         engine_choice = select_from_list(engine_files, 'Select computation engine')
         if not engine_choice:
-            break
+            _delete_log_file(log_file)
+            cleanup_cache(SCRIPT_DIR)
+            return
         engine_module = importlib.import_module(f"engines.{engine_choice[:-3]}")
         cosmo_engine_selected = engine_module
 

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.11.8.  The `copernican_lib` package now collects all
+version 1.11.9.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,9 @@
+
+@echo off
+
+REM Launch the Copernican Suite on Windows
+
+cd %~dp0
+
+python copernican.py %*
+

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Launch the Copernican Suite on Linux
+cd "$(dirname "$0")"
+exec python3 copernican.py "$@"


### PR DESCRIPTION
## Summary
- implement automatic dependency installation into a local virtual environment
- remove log file when user cancels a run
- provide `start.sh` and `start.bat` launchers alongside existing macOS script
- bump version to 1.11.9 and update documentation

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f92ce1364832f838d84112423afaf