### PR TITLE
Implement unified timestamp and clean console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.12.3
+- 2025-07-13: Unified timestamp handling and console output format updated (AI assistant)
+
 ## Version 1.12.2
 - 2025-07-10: Unified dataset metadata files and expanded plot footers (AI assistant)
 - 2025-07-10: Fixed file name sanitization for Planck dataset (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.12.2
+**Version:** 1.12.3
 **Last Updated:** 2025-07-10
 
 The Copernican Suite is a Python toolkit for testing cosmological models against

--- a/copernican.py
+++ b/copernican.py
@@ -12,6 +12,7 @@ import platform
 import shutil
 import subprocess
 import time
+import datetime
 import argparse
 from getpass import getpass
 
@@ -38,7 +39,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.12.2"
+COPERNICAN_VERSION = "1.12.3"
 
 # Local virtual environment used when dependencies are missing
 VENV_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'venv')
@@ -59,6 +60,30 @@ def _delete_log_file(path: str) -> None:
             print(f"Removed log file {path}")
         except OSError:
             pass
+
+def _get_cpu_info() -> tuple[str, str]:
+    """Return CPU model and current clock speed."""
+    cpu = platform.processor() or platform.uname().processor or "Unknown CPU"
+    freq = None
+    try:
+        import psutil  # type: ignore
+        freq_info = psutil.cpu_freq()
+        if freq_info:
+            freq = freq_info.current / 1000.0
+    except Exception:
+        pass
+    if freq is None and platform.system() == "Linux":
+        try:
+            with open("/proc/cpuinfo", "r") as fh:
+                for line in fh:
+                    if line.startswith("model name") and cpu == "Unknown CPU":
+                        cpu = line.split(":", 1)[1].strip()
+                    if line.startswith("cpu MHz") and freq is None:
+                        freq = float(line.split(":", 1)[1]) / 1000.0
+        except Exception:
+            pass
+    freq_str = f"{freq:.2f} GHz" if freq else "Unknown GHz"
+    return cpu, freq_str
 
 # The high-level workflow is broken into small helper functions below. Each
 # helper is documented in plain language so non-programmers can follow the
@@ -335,6 +360,8 @@ def main_workflow():
         CURRENT_LOG_FILE = log_file
         logger = log_mod.get_logger()
         start_ts = time.strftime("%y%m%d_%H%M%S")
+        run_start_dt = datetime.datetime.now()
+        run_start_pc = time.perf_counter()
         logger.info(
             f"Copernican {COPERNICAN_VERSION} has initialized! Current timestamp is {start_ts}. Log file: {log_file}"
         )
@@ -408,18 +435,28 @@ def main_workflow():
         if cmb_data_df is None:
             continue
 
+        lcdm_time = 0.0
+        alt_time = 0.0
         if hasattr(cosmo_engine_selected, 'fit_combined_parameters'):
             logger.info("\n--- Stage 2: Combined Fit (SNe + BAO + CMB) ---")
+            t0 = time.perf_counter()
             lcdm_sne_fit_results = cosmo_engine_selected.fit_combined_parameters(
                 sne_data_df, bao_data_df, cmb_data_df, lcdm
             )
+            lcdm_time += time.perf_counter() - t0
+            t0 = time.perf_counter()
             alt_model_sne_fit_results = cosmo_engine_selected.fit_combined_parameters(
                 sne_data_df, bao_data_df, cmb_data_df, alt_model_plugin
             )
+            alt_time += time.perf_counter() - t0
         else:
             logger.info("\n--- Stage 2: Supernovae Ia Fitting ---")
+            t0 = time.perf_counter()
             lcdm_sne_fit_results = cosmo_engine_selected.fit_sne_parameters(sne_data_df, lcdm)
+            lcdm_time += time.perf_counter() - t0
+            t0 = time.perf_counter()
             alt_model_sne_fit_results = cosmo_engine_selected.fit_sne_parameters(sne_data_df, alt_model_plugin)
+            alt_time += time.perf_counter() - t0
         
         logger.info("\n--- Stage 3: BAO Analysis ---")
         
@@ -496,27 +533,39 @@ def main_workflow():
             logger.info(f"{model_plugin.MODEL_NAME} CMB chi2 = {chi2_val:.2f}")
             return {'chi2_cmb': chi2_val, 'theory_spectrum': theory}
 
+        t0 = time.perf_counter()
         lcdm_full_results = run_bao_analysis(lcdm, lcdm_sne_fit_results, z_plot_smooth)
+        lcdm_time += time.perf_counter() - t0
+        t0 = time.perf_counter()
         alt_model_full_results = run_bao_analysis(alt_model_plugin, alt_model_sne_fit_results, z_plot_smooth)
+        alt_time += time.perf_counter() - t0
 
         logger.info("\n--- Stage 4: CMB Analysis ---")
 
+        t0 = time.perf_counter()
         lcdm_cmb = run_cmb_analysis(
             cmb_data_df,
             lcdm,
             list(lcdm_sne_fit_results['fitted_cosmological_params'].values()),
             lcdm_sne_fit_results.get('fitted_cmb_params'),
         )
+        lcdm_time += time.perf_counter() - t0
+        t0 = time.perf_counter()
         alt_cmb = run_cmb_analysis(
             cmb_data_df,
             alt_model_plugin,
             list(alt_model_sne_fit_results['fitted_cosmological_params'].values()),
             alt_model_sne_fit_results.get('fitted_cmb_params'),
         )
+        alt_time += time.perf_counter() - t0
 
         logger.info("\n--- Stage 5: Generating Outputs ---")
         logger.info(f"{lcdm.MODEL_NAME} CMB chi2 = {lcdm_cmb['chi2_cmb']:.2f}")
         logger.info(f"{alt_model_plugin.MODEL_NAME} CMB chi2 = {alt_cmb['chi2_cmb']:.2f}")
+
+        run_end_dt = datetime.datetime.now()
+        end_ts = run_end_dt.strftime("%Y%m%d_%H%M%S")
+
         plotter.plot_hubble_diagram(
             sne_data_df,
             lcdm_sne_fit_results,
@@ -524,6 +573,7 @@ def main_workflow():
             lcdm,
             alt_model_plugin,
             plot_dir=OUTPUT_DIR,
+            timestamp=end_ts,
         )
         if bao_data_df is not None:
             plotter.plot_bao_observables(
@@ -534,6 +584,7 @@ def main_workflow():
                 alt_model_plugin,
                 sne_data_df,
                 plot_dir=OUTPUT_DIR,
+                timestamp=end_ts,
             )
         if cmb_data_df is not None:
             plotter.plot_cmb_spectrum(
@@ -545,6 +596,7 @@ def main_workflow():
                 lcdm,
                 alt_model_plugin,
                 plot_dir=OUTPUT_DIR,
+                timestamp=end_ts,
             )
 
         print("\n--- Final Theory Summaries ---")
@@ -576,6 +628,7 @@ def main_workflow():
             lcdm,
             alt_model_plugin,
             csv_dir=OUTPUT_DIR,
+            timestamp=end_ts,
         )
         
         if bao_data_df is not None:
@@ -585,6 +638,7 @@ def main_workflow():
                 alt_model_full_results,
                 alt_model_name=alt_model_plugin.MODEL_NAME,
                 csv_dir=OUTPUT_DIR,
+                timestamp=end_ts,
             )
         if cmb_data_df is not None:
             csv_writer.save_cmb_results_csv(
@@ -593,14 +647,26 @@ def main_workflow():
                 alt_cmb,
                 alt_model_name=alt_model_plugin.MODEL_NAME,
                 csv_dir=OUTPUT_DIR,
+                timestamp=end_ts,
             )
 
         print("\n" + "="*50)
         print("Evaluation complete. All files saved to the 'output' directory.")
         print("="*50 + "\n")
 
-        end_ts = time.strftime("%y%m%d_%H%M%S")
+        total_time = time.perf_counter() - run_start_pc
+        cpu_model, cpu_freq = _get_cpu_info()
+        os_info = platform.platform()
+
         logger.info(f"Run completed at {end_ts}.")
+
+        print(f"Run started on {run_start_dt.strftime('%Y-%m-%d %H:%M:%S')}")
+        print(f"Run ended on {run_end_dt.strftime('%Y-%m-%d %H:%M:%S')}")
+        print(
+            f"Run took {lcdm_time:.2f}s for LCDM and {alt_time:.2f}s for {alt_model_plugin.MODEL_NAME}, "
+            f"or {total_time:.2f}s in total, on a system with a {cpu_model} {cpu_freq}, "
+            f"under {os_info}"
+        )
 
         while True:
             another_run = input("Would you like to run another evaluation? (yes/no): ").strip().lower()

--- a/copernican_lib/csv_writer.py
+++ b/copernican_lib/csv_writer.py
@@ -18,6 +18,7 @@ def save_sne_results_detailed_csv(
     lcdm_plugin: Any,
     alt_model_plugin: Any,
     csv_dir: str = ".",
+    timestamp: str | None = None,
 ) -> None:
     """Save a detailed, point-by-point breakdown of the SNe Ia fitting results."""
     ensure_dir_exists(csv_dir)
@@ -50,7 +51,13 @@ def save_sne_results_detailed_csv(
 
     dataset_name = sne_data_df.attrs.get("dataset_name_attr", "SNe_data")
     model_comparison_name = f"LCDM-vs-{alt_model_name}"
-    filename = generate_filename("sne-detailed-data", dataset_name, "csv", model_name=model_comparison_name)
+    filename = generate_filename(
+        "sne-detailed-data",
+        dataset_name,
+        "csv",
+        model_name=model_comparison_name,
+        timestamp=timestamp,
+    )
     try:
         df_out.to_csv(os.path.join(csv_dir, filename), index=False, float_format="%.8g")
         logger.info(f"SNe detailed results CSV saved to {filename}")
@@ -64,6 +71,7 @@ def save_bao_results_csv(
     alt_model_results: Any,
     alt_model_name: str,
     csv_dir: str = ".",
+    timestamp: str | None = None,
 ) -> None:
     """Save a detailed breakdown of the BAO results to a CSV file."""
     ensure_dir_exists(csv_dir)
@@ -85,7 +93,13 @@ def save_bao_results_csv(
 
     dataset_name = bao_data_df.attrs.get("dataset_name_attr", "BAO_data")
     model_comparison_name = f"LCDM-vs-{alt_model_name}"
-    filename = generate_filename("bao-detailed-data", dataset_name, "csv", model_name=model_comparison_name)
+    filename = generate_filename(
+        "bao-detailed-data",
+        dataset_name,
+        "csv",
+        model_name=model_comparison_name,
+        timestamp=timestamp,
+    )
     try:
         df_out.to_csv(os.path.join(csv_dir, filename), index=False, float_format="%.6g")
         logger.info(f"BAO detailed results CSV saved to {filename}")
@@ -99,6 +113,7 @@ def save_cmb_results_csv(
     alt_model_results: Any,
     alt_model_name: str,
     csv_dir: str = ".",
+    timestamp: str | None = None,
 ) -> None:
     """Save CMB spectrum predictions and residuals to a CSV file."""
     ensure_dir_exists(csv_dir)
@@ -165,7 +180,13 @@ def save_cmb_results_csv(
 
     dataset_name = cmb_data_df.attrs.get("dataset_name_attr", "CMB_data")
     model_comparison_name = f"LCDM-vs-{alt_name_safe}"
-    filename = generate_filename("cmb-detailed-data", dataset_name, "csv", model_name=model_comparison_name)
+    filename = generate_filename(
+        "cmb-detailed-data",
+        dataset_name,
+        "csv",
+        model_name=model_comparison_name,
+        timestamp=timestamp,
+    )
     try:
         df_out.to_csv(os.path.join(csv_dir, filename), index=False, float_format="%.6g")
         logger.info(f"CMB detailed results CSV saved to {filename}")

--- a/copernican_lib/logger.py
+++ b/copernican_lib/logger.py
@@ -27,7 +27,7 @@ def setup_logging(log_dir="."):
 
     ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(logging.INFO)
-    ch.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+    ch.setFormatter(logging.Formatter('%(message)s'))
     logger.addHandler(ch)
 
     logging.info(f"Logging initialized. Log file: {log_filename}")

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -90,6 +90,7 @@ def plot_hubble_diagram(
     lcdm_plugin: Any,
     alt_model_plugin: Any,
     plot_dir: str = ".",
+    timestamp: str | None = None,
 ) -> None:
     """Generate and save a Hubble diagram and residuals plot."""
     ensure_dir_exists(plot_dir)
@@ -233,15 +234,22 @@ def plot_hubble_diagram(
         bbox=bbox_alt,
     )
 
+    ts = timestamp or get_timestamp()
     base_line = (
         f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | "
-        f"Copernican Suite {COPERNICAN_VERSION} | {get_timestamp()}"
+        f"Copernican Suite {COPERNICAN_VERSION} | {ts}"
     )
     footer = compose_footer(base_line, sne_data_df.attrs)
     fig.text(0.5, 0.02, footer, ha="center", fontsize=font_sizes["ticks"], wrap=True)
 
     model_comparison_name = f"{lcdm_plugin.MODEL_NAME}-vs-{alt_model_plugin.MODEL_NAME}"
-    filename = generate_filename("hubble-plot", dataset_name, "png", model_name=model_comparison_name)
+    filename = generate_filename(
+        "hubble-plot",
+        dataset_name,
+        "png",
+        model_name=model_comparison_name,
+        timestamp=timestamp,
+    )
     try:
         plt.savefig(os.path.join(plot_dir, filename), dpi=300)
         logger.info(f"Hubble diagram saved to {filename}")
@@ -259,6 +267,7 @@ def plot_bao_observables(
     alt_model_plugin: Any,
     sne_data_df: Any,
     plot_dir: str = ".",
+    timestamp: str | None = None,
 ) -> None:
     """Generate and save a plot of BAO observables versus redshift."""
     ensure_dir_exists(plot_dir)
@@ -371,15 +380,22 @@ def plot_bao_observables(
         bbox=bbox_alt,
     )
 
+    ts = timestamp or get_timestamp()
     base_line = (
         f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | "
-        f"Copernican Suite {COPERNICAN_VERSION} | {get_timestamp()}"
+        f"Copernican Suite {COPERNICAN_VERSION} | {ts}"
     )
     footer = compose_footer(base_line, bao_data_df.attrs)
     fig.text(0.5, 0.02, footer, ha="center", fontsize=font_sizes["ticks"], wrap=True)
 
     model_comparison_name = f"{lcdm_plugin.MODEL_NAME}-vs-{alt_model_plugin.MODEL_NAME}"
-    filename = generate_filename("bao-plot", dataset_name, "png", model_name=model_comparison_name)
+    filename = generate_filename(
+        "bao-plot",
+        dataset_name,
+        "png",
+        model_name=model_comparison_name,
+        timestamp=timestamp,
+    )
     try:
         plt.savefig(os.path.join(plot_dir, filename), dpi=300)
         logger.info(f"BAO plot saved to {filename}")
@@ -429,6 +445,7 @@ def plot_cmb_spectrum(
     lcdm_plugin: Any,
     alt_model_plugin: Any,
     plot_dir: str = ".",
+    timestamp: str | None = None,
 ) -> None:
     """Generate and save a CMB power spectrum plot with residuals."""
     ensure_dir_exists(plot_dir)
@@ -618,15 +635,22 @@ def plot_cmb_spectrum(
         bbox=bbox_alt,
     )
 
+    ts = timestamp or get_timestamp()
     base_line = (
         f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | "
-        f"Copernican Suite {COPERNICAN_VERSION} | {get_timestamp()}"
+        f"Copernican Suite {COPERNICAN_VERSION} | {ts}"
     )
     footer = compose_footer(base_line, cmb_data_df.attrs)
     fig.text(0.5, 0.02, footer, ha="center", fontsize=font_sizes["ticks"], wrap=True)
 
     model_comparison_name = f"{lcdm_plugin.MODEL_NAME}-vs-{alt_model_plugin.MODEL_NAME}"
-    filename = generate_filename("cmb-plot", dataset_name, "png", model_name=model_comparison_name)
+    filename = generate_filename(
+        "cmb-plot",
+        dataset_name,
+        "png",
+        model_name=model_comparison_name,
+        timestamp=timestamp,
+    )
     try:
         plt.savefig(os.path.join(plot_dir, filename), dpi=300)
         logger.info(f"CMB plot saved to {filename}")

--- a/copernican_lib/utils.py
+++ b/copernican_lib/utils.py
@@ -13,8 +13,23 @@ def get_timestamp():
     return time.strftime("%Y%m%d_%H%M%S")
 
 
-def generate_filename(file_type, dataset_name, ext, model_name=""):
-    """Generates a harmonized filename for all outputs."""
+def generate_filename(file_type, dataset_name, ext, model_name="", timestamp=None):
+    """Generates a harmonized filename for all outputs.
+
+    Parameters
+    ----------
+    file_type : str
+        Short descriptor of the file's contents.
+    dataset_name : str
+        Human readable dataset identifier.
+    ext : str
+        File extension without the leading period.
+    model_name : str, optional
+        Name of the cosmological model, used when comparing multiple models.
+    timestamp : str, optional
+        Timestamp string applied to the filename. When ``None`` the current
+        timestamp is generated.
+    """
     sanitized_type = file_type.replace('_', '-').lower()
     sanitized_model = model_name.replace('_', '-').replace('.', '')
     sanitized_dataset = (
@@ -24,8 +39,13 @@ def generate_filename(file_type, dataset_name, ext, model_name=""):
         .replace('.json', '')
         .replace('.dat', '')
     )
-    base_name = f"{sanitized_type}-{sanitized_model}-{sanitized_dataset}" if sanitized_model else f"{sanitized_type}-{sanitized_dataset}"
-    return f"{base_name}_{get_timestamp()}.{ext}"
+    base_name = (
+        f"{sanitized_type}-{sanitized_model}-{sanitized_dataset}"
+        if sanitized_model
+        else f"{sanitized_type}-{sanitized_dataset}"
+    )
+    ts = timestamp or get_timestamp()
+    return f"{base_name}_{ts}.{ext}"
 
 
 def ensure_dir_exists(directory):


### PR DESCRIPTION
## Summary
- remove INFO prefixes in console logs
- allow passing a timestamp into filename generation helpers
- timestamp outputs consistently at the end of a run
- summarize run timing and system info
- bump version to 1.12.3

## Testing
- `python -m unittest discover`
- `python -m py_compile copernican.py copernican_lib/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6874325f0978832f95caac18fb6e2622