### PR TITLE
Convert CAMB spectra to Dl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.12.4
+- 2025-07-15: Converted cached CMB spectra to D_\ell and added scaling test (AI assistant)
+- 2025-07-15: Fixed escape sequences in `_cached_cmb` docstring (AI assistant)
+
 ## Version 1.12.3
 - 2025-07-13: Unified timestamp handling and console output format updated (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.12.3
+**Version:** 1.12.4
 **Last Updated:** 2025-07-10
 
 The Copernican Suite is a Python toolkit for testing cosmological models against

--- a/copernican.py
+++ b/copernican.py
@@ -39,7 +39,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.12.3"
+COPERNICAN_VERSION = "1.12.4"
 
 # Local virtual environment used when dependencies are missing
 VENV_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'venv')

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.11.9.  The `copernican_lib` package now collects all
+version 1.12.4.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -146,11 +146,12 @@ def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
 
 @lru_cache(maxsize=128)
 def _cached_cmb(key):
-    """Return unlensed CAMB spectra for a given parameter key.
+    r"""Return unlensed CAMB spectra for a given parameter key.
 
     The cache key contains the model name, cosmology parameters rounded to six
     significant digits using ``float(f"{float(v):.6g}")``, the maximum
-    multipole ``lmax`` and the requested spectra.
+    multipole ``lmax`` and the requested spectra.  The returned arrays are
+    converted to :math:`D_\ell = \ell(\ell+1)C_\ell/(2\pi)`.
     """
     _, param_tuple, lmax, spectra = key
     param_dict = dict(param_tuple)
@@ -166,13 +167,15 @@ def _cached_cmb(key):
     params.set_for_lmax(lmax + 300, lens_potential_accuracy=0)
     results = camb.get_results(params)
     cls = results.get_unlensed_scalar_cls(lmax=lmax, CMB_unit="muK")
+    ells = np.arange(cls.shape[0])
+    factor = ells * (ells + 1) / (2 * np.pi)
     out = {}
     if "TT" in spectra:
-        out["TT"] = cls[:, 0]
+        out["TT"] = cls[:, 0] * factor
     if "EE" in spectra:
-        out["EE"] = cls[:, 1]
+        out["EE"] = cls[:, 1] * factor
     if "TE" in spectra:
-        out["TE"] = cls[:, 3]
+        out["TE"] = cls[:, 3] * factor
     return out
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ import unittest
 import importlib
 from pathlib import Path
 import numpy as np
+import camb
 
 from copernican_lib import model_parser, model_coder, engine_interface, data_loaders
 import engines.cosmo_engine_comb as engine
@@ -75,6 +76,36 @@ class FunctionalTestCase(unittest.TestCase):
         params = self.plugin.INITIAL_GUESSES
         chi2 = engine.chi_squared_cmb(params, cmb_df, self.plugin)
         self.assertTrue(np.isfinite(chi2))
+
+    def test_cmb_spectrum_scaling(self):
+        camb_params = self.plugin.get_camb_params(self.plugin.INITIAL_GUESSES)
+        ells = np.arange(2, 7)
+        spectra = ("TT", "TE", "EE")
+
+        engine_result = engine.compute_cmb_spectrum_from_dict(camb_params, ells, spectra=spectra)
+
+        params = camb.CAMBparams()
+        params.set_cosmology(
+            H0=camb_params["H0"],
+            ombh2=camb_params["ombh2"],
+            omch2=camb_params["omch2"],
+            tau=camb_params["tau"],
+        )
+        params.omnuh2 = camb_params.get("omnuh2", 0.0)
+        params.InitPower.set_params(As=camb_params["As"], ns=camb_params["ns"])
+        params.set_for_lmax(int(np.max(ells)) + 300, lens_potential_accuracy=0)
+        results = camb.get_results(params)
+        cls = results.get_unlensed_scalar_cls(lmax=int(np.max(ells)), CMB_unit="muK")
+        full_ells = np.arange(cls.shape[0])
+        factor = full_ells * (full_ells + 1) / (2 * np.pi)
+        expected = {
+            "TT": cls[:, 0] * factor,
+            "EE": cls[:, 1] * factor,
+            "TE": cls[:, 3] * factor,
+        }
+
+        for spec in spectra:
+            np.testing.assert_allclose(engine_result[spec], expected[spec][ells], rtol=1e-7)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- scale cached CAMB CMB spectra by ell(ell+1)/(2π)
- document Dl conversion in `_cached_cmb`
- validate Dl scaling via new unit test
- bump version to 1.12.4 and update docs
- fix docstring escape sequences

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875ee22c4c8832fa341081c5e6b81db