### PR TITLE
Introduce web-based JS demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.4**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 2.1.1**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.
@@ -14,6 +14,9 @@ being prepared. Users interact with `copernican.py`, choose a model from
 `./models/`, pick a computational engine from `./engines/` and choose data
 sources. Parsers reside alongside their data. Results are saved under
 `./output/`.
+
+An experimental browser-based interface lives in the `web/` directory. It
+leverages Pyodide to run a trimmed-down workflow entirely in WebAssembly.
 
 The default engine is `engines/cosmo_engine_comb.py`. All model plugins are validated
 through `copernican_lib/engine_interface.py` before being passed to the engine. This
@@ -34,6 +37,7 @@ output/           - Generated plots and CSV tables (created automatically)
 AGENTS.md         - Development specification and contributor rules
 CHANGELOG.md      - Release history
 copernican_lib/optim_utils.py - Shared optimisation helpers used by engines
+web/              - Experimental Pyodide-powered interface
 ```
 Files in `data/` are read-only and must not be modified by AI-driven changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Add one line for each substantive commit or pull request directly under the late
 - 2025-07-15: Updated documentation and developer guide with raw string rule (AI assistant)
 - 2025-07-15: Converted math docstrings to raw strings to silence escape warnings (AI assistant)
 
+## Version 2.1.1
+- 2025-07-15: Added experimental Pyodide-based web interface and updated documentation (AI assistant)
+- 2025-07-15: Bumped Copernican version to 2.1.1 for JS branch (AI assistant)
+
 ## Version 1.12.3
 - 2025-07-13: Unified timestamp handling and console output format updated (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-**Version:** 1.12.4
-**Last Updated:** 2025-07-10
+**Version:** 2.1.1
+**Last Updated:** 2025-07-15
 
-The Copernican Suite is a Python toolkit for testing cosmological models against
+The Copernican Suite is a Python toolkit (with an experimental WebAssembly
+front-end) for testing cosmological models against
 Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO) and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases. The suite provides a modular
 architecture so new models, data parsers and computational engines can be
@@ -88,6 +89,9 @@ Under the hood the program follows a clear pipeline:
    unittest discovery to gather all modules under `tests/`.
 4. Plots and CSV results will appear in the `output/` folder when the run
    completes.
+5. For a browser-based preview open `web/index.html` in a modern browser. This
+   interface uses Pyodide to execute a lightweight workflow entirely in
+   WebAssembly.
 
 ## Dependencies
 This project requires **Python 3.12 or later** and relies on `numpy`, `scipy`, `matplotlib`,

--- a/copernican.py
+++ b/copernican.py
@@ -39,7 +39,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.12.4"
+COPERNICAN_VERSION = "2.1.1"
 
 # Local virtual environment used when dependencies are missing
 VENV_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'venv')

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.12.4.  The `copernican_lib` package now collects all
+version 2.1.1.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.
@@ -12,6 +12,7 @@ focused on numerical work.
 /models/           - JSON model definitions
 /data/             - Observational datasets and their parsers
 /tests/            - Unit and functional tests
+/web/              - Experimental browser-based CLI powered by Pyodide
 ```
 
 `copernican.py` is the command-line entry point that orchestrates model

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,11 @@
+# Copernican Suite JS
+
+This directory contains an experimental WebAssembly build powered by
+[Pyodide](https://pyodide.org/). Open `index.html` in a browser to test a
+simplified interface. Select a `cosmo_model_*.json` file and click **Run** to
+load it. The Python code runs entirely in your browser and prints a brief
+message.
+
+Only a subset of the full Copernican Suite is available in this demo; heavy
+packages such as CAMB are not compiled yet. Results are therefore limited, but
+this proves the concept of a web-based CLI.

--- a/web/cli.js
+++ b/web/cli.js
@@ -1,0 +1,25 @@
+const version = '2.1.1';
+document.getElementById('version').textContent = version;
+let pyodideReadyPromise = loadPyodide({indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.23.4/full/'});
+
+async function runCopernican(file) {
+  const pyodide = await pyodideReadyPromise;
+  const output = document.getElementById('output');
+  output.textContent = 'Initializing Pyodide...\n';
+  await pyodide.loadPackage(['numpy']);
+  const data = await file.text();
+  pyodide.FS.writeFile('model.json', data);
+  const script = await (await fetch('copernican_web.py')).text();
+  pyodide.runPython(script);
+  const result = pyodide.runPython('run("model.json")');
+  output.textContent += result + '\n';
+}
+
+document.getElementById('runBtn').addEventListener('click', async () => {
+  const fileInput = document.getElementById('modelFile');
+  if (fileInput.files.length === 0) {
+    alert('Please select a cosmo_model_*.json file.');
+    return;
+  }
+  runCopernican(fileInput.files[0]);
+});

--- a/web/copernican_web.py
+++ b/web/copernican_web.py
@@ -1,0 +1,10 @@
+import json
+import numpy as np
+
+VERSION = '2.1.1'
+
+def run(model_path: str) -> str:
+    with open(model_path, 'r') as f:
+        model = json.load(f)
+    model_name = model.get('model_name', 'Unnamed Model')
+    return f"Copernican Suite JS {VERSION} loaded model: {model_name}\nNumpy {np.__version__} available"

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Copernican Suite JS</title>
+    <style>
+        body {font-family: Arial, sans-serif; margin: 0; padding: 0;}
+        header {background:#333; color:#fff; padding:10px;}
+        #output {width:100%; height:300px;}
+    </style>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js"></script>
+    <script type="module" src="cli.js"></script>
+</head>
+<body>
+<header>
+    <h1>Copernican Suite JS <span id="version"></span></h1>
+</header>
+<main>
+    <input type="file" id="modelFile" accept="application/json">
+    <button id="runBtn">Run</button>
+    <pre id="output"></pre>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- bump version to 2.1.1
- add experimental Pyodide interface under `web/`
- document the JS build and update the developer guide
- update README with instructions for the browser demo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68761136eab8832fbe8c98f7fbd026da