### PR TITLE
Implement web UI and logging capture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.4**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.5**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.12.5
+- 2025-07-15: Added experimental web UI and unified console logging (AI assistant)
+
 ## Version 1.12.4
 - 2025-07-15: Fixed CMB spectrum scaling bug and added Dl verification test (AI assistant)
 - 2025-07-15: Updated documentation and developer guide with raw string rule (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.12.4
+**Version:** 1.12.5
 **Last Updated:** 2025-07-10
 
 The Copernican Suite is a Python toolkit for testing cosmological models against

--- a/copernican.py
+++ b/copernican.py
@@ -356,7 +356,9 @@ def main_workflow():
 
     while True:
         global CURRENT_LOG_FILE
-        log_file = log_mod.setup_logging(log_dir=OUTPUT_DIR)
+        log_file, log_fh = log_mod.setup_logging(log_dir=OUTPUT_DIR)
+        console = log_mod.ConsoleCapture(log_fh)
+        console.start()
         CURRENT_LOG_FILE = log_file
         logger = log_mod.get_logger()
         start_ts = time.strftime("%y%m%d_%H%M%S")
@@ -379,6 +381,8 @@ def main_workflow():
         selected_model = select_from_list(model_files, 'Select cosmological model')
         if not selected_model:
             _delete_log_file(log_file)
+            console.stop()
+            log_fh.close()
             cleanup_cache(SCRIPT_DIR)
             return
         if selected_model.endswith('.json'):
@@ -418,6 +422,8 @@ def main_workflow():
         engine_choice = select_from_list(engine_files, 'Select computation engine')
         if not engine_choice:
             _delete_log_file(log_file)
+            console.stop()
+            log_fh.close()
             cleanup_cache(SCRIPT_DIR)
             return
         engine_module = importlib.import_module(f"engines.{engine_choice[:-3]}")
@@ -675,11 +681,15 @@ def main_workflow():
             elif another_run in ["no", "n", "2"]:
                 cleanup_cache(SCRIPT_DIR)
                 logger.info("Exiting Copernican Suite. Goodbye!")
+                console.stop()
+                log_fh.close()
                 return
             else:
                 print("Invalid input. Please enter 'yes' or 'no'.")
         
         cleanup_cache(SCRIPT_DIR)
+        console.stop()
+        log_fh.close()
 
 if __name__ == "__main__":
     # Multiprocessing start method must be 'spawn' so that each child process

--- a/copernican_lib/logger.py
+++ b/copernican_lib/logger.py
@@ -7,7 +7,39 @@
 import logging
 import os
 import sys
+import builtins
 from .utils import get_timestamp, ensure_dir_exists
+
+
+class ConsoleCapture:
+    """Tee stdout and user input to the active log file."""
+
+    def __init__(self, log_file_handle):
+        self.log_file = log_file_handle
+        self._orig_stdout = sys.stdout
+        self._orig_input = builtins.input
+
+    def write(self, data):
+        self.log_file.write(data)
+        self._orig_stdout.write(data)
+
+    def flush(self):
+        self.log_file.flush()
+        self._orig_stdout.flush()
+
+    def input(self, prompt=""):
+        self.write(prompt)
+        response = self._orig_input(prompt)
+        self.write(response + "\n")
+        return response
+
+    def start(self):
+        sys.stdout = self
+        builtins.input = self.input
+
+    def stop(self):
+        sys.stdout = self._orig_stdout
+        builtins.input = self._orig_input
 
 
 def setup_logging(log_dir="."):
@@ -20,18 +52,17 @@ def setup_logging(log_dir="."):
 
     log_filename = os.path.join(log_dir, f"copernican-run_{get_timestamp()}.txt")
 
-    fh = logging.FileHandler(log_filename)
-    fh.setLevel(logging.INFO)
-    fh.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
-    logger.addHandler(fh)
+    fh = open(log_filename, "w", encoding="utf-8")
 
     ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(logging.INFO)
     ch.setFormatter(logging.Formatter('%(message)s'))
     logger.addHandler(ch)
 
-    logging.info(f"Logging initialized. Log file: {log_filename}")
-    return log_filename
+    message = f"Logging initialized. Log file: {log_filename}"
+    fh.write(message + "\n")
+    logger.info(message)
+    return log_filename, fh
 
 
 def get_logger():

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.12.4.  The `copernican_lib` package now collects all
+version 1.12.5.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,51 @@
+async function fetchData(url) {
+    const resp = await fetch(url);
+    return resp.json();
+}
+
+function renderList(containerId, items, name) {
+    const div = document.getElementById(containerId);
+    items.forEach((item, idx) => {
+        const id = `${name}-${idx}`;
+        const lbl = document.createElement('label');
+        lbl.innerHTML = `<input type="radio" name="${name}" value="${item}"> ${item}`;
+        div.appendChild(lbl);
+        div.appendChild(document.createElement('br'));
+    });
+}
+
+function switchTab(evt) {
+    document.querySelectorAll('.tab').forEach(btn => btn.classList.remove('active'));
+    evt.target.classList.add('active');
+    document.querySelectorAll('.tabContent').forEach(el => el.classList.add('hidden'));
+    document.getElementById(evt.target.dataset.tab).classList.remove('hidden');
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const models = await fetchData('/api/models');
+    renderList('modelList', models, 'model');
+    const data = await fetchData('/api/datasets');
+    renderList('sneList', data.sne, 'sne');
+    renderList('baoList', data.bao, 'bao');
+    renderList('cmbList', data.cmb, 'cmb');
+
+    document.querySelectorAll('.tab').forEach(btn => btn.addEventListener('click', switchTab));
+
+    document.getElementById('runBtn').addEventListener('click', async () => {
+        const body = {
+            model: document.querySelector('input[name="model"]:checked')?.value,
+            sne: document.querySelector('input[name="sne"]:checked')?.value,
+            bao: document.querySelector('input[name="bao"]:checked')?.value,
+            cmb: document.querySelector('input[name="cmb"]:checked')?.value,
+        };
+        const file = document.getElementById('modelFile').files[0];
+        const formData = new FormData();
+        formData.append('config', JSON.stringify(body));
+        if (file) formData.append('file', file);
+
+        const resp = await fetch('/api/run', { method: 'POST', body: formData });
+        const blob = await resp.blob();
+        document.getElementById('downloadZip').href = URL.createObjectURL(blob);
+        document.getElementById('results').classList.remove('hidden');
+    });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Copernican Suite 1.12.5</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Copernican Suite 1.12.5</h1>
+    </header>
+    <main>
+        <section id="config">
+            <h2>Configuration</h2>
+            <div class="field">
+                <label for="modelFile">Upload Model JSON:</label>
+                <input type="file" id="modelFile" accept="application/json">
+            </div>
+            <div class="field">
+                <p>Select Model from server:</p>
+                <div id="modelList"></div>
+            </div>
+            <div class="field">
+                <p>Select SNe Dataset:</p>
+                <div id="sneList"></div>
+            </div>
+            <div class="field">
+                <p>Select BAO Dataset:</p>
+                <div id="baoList"></div>
+            </div>
+            <div class="field">
+                <p>Select CMB Dataset:</p>
+                <div id="cmbList"></div>
+            </div>
+            <button id="runBtn">Run Evaluation</button>
+        </section>
+        <section id="results" class="hidden">
+            <div class="tabs">
+                <button class="tab active" data-tab="console">Console</button>
+                <button class="tab" data-tab="plots">Plots</button>
+                <button class="tab" data-tab="tables">Tables</button>
+            </div>
+            <div id="console" class="tabContent"></div>
+            <div id="plots" class="tabContent hidden"></div>
+            <div id="tables" class="tabContent hidden"></div>
+            <a id="downloadZip" href="#" download>Download All Results</a>
+        </section>
+    </main>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/web/serve_web.py
+++ b/web/serve_web.py
@@ -1,0 +1,75 @@
+from flask import Flask, send_from_directory, jsonify, request, send_file
+import os
+import json
+import subprocess
+import tempfile
+import shutil
+from copernican_lib import data_loaders
+
+app = Flask(__name__, static_folder='.')
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(BASE_DIR)
+OUTPUT_DIR = os.path.join(REPO_ROOT, 'output')
+
+@app.route('/')
+def index():
+    return send_from_directory(BASE_DIR, 'index.html')
+
+@app.route('/<path:path>')
+def static_proxy(path):
+    return send_from_directory(BASE_DIR, path)
+
+@app.route('/api/models')
+def models():
+    files = [f for f in os.listdir(os.path.join(REPO_ROOT, 'models')) if f.startswith('cosmo_model_') and f.endswith('.json')]
+    return jsonify(sorted(files))
+
+@app.route('/api/datasets')
+def datasets():
+    return jsonify({
+        'sne': list(data_loaders.SNE_PARSERS.keys()),
+        'bao': list(data_loaders.BAO_PARSERS.keys()),
+        'cmb': list(data_loaders.CMB_PARSERS.keys()),
+    })
+
+@app.route('/api/run', methods=['POST'])
+def run_eval():
+    conf = json.loads(request.form.get('config', '{}'))
+    upload = request.files.get('file')
+    model_path = None
+    if upload:
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.json', dir=os.path.join(REPO_ROOT, 'models'))
+        upload.save(tmp.name)
+        model_path = os.path.basename(tmp.name)
+    else:
+        model_path = conf.get('model')
+    if not model_path:
+        return 'No model provided', 400
+
+    inputs = []
+    models = sorted([f for f in os.listdir(os.path.join(REPO_ROOT, 'models')) if f.startswith('cosmo_model_') and f.endswith('.json')])
+    inputs.append(str(models.index(model_path) + 1))
+
+    engines = sorted([f for f in os.listdir(os.path.join(REPO_ROOT, 'engines')) if f.startswith('cosmo_engine_') and f.endswith('.py')])
+    inputs.append('1')  # default engine first
+
+    for group, registry in [('sne', data_loaders.SNE_PARSERS), ('bao', data_loaders.BAO_PARSERS), ('cmb', data_loaders.CMB_PARSERS)]:
+        name = conf.get(group)
+        if name and name in registry:
+            index = list(registry.keys()).index(name) + 1
+            inputs.append(str(index))
+        else:
+            inputs.append('c')
+            return 'Invalid dataset selection', 400
+
+    inputs.append('no')
+    proc = subprocess.Popen(['python', os.path.join(REPO_ROOT, 'copernican.py')], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, cwd=REPO_ROOT)
+    proc.communicate('\n'.join(inputs) + '\n')
+    proc.wait()
+
+    zip_path = shutil.make_archive(os.path.join(BASE_DIR, 'results'), 'zip', OUTPUT_DIR)
+    return send_file(zip_path, mimetype='application/zip', as_attachment=True, download_name='results.zip')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,11 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+header { background: #1a237e; color: white; padding: 10px; }
+main { padding: 20px; }
+.field { margin-bottom: 15px; }
+button { padding: 8px 16px; background: #3949ab; color: white; border: none; cursor: pointer; }
+button:hover { background: #303f9f; }
+.tabs { margin-top: 20px; }
+.tab { margin-right: 5px; }
+.tabContent { border: 1px solid #ccc; padding: 10px; height: 300px; overflow: auto; }
+.hidden { display: none; }
+.active { background: #303f9f; }


### PR DESCRIPTION
## Summary
- add experimental Flask-based web UI under `web/`
- capture console I/O via new `ConsoleCapture` class
- update docs and version numbers for 1.12.5
- changelog entry for the new release

## Testing
- `python copernican.py --run-tests` *(fails: Python 3.12 required)*

------
https://chatgpt.com/codex/tasks/task_e_68761a0e6760832f9f237f7e79c91d3c