### PR TITLE
Expand web UI and bump version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.5**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.6**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.12.6
+- 2025-07-15: Expanded web UI with interactive result viewer and per-file downloads (AI assistant)
+
 ## Version 1.12.5
 - 2025-07-15: Added experimental web UI and unified console logging (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.12.5
-**Last Updated:** 2025-07-10
+**Version:** 1.12.6
+**Last Updated:** 2025-07-15
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO) and Cosmic Microwave Background (CMB) data.
@@ -88,6 +88,9 @@ Under the hood the program follows a clear pipeline:
    unittest discovery to gather all modules under `tests/`.
 4. Plots and CSV results will appear in the `output/` folder when the run
    completes.
+5. To experiment with the browser-based interface run `python web/serve_web.py`
+   and open `http://localhost:5000` in a browser. Results can be viewed and
+   downloaded interactively.
 
 ## Dependencies
 This project requires **Python 3.12 or later** and relies on `numpy`, `scipy`, `matplotlib`,

--- a/copernican.py
+++ b/copernican.py
@@ -39,7 +39,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.12.4"
+COPERNICAN_VERSION = "1.12.6"
 
 # Local virtual environment used when dependencies are missing
 VENV_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'venv')

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.12.5.  The `copernican_lib` package now collects all
+version 1.12.6.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.

--- a/web/app.js
+++ b/web/app.js
@@ -21,6 +21,40 @@ function switchTab(evt) {
     document.getElementById(evt.target.dataset.tab).classList.remove('hidden');
 }
 
+let plots = [];
+let tables = [];
+let logFile = '';
+let plotIdx = 0;
+let tableIdx = 0;
+
+function updatePlotViewer() {
+    if (plots.length === 0) {
+        document.getElementById('plotImg').src = '';
+        document.getElementById('plotName').textContent = 'No plots';
+        document.getElementById('downloadPlot').href = '#';
+        return;
+    }
+    const file = plots[plotIdx];
+    document.getElementById('plotImg').src = `/api/file/${file}`;
+    document.getElementById('plotName').textContent = file;
+    document.getElementById('downloadPlot').href = `/api/file/${file}`;
+}
+
+function updateTableViewer() {
+    if (tables.length === 0) {
+        document.getElementById('tableText').textContent = 'No tables';
+        document.getElementById('tableName').textContent = '';
+        document.getElementById('downloadTable').href = '#';
+        return;
+    }
+    const file = tables[tableIdx];
+    document.getElementById('tableName').textContent = file;
+    document.getElementById('downloadTable').href = `/api/file/${file}`;
+    fetch(`/api/file/${file}`).then(r => r.text()).then(t => {
+        document.getElementById('tableText').textContent = t;
+    });
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
     const models = await fetchData('/api/models');
     renderList('modelList', models, 'model');
@@ -30,6 +64,23 @@ document.addEventListener('DOMContentLoaded', async () => {
     renderList('cmbList', data.cmb, 'cmb');
 
     document.querySelectorAll('.tab').forEach(btn => btn.addEventListener('click', switchTab));
+
+    document.getElementById('prevPlot').addEventListener('click', () => {
+        plotIdx = (plotIdx - 1 + plots.length) % plots.length;
+        updatePlotViewer();
+    });
+    document.getElementById('nextPlot').addEventListener('click', () => {
+        plotIdx = (plotIdx + 1) % plots.length;
+        updatePlotViewer();
+    });
+    document.getElementById('prevTable').addEventListener('click', () => {
+        tableIdx = (tableIdx - 1 + tables.length) % tables.length;
+        updateTableViewer();
+    });
+    document.getElementById('nextTable').addEventListener('click', () => {
+        tableIdx = (tableIdx + 1) % tables.length;
+        updateTableViewer();
+    });
 
     document.getElementById('runBtn').addEventListener('click', async () => {
         const body = {
@@ -44,8 +95,26 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (file) formData.append('file', file);
 
         const resp = await fetch('/api/run', { method: 'POST', body: formData });
-        const blob = await resp.blob();
-        document.getElementById('downloadZip').href = URL.createObjectURL(blob);
+        const result = await resp.json();
+
+        document.getElementById('console').textContent = result.console;
+        document.getElementById('downloadZip').href = result.zip;
+
+        plots = result.plots;
+        tables = result.tables;
+        logFile = result.log;
+        plotIdx = 0;
+        tableIdx = 0;
+        updatePlotViewer();
+        updateTableViewer();
+
+        if (logFile) {
+            fetch(`/api/file/${logFile}`).then(r => r.text()).then(t => {
+                document.getElementById('logText').textContent = t;
+                document.getElementById('downloadLog').href = `/api/file/${logFile}`;
+            });
+        }
+
         document.getElementById('results').classList.remove('hidden');
     });
 });

--- a/web/index.html
+++ b/web/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Copernican Suite 1.12.5</title>
+    <title>Copernican Suite 1.12.6</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <header>
-        <h1>Copernican Suite 1.12.5</h1>
+        <h1>Copernican Suite 1.12.6</h1>
     </header>
     <main>
         <section id="config">
@@ -40,10 +40,31 @@
                 <button class="tab active" data-tab="console">Console</button>
                 <button class="tab" data-tab="plots">Plots</button>
                 <button class="tab" data-tab="tables">Tables</button>
+                <button class="tab" data-tab="logFile">Log File</button>
             </div>
             <div id="console" class="tabContent"></div>
-            <div id="plots" class="tabContent hidden"></div>
-            <div id="tables" class="tabContent hidden"></div>
+            <div id="plots" class="tabContent hidden">
+                <div class="viewer">
+                    <button id="prevPlot">Previous</button>
+                    <span id="plotName"></span>
+                    <button id="nextPlot">Next</button>
+                    <div><img id="plotImg" src="" alt="plot" /></div>
+                    <a id="downloadPlot" href="#" download>Download</a>
+                </div>
+            </div>
+            <div id="tables" class="tabContent hidden">
+                <div class="viewer">
+                    <button id="prevTable">Previous</button>
+                    <span id="tableName"></span>
+                    <button id="nextTable">Next</button>
+                    <pre id="tableText"></pre>
+                    <a id="downloadTable" href="#" download>Download</a>
+                </div>
+            </div>
+            <div id="logFile" class="tabContent hidden">
+                <pre id="logText"></pre>
+                <a id="downloadLog" href="#" download>Download Log</a>
+            </div>
             <a id="downloadZip" href="#" download>Download All Results</a>
         </section>
     </main>

--- a/web/serve_web.py
+++ b/web/serve_web.py
@@ -64,12 +64,41 @@ def run_eval():
             return 'Invalid dataset selection', 400
 
     inputs.append('no')
-    proc = subprocess.Popen(['python', os.path.join(REPO_ROOT, 'copernican.py')], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, cwd=REPO_ROOT)
-    proc.communicate('\n'.join(inputs) + '\n')
+    proc = subprocess.Popen(
+        ['python', os.path.join(REPO_ROOT, 'copernican.py')],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    console_out, _ = proc.communicate('\n'.join(inputs) + '\n')
     proc.wait()
 
+    files = sorted(os.listdir(OUTPUT_DIR))
+    plots = [f for f in files if f.lower().endswith('.png')]
+    tables = [f for f in files if f.lower().endswith('.csv')]
+    logs = [f for f in files if f.lower().endswith('.txt')]
+    log_file = logs[0] if logs else ''
+
     zip_path = shutil.make_archive(os.path.join(BASE_DIR, 'results'), 'zip', OUTPUT_DIR)
-    return send_file(zip_path, mimetype='application/zip', as_attachment=True, download_name='results.zip')
+    return jsonify({
+        'console': console_out,
+        'plots': plots,
+        'tables': tables,
+        'log': log_file,
+        'zip': '/api/download/results.zip'
+    })
+
+
+@app.route('/api/file/<path:filename>')
+def get_file(filename: str):
+    return send_from_directory(OUTPUT_DIR, filename, as_attachment=False)
+
+
+@app.route('/api/download/<path:filename>')
+def download(filename: str):
+    return send_from_directory(BASE_DIR, filename, as_attachment=True)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/web/style.css
+++ b/web/style.css
@@ -7,5 +7,7 @@ button:hover { background: #303f9f; }
 .tabs { margin-top: 20px; }
 .tab { margin-right: 5px; }
 .tabContent { border: 1px solid #ccc; padding: 10px; height: 300px; overflow: auto; }
+.viewer { text-align: center; }
+.viewer img { max-width: 100%; height: auto; }
 .hidden { display: none; }
 .active { background: #303f9f; }


### PR DESCRIPTION
## Summary
- enhance web front-end with per-file result viewer
- add endpoints for file and zip download
- update docs with new web instructions
- bump version to 1.12.6

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68761ea1a050832fab9ad7ac44bd4a17