### PR TITLE
Fix web server import path for dynamic menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
 ## Version 1.12.7
+- 2025-07-15: Web server now adjusts PYTHONPATH to import local packages (AI assistant)
 - 2025-07-15: Improved web UI with dropdown selection and upload options (AI assistant)
 
 ## Version 1.12.6

--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ Under the hood the program follows a clear pipeline:
 4. Plots and CSV results will appear in the `output/` folder when the run
    completes.
 5. To experiment with the browser-based interface run `python web/serve_web.py`
-   and open `http://localhost:5000` in a browser. The web UI now lets you upload
-   a JSON model or pick one from the server via dropdown along with dataset
-   selectors for SNe, BAO and CMB. Results can be viewed and downloaded
-   interactively.
+   and open `http://localhost:5000` in a browser. The server now adjusts
+   `PYTHONPATH` automatically so it can be launched from any directory. The web
+   UI lets you upload a JSON model or pick one from the server via dropdown
+   along with dataset selectors for SNe, BAO and CMB. Results can be viewed and
+   downloaded interactively.
 
 ## Dependencies
 This project requires **Python 3.12 or later** and relies on `numpy`, `scipy`, `matplotlib`,

--- a/web/serve_web.py
+++ b/web/serve_web.py
@@ -4,12 +4,20 @@ import json
 import subprocess
 import tempfile
 import shutil
+import sys
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(BASE_DIR)
+
+# Ensure the project root is in ``sys.path`` so the local package imports work
+# even when ``serve_web.py`` is launched from the ``web`` directory.
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
 from copernican_lib import data_loaders
 
 app = Flask(__name__, static_folder='.')
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-REPO_ROOT = os.path.dirname(BASE_DIR)
 OUTPUT_DIR = os.path.join(REPO_ROOT, 'output')
 
 @app.route('/')


### PR DESCRIPTION
## Summary
- ensure `serve_web.py` inserts repo root into `PYTHONPATH`
- document that the web server can be run from any directory
- log change in changelog

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68763061333c832f80ad15d94ad6d5f4