### PR TITLE
Improve web server startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Add one line for each substantive commit or pull request directly under the late
 - 2025-07-15: Web server now adjusts PYTHONPATH to import local packages (AI assistant)
 - 2025-07-15: Improved web UI with dropdown selection and upload options (AI assistant)
 - 2025-07-15: Moved index.html to repo root and added sequential dataset selection in web UI (AI assistant)
+- 2025-07-15: Web server performs dependency check on startup (AI assistant)
 
 ## Version 1.12.6
 - 2025-07-15: Expanded web UI with interactive result viewer and per-file downloads (AI assistant)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Under the hood the program follows a clear pipeline:
    JavaScript and CSS live under `web/`. The web UI lets you upload a JSON model
    or pick one from the server via dropdown along with dataset selectors for
    SNe, BAO and CMB. Results can be viewed and downloaded interactively.
+   All Python dependencies are checked when the server starts and will be
+   installed into `./venv` if missing so the interface works even on a fresh
+   system.
 
 ## Dependencies
 This project requires **Python 3.12 or later** and relies on `numpy`, `scipy`, `matplotlib`,

--- a/web/serve_web.py
+++ b/web/serve_web.py
@@ -14,6 +14,12 @@ REPO_ROOT = os.path.dirname(BASE_DIR)
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
+# Verify required Python packages before importing project modules. This mirrors
+# the dependency check in ``copernican.py`` so the web interface can be started
+# on a clean system without manual setup.
+from copernican import check_dependencies
+check_dependencies()
+
 from copernican_lib import data_loaders
 
 app = Flask(__name__, static_folder=os.path.join(REPO_ROOT, 'web'), static_url_path='/web')


### PR DESCRIPTION
## Summary
- ensure `serve_web.py` verifies dependencies via the same check used by the CLI
- document automatic dependency setup for the web UI
- log the new behaviour

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_687658db75dc832f91fc9b9754ff0ca8