### PR TITLE
Fix dependency check for Python 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Add one line for each substantive commit or pull request directly under the late
 - 2025-07-15: Fixed CMB spectrum scaling bug and added Dl verification test (AI assistant)
 - 2025-07-15: Updated documentation and developer guide with raw string rule (AI assistant)
 - 2025-07-15: Converted math docstrings to raw strings to silence escape warnings (AI assistant)
+- 2025-07-15: Fixed dependency check for Python 3.13 `find_spec` ValueError (AI assistant)
 
 ## Version 1.12.3
 - 2025-07-13: Unified timestamp handling and console output format updated (AI assistant)

--- a/copernican.py
+++ b/copernican.py
@@ -183,7 +183,18 @@ def check_dependencies():
     """Ensure all required packages are installed and activate venv if needed."""
     print("--- Running System Dependency Check ---")
     required = sorted(_gather_required_packages())
-    missing = [pkg for pkg in required if importlib.util.find_spec(pkg) is None]
+    missing = []
+    for pkg in required:
+        try:
+            if importlib.util.find_spec(pkg) is None:
+                missing.append(pkg)
+        except ValueError:
+            # Python 3.13 may raise ValueError when __main__.__spec__ is None.
+            # Fallback to a simple import attempt in that case.
+            try:
+                importlib.import_module(pkg)
+            except Exception:
+                missing.append(pkg)
 
     inside_venv = os.environ.get('COPERNICAN_VENV_ACTIVE') == '1'
 


### PR DESCRIPTION
## Summary
- handle `importlib.util.find_spec` ValueError in dependency check
- document fix in changelog

## Testing
- `python3 copernican.py --run-tests` *(fails: Python 3.12 or later required)*

------
https://chatgpt.com/codex/tasks/task_e_6876c067fab0832f8829c64fd36ea4c0