### PR TITLE
Implement BAO residuals and simplify dependency check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.4**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.5**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Add one line for each substantive commit or pull request directly under the late
 - 2025-07-15: Converted math docstrings to raw strings to silence escape warnings (AI assistant)
 - 2025-07-15: Fixed dependency check for Python 3.13 `find_spec` ValueError (AI assistant)
 
+## Version 1.12.5
+- 2025-07-16: Removed automatic dependency installation and virtual environment logic (AI assistant)
+- 2025-07-16: Implemented BAO residual plots with smoothed averages (AI assistant)
+- 2025-07-16: Added smoothed residual averages to all plots and extended footer wrapping (AI assistant)
+
 ## Version 1.12.3
 - 2025-07-13: Unified timestamp handling and console output format updated (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.12.4
-**Last Updated:** 2025-07-10
+**Version:** 1.12.5
+**Last Updated:** 2025-07-16
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO) and Cosmic Microwave Background (CMB) data.
@@ -76,11 +76,10 @@ Under the hood the program follows a clear pipeline:
 
 ## Quick Start
 1. Ensure Python 3.12 or later is available. Launch the suite via the `start`
-   script for your platform (`start.command`, `start.bat` or `start.sh`). On the
-   first run the program will create a local virtual environment and install all
-   required packages if they are missing. You may be prompted for your password
-   during this step. Running with an older Python version will print an error
-   and exit immediately.
+   script for your platform (`start.command`, `start.bat` or `start.sh`). The
+   program checks for required Python packages at startup and prints a
+   `pip install` command if any are missing. Running with an older Python
+   version will print an error and exit immediately.
 2. Follow the interactive prompts to choose a model, preferred data sources and
    computation engine.
 3. Execute `python3 copernican.py --run-tests` or run `python -m unittest discover`
@@ -91,16 +90,16 @@ Under the hood the program follows a clear pipeline:
 
 ## Dependencies
 This project requires **Python 3.12 or later** and relies on `numpy`, `scipy`, `matplotlib`,
-`pandas`, `sympy`, `jsonschema` and `camb`. Missing packages are installed automatically
-into the local virtual environment on first launch. Running under an older Python version
-results in an immediate error and exit code 1. Future engines may also depend on `numba`
-or GPU libraries.
+`pandas`, `sympy`, `jsonschema` and `camb`. If any packages are missing the
+program prints a `pip install` command and exits so you can install them
+manually. Running under an older Python version results in an immediate error
+and exit code 1. Future engines may also depend on `numba` or GPU libraries.
  
 ## Building & Installation
 Windows users should open `start.bat`, macOS users should run `start.command`,
-and Linux users can execute `start.sh`.  These helpers create a Python virtual
-environment in `./venv` and install all required packages.  You may then run the
-suite with:
+and Linux users can execute `start.sh`.  These helpers simply run
+`python copernican.py` from the repository root. Make sure the required
+dependencies are installed using `pip` before launching the suite:
 
 ```bash
 python copernican.py
@@ -113,13 +112,6 @@ pip install .    # regular install
 pip install -e . # editable for development
 ```
 
-To remove the suite simply delete the `venv` directory and any installed
-`copernican` package:
-
-```bash
-rm -rf venv
-pip uninstall copernican-suite
-```
 
 ## Directory Layout
 ```

--- a/copernican.py
+++ b/copernican.py
@@ -10,20 +10,26 @@ import os
 import sys
 import platform
 import shutil
-import subprocess
 import time
 import datetime
 import argparse
-from getpass import getpass
 
 # Verify interpreter version early so users see clear feedback
 MIN_PYTHON = (3, 12)
+
+
+def exit_clean(code: int = 0) -> None:
+    """Exit the program after printing a newline."""
+    print()
+    sys.exit(code)
+
+
 if sys.version_info < MIN_PYTHON:
     print(
         f"ERROR: Copernican Suite requires Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]} or later.",
         file=sys.stderr,
     )
-    sys.exit(1)
+    exit_clean(1)
 
 # Delay heavy third-party imports until after the dependency check
 np = None
@@ -39,17 +45,8 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.12.4"
-
-# Local virtual environment used when dependencies are missing
-VENV_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'venv')
+COPERNICAN_VERSION = "1.12.5"
 CURRENT_LOG_FILE = None
-
-
-def _venv_bin(name: str) -> str:
-    """Return the path to a binary inside the virtual environment."""
-    folder = 'Scripts' if os.name == 'nt' else 'bin'
-    return os.path.join(VENV_DIR, folder, name)
 
 
 def _delete_log_file(path: str) -> None:
@@ -196,27 +193,12 @@ def check_dependencies():
             except Exception:
                 missing.append(pkg)
 
-    inside_venv = os.environ.get('COPERNICAN_VENV_ACTIVE') == '1'
-
     if missing:
-        if not inside_venv:
-            print(f"Missing packages detected: {', '.join(missing)}")
-            print("Installing into local virtual environment. You may be asked for your password.")
-            if not os.path.isdir(VENV_DIR):
-                subprocess.check_call([sys.executable, '-m', 'venv', VENV_DIR])
-            pip_exe = _venv_bin('pip')
-            subprocess.check_call([pip_exe, 'install', *required])
-            python_exe = _venv_bin('python')
-            os.environ['COPERNICAN_VENV_ACTIVE'] = '1'
-            os.execv(python_exe, [python_exe] + sys.argv)
-        else:
-            print("Dependency installation failed inside virtual environment.")
-            sys.exit(1)
+        print(f"Missing packages detected: {', '.join(missing)}")
+        print("Please install them with:")
+        print(f"  pip install {' '.join(sorted(missing))}")
+        exit_clean(1)
     else:
-        if not inside_venv and os.path.isdir(VENV_DIR):
-            python_exe = _venv_bin('python')
-            os.environ['COPERNICAN_VENV_ACTIVE'] = '1'
-            os.execv(python_exe, [python_exe] + sys.argv)
         print("✅ System Dependency Check Passed. Continuing...\n")
 
 
@@ -329,7 +311,7 @@ def main_workflow():
     check_dependencies()
     if args.run_tests:
         success = run_startup_tests()
-        sys.exit(0 if success else 1)
+        exit_clean(0 if success else 1)
 
     # Import optional third-party packages after confirming they are installed
     global np, plt, mp, model_parser, model_coder, engine_interface, data_loaders, plotter, csv_writer, log_mod, logger
@@ -391,6 +373,7 @@ def main_workflow():
         if not selected_model:
             _delete_log_file(log_file)
             cleanup_cache(SCRIPT_DIR)
+            print()
             return
         if selected_model.endswith('.json'):
             json_path = os.path.join(models_dir, selected_model)
@@ -430,6 +413,7 @@ def main_workflow():
         if not engine_choice:
             _delete_log_file(log_file)
             cleanup_cache(SCRIPT_DIR)
+            print()
             return
         engine_module = importlib.import_module(f"engines.{engine_choice[:-3]}")
         cosmo_engine_selected = engine_module
@@ -686,6 +670,7 @@ def main_workflow():
             elif another_run in ["no", "n", "2"]:
                 cleanup_cache(SCRIPT_DIR)
                 logger.info("Exiting Copernican Suite. Goodbye!")
+                print()
                 return
             else:
                 print("Invalid input. Please enter 'yes' or 'no'.")
@@ -723,3 +708,4 @@ if __name__ == "__main__":
                 plt.show(block=True)
             except Exception as e_show:
                 print(f"Error during final plt.show(): {e_show}")
+        print()

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -24,13 +24,52 @@ def _wrap_math(text: str) -> str:
     return f"${cleaned}$" if cleaned else ""
 
 
+def _smooth_line(x: np.ndarray, y: np.ndarray, points: int = 200) -> tuple[np.ndarray, np.ndarray]:
+    """Return a smooth interpolation of ``y`` over ``x``."""
+    if len(x) < 4:
+        return x, y
+    try:
+        from scipy.interpolate import make_interp_spline
+
+        idx = np.argsort(x)
+        x_sorted = x[idx]
+        y_sorted = y[idx]
+        order = 3 if len(x_sorted) > 3 else 1
+        spline = make_interp_spline(x_sorted, y_sorted, k=order)
+        x_new = np.linspace(x_sorted[0], x_sorted[-1], points)
+        y_new = spline(x_new)
+        return x_new, y_new
+    except Exception as exc:
+        get_logger().warning(f"Could not smooth line: {exc}")
+        return x, y
+
+
+def get_binned_average(z: np.ndarray, residuals: np.ndarray, n_bins: int = 20) -> tuple[np.ndarray, np.ndarray]:
+    """Return binned average residuals or empty arrays when unavailable."""
+    if len(z) < n_bins:
+        return np.array([]), np.array([])
+    try:
+        from scipy.stats import binned_statistic
+
+        mean_stat, bin_edges, _ = binned_statistic(z, residuals, statistic="mean", bins=n_bins)
+        bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+        valid_indices = ~np.isnan(mean_stat)
+        return bin_centers[valid_indices], mean_stat[valid_indices]
+    except ImportError:
+        get_logger().warning("Scipy not found, cannot plot binned residual averages.")
+        return np.array([]), np.array([])
+    except Exception as exc:
+        get_logger().warning(f"Could not calculate binned average due to an error: {exc}")
+        return np.array([]), np.array([])
+
+
 def compose_footer(base_line: str, data_attrs: dict) -> str:
     """Return a multi-line footer string with dataset information."""
     long_name = data_attrs.get("dataset_long_name", data_attrs.get("dataset_name_attr", ""))
     notes = data_attrs.get("notes", "")
     citation = data_attrs.get("citation", "")
     second_line = f"{_wrap_math(long_name)}: {notes} {citation}".strip()
-    wrapped = textwrap.fill(second_line, width=110)
+    wrapped = textwrap.fill(second_line, width=150)
     return base_line + "\n" + wrapped
 
 
@@ -121,24 +160,6 @@ def plot_hubble_diagram(
     diag_errors_plot = sne_data_df.attrs.get("diag_errors_for_plot", np.ones_like(z_data) * 0.2)
     z_plot_smooth = np.geomspace(max(np.min(z_data) * 0.9, 0.001), np.max(z_data) * 1.05, 200)
 
-    def get_binned_average(z: np.ndarray, residuals: np.ndarray, n_bins: int = 20) -> tuple[np.ndarray, np.ndarray]:
-        """Return binned average residuals for plotting or an empty array if unavailable."""
-        if len(z) < n_bins:
-            return np.array([]), np.array([])
-        try:
-            from scipy.stats import binned_statistic
-
-            mean_stat, bin_edges, _ = binned_statistic(z, residuals, statistic="mean", bins=n_bins)
-            bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
-            valid_indices = ~np.isnan(mean_stat)
-            return bin_centers[valid_indices], mean_stat[valid_indices]
-        except ImportError:
-            logger.warning("Scipy not found, cannot plot binned residual averages.")
-            return np.array([]), np.array([])
-        except Exception as exc:
-            logger.warning(f"Could not calculate binned average due to an error: {exc}")
-            return np.array([]), np.array([])
-
     fig, axs = plt.subplots(2, 1, figsize=(17, 12), sharex=True, gridspec_kw={"height_ratios": [3, 1.5], "hspace": 0.05})
     plt.subplots_adjust(left=0.08, bottom=0.12, right=0.75, top=0.92)
     try:
@@ -170,6 +191,7 @@ def plot_hubble_diagram(
         axs[0].plot(z_plot_smooth, mu_model_lcdm_smooth, color="red", ls="-", label=fr"$\Lambda$CDM ($\chi^2$={chi2_lcdm})", lw=2.5)
         axs[1].errorbar(z_data, res_lcdm, yerr=diag_errors_plot, fmt=".", color="red", alpha=0.5, label=r"$\Lambda$CDM Res.", elinewidth=1, capsize=2, ms=4)
         z_lcdm_avg, res_lcdm_avg = get_binned_average(z_data, res_lcdm)
+        z_lcdm_avg, res_lcdm_avg = _smooth_line(z_lcdm_avg, res_lcdm_avg)
         axs[1].plot(z_lcdm_avg, res_lcdm_avg, color="darkred", ls="-", lw=2, zorder=10, label=r"Avg. $\Lambda$CDM Res.")
 
     alt_name_raw = getattr(alt_model_plugin, "MODEL_NAME", "AltModel")
@@ -196,6 +218,7 @@ def plot_hubble_diagram(
             ms=4,
         )
         z_alt_avg, res_alt_avg = get_binned_average(z_data, res_alt)
+        z_alt_avg, res_alt_avg = _smooth_line(z_alt_avg, res_alt_avg)
         axs[1].plot(z_alt_avg, res_alt_avg, color="darkblue", ls="--", lw=2, zorder=11, label=f"Avg. {alt_name_latex} Res.")
 
     axs[0].set_ylabel(r"Distance Modulus ($\mu$)", fontsize=font_sizes["label"])
@@ -283,7 +306,15 @@ def plot_bao_observables(
         "ticks": 12,
     }
 
-    fig, ax = plt.subplots(figsize=(17, 10))
+    fig, axs = plt.subplots(
+        2,
+        1,
+        figsize=(17, 12),
+        sharex=True,
+        gridspec_kw={"height_ratios": [3, 1.5], "hspace": 0.05},
+    )
+    ax = axs[0]
+    res_ax = axs[1]
     plt.subplots_adjust(left=0.08, bottom=0.13, right=0.75, top=0.90)
     try:
         plt.style.use("seaborn-v0_8-darkgrid")
@@ -339,13 +370,61 @@ def plot_bao_observables(
     alt_name_latex = alt_name_raw.replace("_", r"\_")
     plot_model_bao(alt_model_full_results, "blue", line_styles, alt_name_latex, alpha=0.25)
 
-    ax.set_xlabel("Redshift (z)", fontsize=font_sizes["label"])
+    # --- Residuals ---
+    lcdm_pred = lcdm_full_results.get("pred_df")
+    if lcdm_pred is not None:
+        res_lcdm = bao_data_df["value"].values - lcdm_pred["model_prediction"].values
+        res_ax.errorbar(
+            bao_data_df["redshift"],
+            res_lcdm,
+            yerr=bao_data_df["error"],
+            fmt=".",
+            color="red",
+            alpha=0.5,
+            label=r"$\Lambda$CDM Res.",
+            elinewidth=1,
+            capsize=2,
+            ms=4,
+        )
+        z_avg, r_avg = get_binned_average(bao_data_df["redshift"].values, res_lcdm)
+        z_avg, r_avg = _smooth_line(z_avg, r_avg)
+        res_ax.plot(z_avg, r_avg, color="darkred", ls="-", lw=2, zorder=10, label=r"Avg. $\Lambda$CDM Res.")
+
+    alt_pred = alt_model_full_results.get("pred_df")
+    if alt_pred is not None:
+        res_alt = bao_data_df["value"].values - alt_pred["model_prediction"].values
+        res_ax.errorbar(
+            bao_data_df["redshift"],
+            res_alt,
+            yerr=bao_data_df["error"],
+            fmt=".",
+            mfc="none",
+            mec="blue",
+            ecolor="lightblue",
+            alpha=0.5,
+            label=fr"{alt_name_latex} Res.",
+            elinewidth=1,
+            capsize=2,
+            ms=4,
+        )
+        z_avg, r_avg = get_binned_average(bao_data_df["redshift"].values, res_alt)
+        z_avg, r_avg = _smooth_line(z_avg, r_avg)
+        res_ax.plot(z_avg, r_avg, color="darkblue", ls="--", lw=2, zorder=11, label=f"Avg. {alt_name_latex} Res.")
+
     ax.set_ylabel(r"$D_X/r_s$", fontsize=font_sizes["label"])
     ax.set_title(f"BAO Observables vs. Redshift: {dataset_name}", fontsize=font_sizes["title"])
     ax.legend(fontsize=font_sizes["legend"], loc="best")
     ax.minorticks_on()
     ax.tick_params(axis="both", which="major", labelsize=font_sizes["ticks"])
     ax.grid(True, which="both", linestyle="--", linewidth=0.5)
+
+    res_ax.axhline(0, color="black", ls="--", lw=1)
+    res_ax.set_xlabel("Redshift (z)", fontsize=font_sizes["label"])
+    res_ax.set_ylabel(r"$D_X/r_s^{obs} - D_X/r_s^{th}$", fontsize=font_sizes["label"])
+    res_ax.legend(fontsize=font_sizes["legend"], loc="best")
+    res_ax.minorticks_on()
+    res_ax.tick_params(axis="both", which="major", labelsize=font_sizes["ticks"])
+    res_ax.grid(True, which="both", linestyle="--", linewidth=0.5)
 
     bbox_lcdm = dict(boxstyle="round,pad=0.5", fc="#FFEEEE", ec="darkred", alpha=0.8)
     bbox_alt = dict(boxstyle="round,pad=0.5", fc="#EEF2FF", ec="darkblue", alpha=0.8)
@@ -564,10 +643,21 @@ def plot_cmb_spectrum(
                     fmt=".",
                     color="red",
                     alpha=0.5,
-                    label=r"$\Lambda$CDM Res.",
+                    label=r"$\Lambda$CDM Res." if i == 0 else None,
                     elinewidth=1,
                     capsize=2,
                     ms=4,
+                )
+                z_avg, r_avg = get_binned_average(ells, res)
+                z_avg, r_avg = _smooth_line(z_avg, r_avg)
+                axs[idx_res].plot(
+                    z_avg,
+                    r_avg,
+                    color="darkred",
+                    ls="-",
+                    lw=2,
+                    zorder=10,
+                    label=r"Avg. $\Lambda$CDM Res." if i == 0 else None,
                 )
 
         if alt_theory is not None:
@@ -588,10 +678,21 @@ def plot_cmb_spectrum(
                     mec="blue",
                     ecolor="lightblue",
                     alpha=0.5,
-                    label=fr"{alt_name_latex} Res.",
+                    label=fr"{alt_name_latex} Res." if i == 0 else None,
                     elinewidth=1,
                     capsize=2,
                     ms=4,
+                )
+                z_avg, r_avg = get_binned_average(ells, res)
+                z_avg, r_avg = _smooth_line(z_avg, r_avg)
+                axs[idx_res].plot(
+                    z_avg,
+                    r_avg,
+                    color="darkblue",
+                    ls="--",
+                    lw=2,
+                    zorder=11,
+                    label=f"Avg. {alt_name_latex} Res." if i == 0 else None,
                 )
 
         axs[idx_main].set_ylabel(r"$D_\ell\ (\mu K^2)$", fontsize=font_sizes["label"])

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.12.4.  The `copernican_lib` package now collects all
+version 1.12.5.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.


### PR DESCRIPTION
## Summary
- remove automatic dependency installation and virtualenv logic
- add residual subplots with smoothed averages for BAO and CMB
- extend footer wrapping width
- update documentation for new manual dependency handling
- bump version to 1.12.5

## Testing
- `pip install numpy scipy matplotlib pandas sympy jsonschema camb`
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_6876f4f112c8832f9232a48aa28e39dc