### PR TITLE
Fix dependency check for virtual envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
 ## Version 1.12.5
+- 2025-07-16: Ignored virtual env directories when scanning imports for dependency check (AI assistant)
 - 2025-07-16: Removed automatic dependency installation and virtual environment logic (AI assistant)
 - 2025-07-16: Implemented BAO residual plots with smoothed averages (AI assistant)
 - 2025-07-16: Added smoothed residual averages to all plots and extended footer wrapping (AI assistant)

--- a/copernican.py
+++ b/copernican.py
@@ -150,10 +150,24 @@ def _gather_required_packages():
     """Return external packages imported across project modules."""
     pkg_names = set()
     search_dirs = ["copernican_lib", "engines", "tests", "."]
+    ignore_dirs = {
+        "venv",
+        ".venv",
+        "env",
+        "build",
+        "dist",
+        "__pycache__",
+        "copernican_suite.egg-info",
+    }
     for base in search_dirs:
         if not os.path.isdir(base):
             continue
-        for root, _, files in os.walk(base):
+        for root, dirs, files in os.walk(base):
+            dirs[:] = [
+                d
+                for d in dirs
+                if d not in ignore_dirs and not d.startswith(".") and "site-packages" not in d
+            ]
             for fname in files:
                 if not fname.endswith(".py"):
                     continue


### PR DESCRIPTION
## Summary
- ignore local virtual environment and build folders when scanning imports for dependencies
- document the update in CHANGELOG

## Testing
- `python3 copernican.py --run-tests` *(fails: Python 3.12 or later required)*

------
https://chatgpt.com/codex/tasks/task_e_68770a9208d0832f835830a0c6dceb33