### PR TITLE
Release 1.12.6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.5**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.6**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.12.6
+- 2025-07-16: Improved footer wrapping, plot legends and info boxes with combined chi2; tweaked BAO residuals (AI assistant)
+
 ## Version 1.12.5
 - 2025-07-16: Ignored virtual env directories when scanning imports for dependency check (AI assistant)
 - 2025-07-16: Removed automatic dependency installation and virtual environment logic (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.12.5
+**Version:** 1.12.6
 **Last Updated:** 2025-07-16
 
 The Copernican Suite is a Python toolkit for testing cosmological models against

--- a/copernican.py
+++ b/copernican.py
@@ -47,7 +47,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.12.5"
+COPERNICAN_VERSION = "1.12.6"
 CURRENT_LOG_FILE = None
 
 
@@ -166,7 +166,9 @@ def _gather_required_packages():
             dirs[:] = [
                 d
                 for d in dirs
-                if d not in ignore_dirs and not d.startswith(".") and "site-packages" not in d
+                if d not in ignore_dirs
+                and not d.startswith(".")
+                and "site-packages" not in d
             ]
             for fname in files:
                 if not fname.endswith(".py"):
@@ -821,9 +823,7 @@ if __name__ == "__main__":
     except Exception:
         logger_obj = log_mod.get_logger() if log_mod else None
         if logger_obj and logger_obj.hasHandlers():
-            logger_obj.critical(
-                "Unhandled exception in main_workflow!", exc_info=True
-            )
+            logger_obj.critical("Unhandled exception in main_workflow!", exc_info=True)
         else:
             print("CRITICAL UNHANDLED EXCEPTION IN MAIN WORKFLOW:")
             import traceback

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -20,11 +20,13 @@ def _wrap_math(text: str) -> str:
     """Return ``text`` wrapped in dollar signs for MathText rendering."""
     if text is None:
         return ""
-    cleaned = re.sub(r'^\$+|\$+$', '', str(text).strip())
+    cleaned = re.sub(r"^\$+|\$+$", "", str(text).strip())
     return f"${cleaned}$" if cleaned else ""
 
 
-def _smooth_line(x: np.ndarray, y: np.ndarray, points: int = 200) -> tuple[np.ndarray, np.ndarray]:
+def _smooth_line(
+    x: np.ndarray, y: np.ndarray, points: int = 200
+) -> tuple[np.ndarray, np.ndarray]:
     """Return a smooth interpolation of ``y`` over ``x``."""
     if len(x) < 4:
         return x, y
@@ -44,14 +46,18 @@ def _smooth_line(x: np.ndarray, y: np.ndarray, points: int = 200) -> tuple[np.nd
         return x, y
 
 
-def get_binned_average(z: np.ndarray, residuals: np.ndarray, n_bins: int = 20) -> tuple[np.ndarray, np.ndarray]:
+def get_binned_average(
+    z: np.ndarray, residuals: np.ndarray, n_bins: int = 20
+) -> tuple[np.ndarray, np.ndarray]:
     """Return binned average residuals or empty arrays when unavailable."""
     if len(z) < n_bins:
         return np.array([]), np.array([])
     try:
         from scipy.stats import binned_statistic
 
-        mean_stat, bin_edges, _ = binned_statistic(z, residuals, statistic="mean", bins=n_bins)
+        mean_stat, bin_edges, _ = binned_statistic(
+            z, residuals, statistic="mean", bins=n_bins
+        )
         bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
         valid_indices = ~np.isnan(mean_stat)
         return bin_centers[valid_indices], mean_stat[valid_indices]
@@ -59,33 +65,40 @@ def get_binned_average(z: np.ndarray, residuals: np.ndarray, n_bins: int = 20) -
         get_logger().warning("Scipy not found, cannot plot binned residual averages.")
         return np.array([]), np.array([])
     except Exception as exc:
-        get_logger().warning(f"Could not calculate binned average due to an error: {exc}")
+        get_logger().warning(
+            f"Could not calculate binned average due to an error: {exc}"
+        )
         return np.array([]), np.array([])
 
 
 def compose_footer(base_line: str, data_attrs: dict) -> str:
     """Return a multi-line footer string with dataset information."""
-    long_name = data_attrs.get("dataset_long_name", data_attrs.get("dataset_name_attr", ""))
+    long_name = data_attrs.get(
+        "dataset_long_name", data_attrs.get("dataset_name_attr", "")
+    )
     notes = data_attrs.get("notes", "")
     citation = data_attrs.get("citation", "")
     second_line = f"{_wrap_math(long_name)}: {notes} {citation}".strip()
-    wrapped = textwrap.fill(second_line, width=150)
+    wrapped = textwrap.fill(second_line, width=185)
     return base_line + "\n" + wrapped
 
 
-def format_model_summary_text(model_plugin: Any, is_sne_summary: bool,
-                              fit_results: Any, **kwargs: Any) -> str:
+def format_model_summary_text(
+    model_plugin: Any, is_sne_summary: bool, fit_results: Any, **kwargs: Any
+) -> str:
     """Return a formatted text block with model details and fit statistics."""
     lines: list[str] = []
     model_name_raw = getattr(model_plugin, "MODEL_NAME", "N/A")
     model_name_latex = model_name_raw.replace("_", r"\_")
-    lines.append(fr"**Model: {model_name_latex}**")
+    lines.append(rf"**Model: {model_name_latex}**")
 
-    eq_attr = "MODEL_EQUATIONS_LATEX_SN" if is_sne_summary else "MODEL_EQUATIONS_LATEX_BAO"
+    eq_attr = (
+        "MODEL_EQUATIONS_LATEX_SN" if is_sne_summary else "MODEL_EQUATIONS_LATEX_BAO"
+    )
     if hasattr(model_plugin, eq_attr):
         lines.append("$\\mathbf{Mathematical\\ Form:}$")
         for eq_line in getattr(model_plugin, eq_attr):
-            lines.append(f"  {eq_line}")
+            lines.append(f"  {_wrap_math(eq_line)}")
 
     lines.append("$\\mathbf{Cosmological\\ Parameters:}$")
     param_names = getattr(model_plugin, "PARAMETER_NAMES", [])
@@ -98,26 +111,40 @@ def format_model_summary_text(model_plugin: Any, is_sne_summary: bool,
             latex_name = param_latex_names[i] if i < len(param_latex_names) else name
             latex_name = _wrap_math(latex_name)
             if val is not None:
-                lines.append(fr"  {latex_name} = ${val:.4g}$")
+                lines.append(rf"  {latex_name} = ${val:.4g}$")
             else:
-                lines.append(fr"  {latex_name} = N/A")
+                lines.append(rf"  {latex_name} = N/A")
     else:
         lines.append("  (Fit failed or parameters unavailable)")
 
     if is_sne_summary and fit_results.get("fitted_nuisance_params"):
         lines.append("$\\mathbf{SNe\\ Nuisance\\ Parameters:}$")
         for name, val in fit_results["fitted_nuisance_params"].items():
-            name_latex = {"M_B": r"M_B", "alpha_salt2": r"\alpha", "beta_salt2": r"\beta"}.get(name, name)
-            lines.append(fr"  {_wrap_math(name_latex)} = ${val:.4g}$")
+            name_latex = {
+                "M_B": r"M_B",
+                "alpha_salt2": r"\alpha",
+                "beta_salt2": r"\beta",
+            }.get(name, name)
+            lines.append(rf"  {_wrap_math(name_latex)} = ${val:.4g}$")
 
     if is_sne_summary:
         lines.append("$\\mathbf{SNe\\ Fit\\ Statistics:}$")
-        lines.append(fr"  $\chi^2_{{SNe}}$ = {fit_results.get('chi2_min', np.nan):.2f}")
+        lines.append(
+            rf"  $\chi^2_{{SNe}}$ = {fit_results.get('chi2_sne', fit_results.get('chi2_min', np.nan)):.2f}"
+        )
+        if "chi2_total" in fit_results:
+            lines.append(
+                rf"  $\chi^2_{{tot}}$ = {fit_results.get('chi2_total', np.nan):.2f}"
+            )
     else:
         # Display BAO fit statistics in the info box
         lines.append("$\\mathbf{BAO\\ Fit\\ Results:}$")
-        lines.append(fr"  $r_s$ = {kwargs.get('rs_Mpc', np.nan):.2f} Mpc")
-        lines.append(fr"  $\chi^2_{{BAO}}$ = {kwargs.get('chi2_bao', np.nan):.2f}")
+        lines.append(rf"  $r_s$ = {kwargs.get('rs_Mpc', np.nan):.2f} Mpc")
+        lines.append(rf"  $\chi^2_{{BAO}}$ = {kwargs.get('chi2_bao', np.nan):.2f}")
+        if "chi2_total" in kwargs:
+            lines.append(
+                rf"  $\chi^2_{{tot}}$ = {kwargs.get('chi2_total', np.nan):.2f}"
+            )
 
     return "\n".join(lines)
 
@@ -146,21 +173,51 @@ def plot_hubble_diagram(
     }
 
     if "mu_obs" not in sne_data_df.columns:
-        fit_res_for_mu = alt_model_fit_results if alt_model_fit_results and alt_model_fit_results.get("fitted_nuisance_params") else lcdm_fit_results
-        if sne_data_df.attrs.get("fit_style") == "h2_fit_nuisance" and fit_res_for_mu and fit_res_for_mu.get("fitted_nuisance_params"):
+        fit_res_for_mu = (
+            alt_model_fit_results
+            if alt_model_fit_results
+            and alt_model_fit_results.get("fitted_nuisance_params")
+            else lcdm_fit_results
+        )
+        if (
+            sne_data_df.attrs.get("fit_style") == "h2_fit_nuisance"
+            and fit_res_for_mu
+            and fit_res_for_mu.get("fitted_nuisance_params")
+        ):
             nuisance = fit_res_for_mu["fitted_nuisance_params"]
-            M_B, alpha, beta = nuisance["M_B"], nuisance["alpha_salt2"], nuisance["beta_salt2"]
-            sne_data_df["mu_obs"] = sne_data_df["mb"] - M_B + alpha * sne_data_df["x1"] - beta * sne_data_df["c"]
+            M_B, alpha, beta = (
+                nuisance["M_B"],
+                nuisance["alpha_salt2"],
+                nuisance["beta_salt2"],
+            )
+            sne_data_df["mu_obs"] = (
+                sne_data_df["mb"]
+                - M_B
+                + alpha * sne_data_df["x1"]
+                - beta * sne_data_df["c"]
+            )
         else:
-            logger.error("Cannot plot Hubble Diagram: 'mu_obs' column missing and could not be calculated.")
+            logger.error(
+                "Cannot plot Hubble Diagram: 'mu_obs' column missing and could not be calculated."
+            )
             return
 
     mu_obs_data = sne_data_df["mu_obs"].values
     z_data = sne_data_df["zcmb"].values
-    diag_errors_plot = sne_data_df.attrs.get("diag_errors_for_plot", np.ones_like(z_data) * 0.2)
-    z_plot_smooth = np.geomspace(max(np.min(z_data) * 0.9, 0.001), np.max(z_data) * 1.05, 200)
+    diag_errors_plot = sne_data_df.attrs.get(
+        "diag_errors_for_plot", np.ones_like(z_data) * 0.2
+    )
+    z_plot_smooth = np.geomspace(
+        max(np.min(z_data) * 0.9, 0.001), np.max(z_data) * 1.05, 200
+    )
 
-    fig, axs = plt.subplots(2, 1, figsize=(17, 12), sharex=True, gridspec_kw={"height_ratios": [3, 1.5], "hspace": 0.05})
+    fig, axs = plt.subplots(
+        2,
+        1,
+        figsize=(17, 12),
+        sharex=True,
+        gridspec_kw={"height_ratios": [3, 1.5], "hspace": 0.05},
+    )
     plt.subplots_adjust(left=0.08, bottom=0.12, right=0.75, top=0.92)
     try:
         plt.style.use("seaborn-v0_8-darkgrid")
@@ -184,25 +241,62 @@ def plot_hubble_diagram(
 
     if lcdm_fit_results and lcdm_fit_results.get("success"):
         p_lcdm = list(lcdm_fit_results["fitted_cosmological_params"].values())
-        mu_model_lcdm_smooth = lcdm_plugin.distance_modulus_model(z_plot_smooth, *p_lcdm)
+        mu_model_lcdm_smooth = lcdm_plugin.distance_modulus_model(
+            z_plot_smooth, *p_lcdm
+        )
         mu_model_lcdm_points = lcdm_plugin.distance_modulus_model(z_data, *p_lcdm)
         res_lcdm = mu_obs_data - mu_model_lcdm_points
         chi2_lcdm = f"{lcdm_fit_results.get('chi2_min', np.nan):.2f}"
-        axs[0].plot(z_plot_smooth, mu_model_lcdm_smooth, color="red", ls="-", label=fr"$\Lambda$CDM ($\chi^2$={chi2_lcdm})", lw=2.5)
-        axs[1].errorbar(z_data, res_lcdm, yerr=diag_errors_plot, fmt=".", color="red", alpha=0.5, label=r"$\Lambda$CDM Res.", elinewidth=1, capsize=2, ms=4)
+        axs[0].plot(
+            z_plot_smooth,
+            mu_model_lcdm_smooth,
+            color="red",
+            ls="-",
+            label=rf"$\Lambda$CDM ($\chi^2$={chi2_lcdm})",
+            lw=2.5,
+        )
+        axs[1].errorbar(
+            z_data,
+            res_lcdm,
+            yerr=diag_errors_plot,
+            fmt=".",
+            color="red",
+            alpha=0.5,
+            label=r"$\Lambda$CDM Res.",
+            elinewidth=1,
+            capsize=2,
+            ms=4,
+        )
         z_lcdm_avg, res_lcdm_avg = get_binned_average(z_data, res_lcdm)
         z_lcdm_avg, res_lcdm_avg = _smooth_line(z_lcdm_avg, res_lcdm_avg)
-        axs[1].plot(z_lcdm_avg, res_lcdm_avg, color="darkred", ls="-", lw=2, zorder=10, label=r"Avg. $\Lambda$CDM Res.")
+        axs[1].plot(
+            z_lcdm_avg,
+            res_lcdm_avg,
+            color="darkred",
+            ls="-",
+            lw=2,
+            zorder=10,
+            label=r"Avg. $\Lambda$CDM Res.",
+        )
 
     alt_name_raw = getattr(alt_model_plugin, "MODEL_NAME", "AltModel")
     alt_name_latex = alt_name_raw.replace("_", r"\_")
     if alt_model_fit_results and alt_model_fit_results.get("success"):
         p_alt = list(alt_model_fit_results["fitted_cosmological_params"].values())
-        mu_model_alt_smooth = alt_model_plugin.distance_modulus_model(z_plot_smooth, *p_alt)
+        mu_model_alt_smooth = alt_model_plugin.distance_modulus_model(
+            z_plot_smooth, *p_alt
+        )
         mu_model_alt_points = alt_model_plugin.distance_modulus_model(z_data, *p_alt)
         res_alt = mu_obs_data - mu_model_alt_points
         chi2_alt = f"{alt_model_fit_results.get('chi2_min', np.nan):.2f}"
-        axs[0].plot(z_plot_smooth, mu_model_alt_smooth, color="blue", ls="--", label=fr"{alt_name_latex} ($\chi^2$={chi2_alt})", lw=2.5)
+        axs[0].plot(
+            z_plot_smooth,
+            mu_model_alt_smooth,
+            color="blue",
+            ls="--",
+            label=rf"{alt_name_latex} ($\chi^2$={chi2_alt})",
+            lw=2.5,
+        )
         axs[1].errorbar(
             z_data,
             res_alt,
@@ -212,14 +306,22 @@ def plot_hubble_diagram(
             mec="blue",
             ecolor="lightblue",
             alpha=0.5,
-            label=fr"{alt_name_latex} Res.",
+            label=rf"{alt_name_latex} Res.",
             elinewidth=1,
             capsize=2,
             ms=4,
         )
         z_alt_avg, res_alt_avg = get_binned_average(z_data, res_alt)
         z_alt_avg, res_alt_avg = _smooth_line(z_alt_avg, res_alt_avg)
-        axs[1].plot(z_alt_avg, res_alt_avg, color="darkblue", ls="--", lw=2, zorder=11, label=f"Avg. {alt_name_latex} Res.")
+        axs[1].plot(
+            z_alt_avg,
+            res_alt_avg,
+            color="darkblue",
+            ls="--",
+            lw=2,
+            zorder=11,
+            label=f"Avg. {alt_name_latex} Res.",
+        )
 
     axs[0].set_ylabel(r"Distance Modulus ($\mu$)", fontsize=font_sizes["label"])
     axs[0].legend(fontsize=font_sizes["legend"], loc="lower right")
@@ -239,7 +341,9 @@ def plot_hubble_diagram(
     fig.text(
         0.77,
         0.90,
-        format_model_summary_text(lcdm_plugin, is_sne_summary=True, fit_results=lcdm_fit_results),
+        format_model_summary_text(
+            lcdm_plugin, is_sne_summary=True, fit_results=lcdm_fit_results
+        ),
         fontsize=font_sizes["infobox"],
         va="top",
         ha="left",
@@ -249,7 +353,9 @@ def plot_hubble_diagram(
     fig.text(
         0.77,
         0.52,
-        format_model_summary_text(alt_model_plugin, is_sne_summary=True, fit_results=alt_model_fit_results),
+        format_model_summary_text(
+            alt_model_plugin, is_sne_summary=True, fit_results=alt_model_fit_results
+        ),
         fontsize=font_sizes["infobox"],
         va="top",
         ha="left",
@@ -339,10 +445,18 @@ def plot_bao_observables(
             zorder=5,
         )
 
-    def plot_model_bao(results: Any, color: str, line_styles: list[str], label_prefix: str, alpha: float = 1.0) -> None:
+    def plot_model_bao(
+        results: Any,
+        color: str,
+        line_styles: list[str],
+        label_prefix: str,
+        alpha: float = 1.0,
+    ) -> None:
         """Internal helper to plot a model's smooth BAO curves."""
         if not results or not results.get("smooth_predictions"):
-            logger.warning(f"Skipping BAO plot for {label_prefix} as smooth predictions are missing.")
+            logger.warning(
+                f"Skipping BAO plot for {label_prefix} as smooth predictions are missing."
+            )
             return
 
         smooth_preds = results["smooth_predictions"]
@@ -354,26 +468,56 @@ def plot_bao_observables(
             if np.any(valid_indices):
                 ax.plot(z_vals[valid_indices], y_vals[valid_indices], **kwargs)
             else:
-                logger.warning(f"No valid data points to plot for {kwargs.get('label')}")
+                logger.warning(
+                    f"No valid data points to plot for {kwargs.get('label')}"
+                )
 
         if "DM_over_rs" in obs_types:
-            robust_plot(z, smooth_preds["dm_over_rs"], color=color, ls=line_styles[0], lw=2.5, label=fr"{label_prefix} ($D_M/r_s$)", alpha=alpha)
+            robust_plot(
+                z,
+                smooth_preds["dm_over_rs"],
+                color=color,
+                ls=line_styles[0],
+                lw=2.5,
+                label=rf"{label_prefix} ($D_M/r_s$)",
+                alpha=alpha,
+            )
         if "DH_over_rs" in obs_types:
-            robust_plot(z, smooth_preds["dh_over_rs"], color=color, ls=line_styles[1], lw=2.5, label=fr"{label_prefix} ($D_H/r_s$)", alpha=alpha)
+            robust_plot(
+                z,
+                smooth_preds["dh_over_rs"],
+                color=color,
+                ls=line_styles[1],
+                lw=2.5,
+                label=rf"{label_prefix} ($D_H/r_s$)",
+                alpha=alpha,
+            )
         if "DV_over_rs" in obs_types:
-            robust_plot(z, smooth_preds["dv_over_rs"], color=color, ls=line_styles[2], lw=2.5, label=fr"{label_prefix} ($D_V/r_s$)", alpha=alpha)
+            robust_plot(
+                z,
+                smooth_preds["dv_over_rs"],
+                color=color,
+                ls=line_styles[2],
+                lw=2.5,
+                label=rf"{label_prefix} ($D_V/r_s$)",
+                alpha=alpha,
+            )
 
     line_styles = ["-", "--", ":"]
     plot_model_bao(lcdm_full_results, "red", line_styles, r"$\Lambda$CDM")
 
     alt_name_raw = getattr(alt_model_plugin, "MODEL_NAME", "AltModel")
     alt_name_latex = alt_name_raw.replace("_", r"\_")
-    plot_model_bao(alt_model_full_results, "blue", line_styles, alt_name_latex, alpha=0.25)
+    plot_model_bao(
+        alt_model_full_results, "blue", line_styles, alt_name_latex, alpha=0.25
+    )
 
     # --- Residuals ---
+    all_res = []
     lcdm_pred = lcdm_full_results.get("pred_df")
     if lcdm_pred is not None:
         res_lcdm = bao_data_df["value"].values - lcdm_pred["model_prediction"].values
+        all_res.append(res_lcdm)
         res_ax.errorbar(
             bao_data_df["redshift"],
             res_lcdm,
@@ -388,11 +532,20 @@ def plot_bao_observables(
         )
         z_avg, r_avg = get_binned_average(bao_data_df["redshift"].values, res_lcdm)
         z_avg, r_avg = _smooth_line(z_avg, r_avg)
-        res_ax.plot(z_avg, r_avg, color="darkred", ls="-", lw=2, zorder=10, label=r"Avg. $\Lambda$CDM Res.")
+        res_ax.plot(
+            z_avg,
+            r_avg,
+            color="darkred",
+            ls="-",
+            lw=2,
+            zorder=10,
+            label=r"Avg. $\Lambda$CDM Res.",
+        )
 
     alt_pred = alt_model_full_results.get("pred_df")
     if alt_pred is not None:
         res_alt = bao_data_df["value"].values - alt_pred["model_prediction"].values
+        all_res.append(res_alt)
         res_ax.errorbar(
             bao_data_df["redshift"],
             res_alt,
@@ -402,17 +555,32 @@ def plot_bao_observables(
             mec="blue",
             ecolor="lightblue",
             alpha=0.5,
-            label=fr"{alt_name_latex} Res.",
+            label=rf"{alt_name_latex} Res.",
             elinewidth=1,
             capsize=2,
-            ms=4,
+            ms=7,
         )
         z_avg, r_avg = get_binned_average(bao_data_df["redshift"].values, res_alt)
         z_avg, r_avg = _smooth_line(z_avg, r_avg)
-        res_ax.plot(z_avg, r_avg, color="darkblue", ls="--", lw=2, zorder=11, label=f"Avg. {alt_name_latex} Res.")
+        res_ax.plot(
+            z_avg,
+            r_avg,
+            color="darkblue",
+            ls="--",
+            lw=2,
+            zorder=11,
+            label=f"Avg. {alt_name_latex} Res.",
+        )
+
+    if all_res:
+        max_res = np.nanmax(np.abs(np.concatenate(all_res)))
+        if np.isfinite(max_res) and max_res > 0:
+            res_ax.set_ylim(-1.2 * max_res, 1.2 * max_res)
 
     ax.set_ylabel(r"$D_X/r_s$", fontsize=font_sizes["label"])
-    ax.set_title(f"BAO Observables vs. Redshift: {dataset_name}", fontsize=font_sizes["title"])
+    ax.set_title(
+        f"BAO Observables vs. Redshift: {dataset_name}", fontsize=font_sizes["title"]
+    )
     ax.legend(fontsize=font_sizes["legend"], loc="best")
     ax.minorticks_on()
     ax.tick_params(axis="both", which="major", labelsize=font_sizes["ticks"])
@@ -484,12 +652,17 @@ def plot_bao_observables(
         plt.close(fig)
 
 
-def format_cmb_summary_text(model_plugin: Any, sne_results: Any, chi2_cmb: float) -> str:
+def format_cmb_summary_text(
+    model_plugin: Any,
+    sne_results: Any,
+    chi2_cmb: float,
+    chi2_total: float | None = None,
+) -> str:
     """Return formatted summary text for CMB plots."""
     lines: list[str] = []
     model_name_raw = getattr(model_plugin, "MODEL_NAME", "N/A")
     model_name_latex = model_name_raw.replace("_", r"\_")
-    lines.append(fr"**Model: {model_name_latex}**")
+    lines.append(rf"**Model: {model_name_latex}**")
 
     lines.append(r"$\mathbf{Cosmological\ Parameters:}$")
     param_names = getattr(model_plugin, "PARAMETER_NAMES", [])
@@ -500,7 +673,7 @@ def format_cmb_summary_text(model_plugin: Any, sne_results: Any, chi2_cmb: float
             val = fitted_cosmo_params.get(name)
             latex_name = param_latex_names[i] if i < len(param_latex_names) else name
             if val is not None:
-                lines.append(fr"  {latex_name} = ${val:.4g}$")
+                lines.append(rf"  {latex_name} = ${val:.4g}$")
             else:
                 lines.append(f"  {latex_name} = N/A")
     else:
@@ -508,9 +681,11 @@ def format_cmb_summary_text(model_plugin: Any, sne_results: Any, chi2_cmb: float
 
     lines.append(r"$\mathbf{CMB\ Fit\ Statistics:}$")
     if chi2_cmb is not None and np.isfinite(chi2_cmb):
-        lines.append(fr"  $\chi^2_{{CMB}}$ = {chi2_cmb:.2f}")
+        lines.append(rf"  $\chi^2_{{CMB}}$ = {chi2_cmb:.2f}")
     else:
         lines.append("  $\\chi^2_{CMB}$ = N/A")
+    if chi2_total is not None and np.isfinite(chi2_total):
+        lines.append(rf"  $\chi^2_{{tot}}$ = {chi2_total:.2f}")
 
     return "\n".join(lines)
 
@@ -617,12 +792,20 @@ def plot_cmb_spectrum(
         )
 
         if lcdm_theory is not None:
-            th = lcdm_theory.get(comp) if isinstance(lcdm_theory, dict) else (
-                lcdm_theory if comp == "TT" else None
+            th = (
+                lcdm_theory.get(comp)
+                if isinstance(lcdm_theory, dict)
+                else (lcdm_theory if comp == "TT" else None)
             )
             if th is not None:
-                chi2_lcdm = f"{lcdm_cmb_results.get('chi2_cmb', np.nan):.2f}" if comp == "TT" else ""
-                label = r"$\Lambda$CDM" + (rf" ($\chi^2$={chi2_lcdm})" if chi2_lcdm else "")
+                chi2_lcdm = (
+                    f"{lcdm_cmb_results.get('chi2_cmb', np.nan):.2f}"
+                    if comp == "TT"
+                    else ""
+                )
+                label = r"$\Lambda$CDM" + (
+                    rf" ($\chi^2$={chi2_lcdm})" if chi2_lcdm else ""
+                )
                 axs[idx_main].plot(ells, th, color="red", ls="-", lw=2.0, label=label)
                 cv = np.sqrt(2.0 / (2 * ells + 1.0)) * th
                 lower = np.clip(th - cv, 1e-8, None)
@@ -661,12 +844,20 @@ def plot_cmb_spectrum(
                 )
 
         if alt_theory is not None:
-            th = alt_theory.get(comp) if isinstance(alt_theory, dict) else (
-                alt_theory if comp == "TT" else None
+            th = (
+                alt_theory.get(comp)
+                if isinstance(alt_theory, dict)
+                else (alt_theory if comp == "TT" else None)
             )
             if th is not None:
-                chi2_alt = f"{alt_cmb_results.get('chi2_cmb', np.nan):.2f}" if comp == "TT" else ""
-                label = fr"{alt_name_latex}" + (rf" ($\chi^2$={chi2_alt})" if chi2_alt else "")
+                chi2_alt = (
+                    f"{alt_cmb_results.get('chi2_cmb', np.nan):.2f}"
+                    if comp == "TT"
+                    else ""
+                )
+                label = rf"{alt_name_latex}" + (
+                    rf" ($\chi^2$={chi2_alt})" if chi2_alt else ""
+                )
                 axs[idx_main].plot(ells, th, color="blue", ls="--", lw=2.0, label=label)
                 res = obs - th
                 axs[idx_res].errorbar(
@@ -678,7 +869,7 @@ def plot_cmb_spectrum(
                     mec="blue",
                     ecolor="lightblue",
                     alpha=0.5,
-                    label=fr"{alt_name_latex} Res." if i == 0 else None,
+                    label=rf"{alt_name_latex} Res." if i == 0 else None,
                     elinewidth=1,
                     capsize=2,
                     ms=4,
@@ -703,22 +894,34 @@ def plot_cmb_spectrum(
             f"CMB {comp} Power Spectrum: {dataset_name}", fontsize=font_sizes["title"]
         )
         axs[idx_main].minorticks_on()
-        axs[idx_main].tick_params(axis="both", which="major", labelsize=font_sizes["ticks"])
+        axs[idx_main].tick_params(
+            axis="both", which="major", labelsize=font_sizes["ticks"]
+        )
 
         axs[idx_res].axhline(0, color="black", ls="--", lw=1)
         if i == len(components) - 1:
             axs[idx_res].set_xlabel(r"Multipole $\ell$", fontsize=font_sizes["label"])
-        axs[idx_res].set_ylabel(r"$D_\ell^{obs} - D_\ell^{th}$", fontsize=font_sizes["label"])
-        axs[idx_res].legend(fontsize=font_sizes["legend"], loc="best")
+        axs[idx_res].set_ylabel(
+            r"$D_\ell^{obs} - D_\ell^{th}$", fontsize=font_sizes["label"]
+        )
+        if i == 0:
+            axs[idx_res].legend(fontsize=font_sizes["legend"], loc="best")
         axs[idx_res].minorticks_on()
-        axs[idx_res].tick_params(axis="both", which="major", labelsize=font_sizes["ticks"])
+        axs[idx_res].tick_params(
+            axis="both", which="major", labelsize=font_sizes["ticks"]
+        )
 
     bbox_lcdm = dict(boxstyle="round,pad=0.5", fc="#FFEEEE", ec="darkred", alpha=0.8)
     bbox_alt = dict(boxstyle="round,pad=0.5", fc="#EEF2FF", ec="darkblue", alpha=0.8)
     fig.text(
         0.77,
         0.90,
-        format_cmb_summary_text(lcdm_plugin, lcdm_sne_results, lcdm_cmb_results.get("chi2_cmb")),
+        format_cmb_summary_text(
+            lcdm_plugin,
+            lcdm_sne_results,
+            lcdm_cmb_results.get("chi2_cmb"),
+            lcdm_sne_results.get("chi2_total"),
+        ),
         fontsize=font_sizes["infobox"],
         va="top",
         ha="left",
@@ -728,7 +931,12 @@ def plot_cmb_spectrum(
     fig.text(
         0.77,
         0.55,
-        format_cmb_summary_text(alt_model_plugin, alt_sne_results, alt_cmb_results.get("chi2_cmb")),
+        format_cmb_summary_text(
+            alt_model_plugin,
+            alt_sne_results,
+            alt_cmb_results.get("chi2_cmb"),
+            alt_sne_results.get("chi2_total"),
+        ),
         fontsize=font_sizes["infobox"],
         va="top",
         ha="left",

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.12.5.  The `copernican_lib` package now collects all
+version 1.12.6.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.


### PR DESCRIPTION
## Summary
- extend footer wrapping to 185 characters
- fix empty CMB residual legend warning
- show combined and per-dataset chi² in plot info boxes
- narrow BAO residual axes and enlarge alt model markers
- ensure equations render as math
- document version 1.12.6

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68771121c390832f9b777c58b5436d2b