### PR TITLE
Improve logging and bump version to 1.12.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.6**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.7**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.12.7
+- 2025-07-16: Log now records console output verbatim and strips absolute paths (AI assistant)
+
 ## Version 1.12.6
 - 2025-07-16: Improved footer wrapping, plot legends and info boxes with combined chi2; tweaked BAO residuals (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.12.6
+**Version:** 1.12.7
 **Last Updated:** 2025-07-16
 
 The Copernican Suite is a Python toolkit for testing cosmological models against

--- a/copernican.py
+++ b/copernican.py
@@ -47,7 +47,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.12.6"
+COPERNICAN_VERSION = "1.12.7"
 CURRENT_LOG_FILE = None
 
 
@@ -424,7 +424,7 @@ def main_workflow():
 
     while True:
         global CURRENT_LOG_FILE
-        log_file = log_mod.setup_logging(log_dir=OUTPUT_DIR)
+        log_file = log_mod.setup_logging(log_dir=OUTPUT_DIR, base_dir=SCRIPT_DIR)
         CURRENT_LOG_FILE = log_file
         logger = log_mod.get_logger()
         start_ts = time.strftime("%y%m%d_%H%M%S")

--- a/copernican_lib/logger.py
+++ b/copernican_lib/logger.py
@@ -7,11 +7,64 @@
 import logging
 import os
 import sys
+import builtins
+import datetime
 from .utils import get_timestamp, ensure_dir_exists
 
 
-def setup_logging(log_dir="."):
-    """Initializes logging to both console and a file."""
+class _PathFilter(logging.Filter):
+    """Filter that strips absolute paths above the project root."""
+
+    def __init__(self, base_dir: str):
+        super().__init__()
+        self.base_dir = os.path.abspath(base_dir)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = record.msg.replace(self.base_dir + os.sep, "").replace(
+                self.base_dir, "."
+            )
+        return True
+
+
+def _patch_builtins(base_dir: str) -> None:
+    """Mirror print and input to the logger with path sanitisation."""
+
+    logger = logging.getLogger()
+    if getattr(builtins.print, "__copernican_patched__", False):
+        return
+
+    orig_print = builtins.print
+    orig_input = builtins.input
+
+    def _shorten(msg: str) -> str:
+        base = os.path.abspath(base_dir)
+        return msg.replace(base + os.sep, "").replace(base, ".")
+
+    def print_patch(*args, **kwargs):
+        orig_print(*args, **kwargs)
+        if kwargs.get("file", sys.stdout) is sys.stdout:
+            sep = kwargs.get("sep", " ")
+            end = kwargs.get("end", "\n")
+            message = sep.join(str(a) for a in args)
+            if end != "\n":
+                message += end
+            logger.info(_shorten(message))
+
+    def input_patch(prompt: str = ""):
+        response = orig_input(prompt)
+        logger.info(_shorten(f"{prompt}{response}"))
+        return response
+
+    print_patch.__copernican_patched__ = True
+    input_patch.__copernican_patched__ = True
+    builtins.print = print_patch
+    builtins.input = input_patch
+
+
+def setup_logging(log_dir: str = ".", base_dir: str | None = None) -> str:
+    """Initializes logging handlers and patches ``print``/``input``."""
+
     ensure_dir_exists(log_dir)
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
@@ -22,15 +75,21 @@ def setup_logging(log_dir="."):
 
     fh = logging.FileHandler(log_filename)
     fh.setLevel(logging.INFO)
-    fh.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+    fh.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+    if base_dir:
+        fh.addFilter(_PathFilter(base_dir))
     logger.addHandler(fh)
 
     ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(logging.INFO)
-    ch.setFormatter(logging.Formatter('%(message)s'))
+    ch.setFormatter(logging.Formatter("%(message)s"))
     logger.addHandler(ch)
 
     logging.info(f"Logging initialized. Log file: {log_filename}")
+
+    if base_dir:
+        _patch_builtins(base_dir)
+
     return log_filename
 
 

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.12.6.  The `copernican_lib` package now collects all
+version 1.12.7.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.


### PR DESCRIPTION
## Summary
- log console output via patched `print` and `input`
- sanitise file paths in log file and keep console output unchanged
- update docs and configuration for version 1.12.7

## Testing
- `python -m py_compile copernican_lib/logger.py copernican.py`
- `python -m unittest discover` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687764b66694832fa40099eb7631d3cd