### PR TITLE
Fix logging duplication and footer layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.7**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.8**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.12.8
+- 2025-07-19: Updated logger to avoid duplicate console output and capture user input (AI assistant)
+- 2025-07-19: Footer lines now rendered with smaller font to prevent overlap (AI assistant)
+
 ## Version 1.12.7
 - 2025-07-16: Log now records console output verbatim and strips absolute paths (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.12.7
-**Last Updated:** 2025-07-16
+**Version:** 1.12.8
+**Last Updated:** 2025-07-19
 
 The Copernican Suite is a Python toolkit for testing cosmological models against
 Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO) and Cosmic Microwave Background (CMB) data.

--- a/copernican.py
+++ b/copernican.py
@@ -47,7 +47,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.12.7"
+COPERNICAN_VERSION = "1.12.8"
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/logger.py
+++ b/copernican_lib/logger.py
@@ -1,8 +1,10 @@
 # Copernican Suite Logger
-"""Logging utilities for the Copernican Suite."""
-# The application writes human-readable logs both to the console and to a file
-# in the output directory. This module centralises the setup so every module can
-# retrieve the same logger instance.
+"""Logging utilities for the Copernican Suite.
+
+The logger records all console input and output verbatim while also emitting
+standard log messages. ``print`` and ``input`` are patched so their text is
+captured to the log file without being echoed twice on the console.
+"""
 
 import logging
 import os
@@ -27,6 +29,17 @@ class _PathFilter(logging.Filter):
         return True
 
 
+class _ConsoleFilter(logging.Filter):
+    """Filter to exclude captured console messages from the StreamHandler."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # When ``console_capture`` is True the message originated from
+        # ``print`` or ``input``. Those messages are already displayed on the
+        # console via the original call, so the stream handler should ignore
+        # them to avoid duplicate lines.
+        return not getattr(record, "console_capture", False)
+
+
 def _patch_builtins(base_dir: str) -> None:
     """Mirror print and input to the logger with path sanitisation."""
 
@@ -49,11 +62,17 @@ def _patch_builtins(base_dir: str) -> None:
             message = sep.join(str(a) for a in args)
             if end != "\n":
                 message += end
-            logger.info(_shorten(message))
+            logger.info(
+                _shorten(message),
+                extra={"console_capture": True},
+            )
 
     def input_patch(prompt: str = ""):
         response = orig_input(prompt)
-        logger.info(_shorten(f"{prompt}{response}"))
+        logger.info(
+            _shorten(f"{prompt}{response}"),
+            extra={"console_capture": True},
+        )
         return response
 
     print_patch.__copernican_patched__ = True
@@ -83,6 +102,9 @@ def setup_logging(log_dir: str = ".", base_dir: str | None = None) -> str:
     ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(logging.INFO)
     ch.setFormatter(logging.Formatter("%(message)s"))
+    # Exclude messages that already appeared on the console via patched
+    # ``print``/``input`` calls.
+    ch.addFilter(_ConsoleFilter())
     logger.addHandler(ch)
 
     logging.info(f"Logging initialized. Log file: {log_filename}")

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -71,16 +71,22 @@ def get_binned_average(
         return np.array([]), np.array([])
 
 
-def compose_footer(base_line: str, data_attrs: dict) -> str:
-    """Return a multi-line footer string with dataset information."""
+def compose_footer(base_line: str, data_attrs: dict) -> list[str]:
+    """Return footer lines with dataset information."""
+
     long_name = data_attrs.get(
         "dataset_long_name", data_attrs.get("dataset_name_attr", "")
     )
     notes = data_attrs.get("notes", "")
     citation = data_attrs.get("citation", "")
     second_line = f"{_wrap_math(long_name)}: {notes} {citation}".strip()
-    wrapped = textwrap.fill(second_line, width=185)
-    return base_line + "\n" + wrapped
+    # Allow more characters per line so lengthy citations do not wrap
+    # excessively. Each wrapped line will be drawn separately with a
+    # slightly smaller font size by the caller.
+    if second_line:
+        wrapped_lines = textwrap.wrap(second_line, width=200)
+        return [base_line] + wrapped_lines
+    return [base_line]
 
 
 def format_model_summary_text(
@@ -368,8 +374,12 @@ def plot_hubble_diagram(
         f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | "
         f"Copernican Suite {COPERNICAN_VERSION} | {ts}"
     )
-    footer = compose_footer(base_line, sne_data_df.attrs)
-    fig.text(0.5, 0.02, footer, ha="center", fontsize=font_sizes["ticks"], wrap=True)
+    footer_lines = compose_footer(base_line, sne_data_df.attrs)
+    y = 0.02
+    for idx, line in enumerate(footer_lines):
+        fs = font_sizes["ticks"] if idx == 0 else font_sizes["ticks"] - 1
+        fig.text(0.5, y, line, ha="center", fontsize=fs, wrap=True)
+        y -= 0.015
 
     model_comparison_name = f"{lcdm_plugin.MODEL_NAME}-vs-{alt_model_plugin.MODEL_NAME}"
     filename = generate_filename(
@@ -632,8 +642,12 @@ def plot_bao_observables(
         f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | "
         f"Copernican Suite {COPERNICAN_VERSION} | {ts}"
     )
-    footer = compose_footer(base_line, bao_data_df.attrs)
-    fig.text(0.5, 0.02, footer, ha="center", fontsize=font_sizes["ticks"], wrap=True)
+    footer_lines = compose_footer(base_line, bao_data_df.attrs)
+    y = 0.02
+    for idx, line in enumerate(footer_lines):
+        fs = font_sizes["ticks"] if idx == 0 else font_sizes["ticks"] - 1
+        fig.text(0.5, y, line, ha="center", fontsize=fs, wrap=True)
+        y -= 0.015
 
     model_comparison_name = f"{lcdm_plugin.MODEL_NAME}-vs-{alt_model_plugin.MODEL_NAME}"
     filename = generate_filename(
@@ -949,8 +963,12 @@ def plot_cmb_spectrum(
         f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | "
         f"Copernican Suite {COPERNICAN_VERSION} | {ts}"
     )
-    footer = compose_footer(base_line, cmb_data_df.attrs)
-    fig.text(0.5, 0.02, footer, ha="center", fontsize=font_sizes["ticks"], wrap=True)
+    footer_lines = compose_footer(base_line, cmb_data_df.attrs)
+    y = 0.02
+    for idx, line in enumerate(footer_lines):
+        fs = font_sizes["ticks"] if idx == 0 else font_sizes["ticks"] - 1
+        fig.text(0.5, y, line, ha="center", fontsize=fs, wrap=True)
+        y -= 0.015
 
     model_comparison_name = f"{lcdm_plugin.MODEL_NAME}-vs-{alt_model_plugin.MODEL_NAME}"
     filename = generate_filename(

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.12.7.  The `copernican_lib` package now collects all
+version 1.12.8.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.


### PR DESCRIPTION
## Summary
- capture console input and output without double-printing
- improve footer layout by drawing wrapped lines with smaller font
- bump version to 1.12.8 and update docs

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_687ba88b50e4832f80d3c75ec4483c6b