### PR TITLE
Improve docs, add contributing guide, bump version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.8**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.9**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.
@@ -35,6 +35,9 @@ AGENTS.md         - Development specification and contributor rules
 CHANGELOG.md      - Release history
 copernican_lib/optim_utils.py - Shared optimisation helpers used by engines
 ```
+Installing the suite with `pip` produces a `copernican_suite.egg-info` directory
+containing build metadata. This folder can be safely removed and should not be
+edited manually.
 Files in `data/` are read-only and must not be modified by AI-driven changes.
 
 The current plotting style and algorithms are considered stable. Do not alter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.12.9
+- 2025-07-19: Expanded and clarified documentation; explained `.egg-info` folder and added CONTRIBUTING guide (AI assistant)
+
 ## Version 1.12.8
 - 2025-07-19: Updated logger to avoid duplicate console output and capture user input (AI assistant)
 - 2025-07-19: Footer lines now rendered with smaller font to prevent overlap (AI assistant)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to the Copernican Suite
+
+Thank you for considering a contribution. Before opening a pull request, please
+read `AGENTS.md` for the full development specification. The quick checklist is:
+
+1. Run the test suite with `python -m unittest discover` or `copernican.py --run-tests`.
+2. Document your changes in `CHANGELOG.md` using the `- YYYY-MM-DD: summary (author)` format.
+3. Update documentation where needed, including `README.md` and `AGENTS.md`.
+4. Ensure your code is well commented and follows the project's style.
+
+Pull requests that do not meet these requirements may be rejected.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-**Version:** 1.12.8
+**Version:** 1.12.9
 **Last Updated:** 2025-07-19
 
-The Copernican Suite is a Python toolkit for testing cosmological models against
-Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO) and Cosmic Microwave Background (CMB) data.
-Support for gravitational waves and standard siren events is planned for future releases. The suite provides a modular
-architecture so new models, data parsers and computational engines can be
+The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
+Support for gravitational waves and standard siren events is planned for future releases.
+The suite provides a modular architecture so new models, data parsers and computational engines can be plugged in with minimal effort.
 Additional design notes can be found under the `docs/` directory.
-plugged in with minimal effort.
 
 ---
 
@@ -112,6 +110,11 @@ pip install .    # regular install
 pip install -e . # editable for development
 ```
 
+Installing the suite with `pip` creates a `copernican_suite.egg-info` directory.
+This folder contains package metadata such as the version number, dependency
+list and entry points used by Python's packaging tools. It is generated
+automatically and does not need to be tracked in version control.
+
 
 ## Directory Layout
 ```
@@ -124,6 +127,7 @@ data/             - Observation data organized as ``data/<type>/<source>/``
                          (binary Fortran matrix)
 output/           - All generated results
 AGENTS.md         - Development specification and contributor rules
+CONTRIBUTING.md   - Quick checklist for pull requests
 CHANGELOG.md      - Release history
 copernican_lib/          - Helper modules
   logger.py         - Logging setup and helpers
@@ -266,6 +270,8 @@ Code should be thoroughly commented so future contributors can
 understand the reasoning behind each step. The documentation in `README.md` and
 `AGENTS.md` must be updated whenever behavior or structure changes.
 See `CHANGELOG.md` for the complete project history.
+The short file `CONTRIBUTING.md` summarises the basic workflow for submitting
+patches and links back to these guidelines.
 
 To start developing, install the suite in editable mode:
 

--- a/copernican.py
+++ b/copernican.py
@@ -47,7 +47,7 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.12.8"
+COPERNICAN_VERSION = "1.12.9"
 CURRENT_LOG_FILE = None
 
 

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.12.8.  The `copernican_lib` package now collects all
+version 1.12.9.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.


### PR DESCRIPTION
## Summary
- document `.egg-info` usage
- fix truncated README introduction
- add `CONTRIBUTING.md`
- note `egg-info` directory in AGENTS
- bump version to 1.12.9 in docs and code

## Testing
- `python -m unittest discover` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687bae31934c832fad09c578217dc029