### PR TITLE
Implement automatic semver bumping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.12.9**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.13.0**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.
@@ -136,7 +136,7 @@ To keep the project maintainable all contributors, human or AI, must follow thes
 1. **Summarize every change in `CHANGELOG.md`.** Use the template `- YYYY-MM-DD: short summary (author)` for each entry. Legacy `dev_note` headers should be migrated to the changelog when touched.
 2. **Comment code extensively** to explain non-obvious logic or algorithms.
 3. **Update documentation**, including this `AGENTS.md` and `README.md`, whenever behavior or structure changes.
-4. **Do not change the project version number unless explicitly requested by a human contributor.**
+4. **Bump the project version according to Semantic Versioning whenever changes introduce new features, fixes or breaking changes.**
 5. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in any file.**
 6. **Use raw string literals for regular expressions, docstrings with LaTeX or backslashes, and Windows paths** to avoid Python's "invalid escape sequence" warnings.
 
@@ -146,4 +146,5 @@ Failure to follow these guidelines will compromise the Copernican Suite.
 The project follows Semantic Versioning (`MAJOR.MINOR.PATCH`). Increment the
 `MAJOR` number for breaking changes, the `MINOR` for new backward-compatible
 features and the `PATCH` for bug fixes. Package versions are derived from Git
-tags using `setuptools_scm`.
+tags using `setuptools_scm`. Contributors must update the version whenever
+a pull request introduces a change covered by these rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check what is the current date when you are logging last changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Use this template:
 
+## Version 1.13.0
+- 2025-07-24: Enforced automatic SemVer bumps and updated version references (AI assistant)
+
 ## Version 1.12.9
 - 2025-07-19: Expanded and clarified documentation; explained `.egg-info` folder and added CONTRIBUTING guide (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.12.9
-**Last Updated:** 2025-07-19
+**Version:** 1.13.0
+**Last Updated:** 2025-07-24
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.

--- a/copernican.py
+++ b/copernican.py
@@ -6,6 +6,7 @@ Copernican Suite - Main Orchestrator.
 
 import importlib.util
 import importlib
+from importlib.metadata import version as package_version, PackageNotFoundError
 import ast
 import os
 import sys
@@ -47,7 +48,10 @@ log_mod = None
 logger = None
 data_loaders = None
 
-COPERNICAN_VERSION = "1.12.9"
+try:
+    COPERNICAN_VERSION = package_version("copernican-suite")
+except PackageNotFoundError:
+    COPERNICAN_VERSION = "1.13.0"
 CURRENT_LOG_FILE = None
 
 

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,7 +1,7 @@
 # Copernican Suite Architecture
 
 This short document explains the updated folder layout introduced in
-version 1.12.9.  The `copernican_lib` package now collects all
+version 1.13.0.  The `copernican_lib` package now collects all
 reusable modules that were previously found under `scripts/`.  Engines
 and data parsers import utilities from this package so they can remain
 focused on numerical work.


### PR DESCRIPTION
## Summary
- enforce automatic semantic versioning in AGENTS.md
- update docs and README for version 1.13.0
- fetch package version dynamically with fallback in copernican.py
- document change in CHANGELOG

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_688228866750832f9d9bd8aa8c04cb6a