### PR TITLE
Fix JLA covariance handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.3**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.4**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes below and keep the line after this one empty:
 
+## Version 1.14.4
+- 2025-07-27: Handled near-singular JLA covariance by falling back to diagonal errors (AI assistant)
+
 ## Version 1.14.3
 - 2025-07-27: Removed deprecated UniStra SNe data and fixed JLA covariance handling (AI assistant)
 - 2025-07-27: Improved fit report outputs and enlarged plot dimensions (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.14.3
+**Version:** 1.14.4
 **Last Updated:** 2025-07-27
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.

--- a/data/sne/jla2014/cosmo_parser_jla2014.py
+++ b/data/sne/jla2014/cosmo_parser_jla2014.py
@@ -98,7 +98,14 @@ def parse_jla2014(
                 A[i, idx + 2] = -salt2_beta_fixed
             mu_cov = A @ cov_params @ A.T
             diag_errors_for_plot = np.sqrt(np.diag(mu_cov))
-            covariance_matrix_inv = np.linalg.inv(mu_cov)
+            cond = np.linalg.cond(mu_cov)
+            if np.isfinite(cond) and cond < 1e8:
+                covariance_matrix_inv = np.linalg.inv(mu_cov)
+            else:
+                logger.warning(
+                    "JLA covariance matrix nearly singular; falling back to diagonal errors"
+                )
+                covariance_matrix_inv = None
         except Exception as e:
             logger.warning(f"Could not process JLA covariance matrix: {e}")
             covariance_matrix_inv = None

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -18,3 +18,14 @@ The suite exposes a small API intended for advanced scripting. The
 
 Plugins are validated through `engine_interface.validate_plugin` before use.
 Engines expect the attributes listed in `engine_interface.REQUIRED_ATTRIBUTES`.
+
+## Standardised Dataset Format
+
+All data parsers return a `pandas.DataFrame` with common columns and
+metadata so that the engines remain agnostic to the origin of the data.
+For supernovae datasets the table contains at minimum `Name`, `zcmb`,
+`mu_obs` and `e_mu_obs`.  Attributes such as `covariance_matrix_inv`,
+`diag_errors_for_plot` and `dataset_name_attr` are attached via the
+``DataFrame.attrs`` dictionary.  BAO and CMB loaders follow the same
+pattern.  New datasets can therefore be added simply by placing them
+under ``data/<type>/<source>/`` and providing a compatible parser.

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -21,6 +21,9 @@ Every dataset folder also provides a `metadata_*.json` describing the source. Th
 *Source:* "Improved cosmological constraints from a joint analysis of the SDSS-II and SNLS supernova samples" (Betoule et al. 2014).
 *Location:* `data/sne/jla2014/`.
 *Parser:* `cosmo_parser_jla2014.py` reads `tablef3.dat` together with the full covariance matrix in `tablef4.fit` to provide distance moduli with systematic uncertainties.
+If the covariance matrix is nearly singular the parser logs a warning and
+falls back to the diagonal errors only. This ensures chi-squared values remain
+well-behaved when the full matrix cannot be inverted reliably.
 
 ### Pantheon+ 2022 (Scolnic et al.)
 *Source:* Pantheon+SH0ES data release (Scolnic et al. 2022).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "sympy",
     "jsonschema",
     "camb",
+    "astropy",
 ]
 
 [project.scripts]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -30,7 +30,7 @@ class FunctionalTestCase(unittest.TestCase):
         sne_df = data_loaders.load_sne_data('JLA 2014 (Betoule et al.)')
         self.assertIsNotNone(sne_df)
         sne_df = sne_df.head(3)
-        if 'covariance_matrix_inv' in sne_df.attrs:
+        if sne_df.attrs.get('covariance_matrix_inv') is not None:
             sne_df.attrs['covariance_matrix_inv'] = sne_df.attrs['covariance_matrix_inv'][:3, :3]
             sne_df.attrs['diag_errors_for_plot'] = sne_df.attrs['diag_errors_for_plot'][:3]
 
@@ -64,7 +64,7 @@ class FunctionalTestCase(unittest.TestCase):
 
     def test_combined_fit(self):
         sne_df = data_loaders.load_sne_data('JLA 2014 (Betoule et al.)').head(2)
-        if 'covariance_matrix_inv' in sne_df.attrs:
+        if sne_df.attrs.get('covariance_matrix_inv') is not None:
             sne_df.attrs['covariance_matrix_inv'] = sne_df.attrs['covariance_matrix_inv'][:2, :2]
             sne_df.attrs['diag_errors_for_plot'] = sne_df.attrs['diag_errors_for_plot'][:2]
         bao_df = data_loaders.load_bao_data('Test BAO dataset').head(2)


### PR DESCRIPTION
## Summary
- handle near-singular JLA covariance by falling back to diagonal errors
- document standardised DataFrame interface and dataset quirks
- update version to 1.14.4
- relax tests to work without covariance
- add `astropy` as a dependency

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_688497aa3c5c832fbf95d4b3d83830f2