### PR TITLE
Fix JLA covariance docs and update plot layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.4**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.5**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes below and keep the line after this one empty:
 
+## Version 1.14.5
+- 2025-07-26: Documented JLA covariance fallback and tightened info box layout (AI assistant)
+
 ## Version 1.14.4
 - 2025-07-27: Handled near-singular JLA covariance by falling back to diagonal errors (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.14.4
+**Version:** 1.14.5
 **Last Updated:** 2025-07-27
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.

--- a/copernican.py
+++ b/copernican.py
@@ -50,7 +50,7 @@ data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
 # outdated. Automatic releases are not yet enabled.
-COPERNICAN_VERSION = "1.14.4"
+COPERNICAN_VERSION = "1.14.5"
 CURRENT_LOG_FILE = None
 
 
@@ -723,8 +723,8 @@ def main_workflow():
             if sne_res:
                 for name, val in sne_res.get("fitted_cosmological_params", {}).items():
                     print(f"  {name} = {val:.5g}")
-            chi2_sne = sne_res.get('chi2_sne', sne_res.get('chi2_min', float('nan')))
-            chi2_total = sne_res.get('chi2_total', float('nan'))
+            chi2_sne = sne_res.get("chi2_sne", sne_res.get("chi2_min", float("nan")))
+            chi2_total = sne_res.get("chi2_total", float("nan"))
             print(f"  χ²_Total = {chi2_total:.2f}")
             print(f"  χ²_SNe = {chi2_sne:.2f}")
             if bao_res:

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -241,6 +241,12 @@ def plot_hubble_diagram(
         max(np.min(z_data) * 0.9, 0.001), np.max(z_data) * 1.05, 200
     )
 
+    info_gap = 0.02
+    left = 0.08
+    right = 0.75
+    top = 0.92
+    box_height = 0.33
+
     fig, axs = plt.subplots(
         2,
         1,
@@ -248,7 +254,19 @@ def plot_hubble_diagram(
         sharex=True,
         gridspec_kw={"height_ratios": [4, 1.5], "hspace": 0.05},
     )
-    plt.subplots_adjust(left=0.08, bottom=0.24, right=0.75, top=0.92)
+
+    footer_lines = compose_footer(
+        f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | Copernican Suite {COPERNICAN_VERSION} | {timestamp or get_timestamp()}",
+        sne_data_df.attrs,
+    )
+    line_height = 0.015
+    footer_height = len(footer_lines) * line_height
+    plt.subplots_adjust(
+        left=left,
+        right=right,
+        top=top,
+        bottom=left + footer_height + info_gap,
+    )
 
     axs[0].errorbar(
         z_data,
@@ -366,9 +384,11 @@ def plot_hubble_diagram(
 
     bbox_lcdm = dict(boxstyle="round,pad=0.5", fc="#FFEEEE", ec="darkred", alpha=0.8)
     bbox_alt = dict(boxstyle="round,pad=0.5", fc="#EEF2FF", ec="darkblue", alpha=0.8)
+    red_y = top - info_gap
+    blue_y = red_y - box_height - info_gap
     fig.text(
         0.77,
-        0.90,
+        red_y,
         format_model_summary_text(
             lcdm_plugin,
             "sne",
@@ -382,7 +402,7 @@ def plot_hubble_diagram(
     )
     fig.text(
         0.77,
-        0.52,
+        blue_y,
         format_model_summary_text(
             alt_model_plugin,
             "sne",
@@ -395,17 +415,11 @@ def plot_hubble_diagram(
         bbox=bbox_alt,
     )
 
-    ts = timestamp or get_timestamp()
-    base_line = (
-        f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | "
-        f"Copernican Suite {COPERNICAN_VERSION} | {ts}"
-    )
-    footer_lines = compose_footer(base_line, sne_data_df.attrs)
-    y = 0.07
+    y = left + footer_height
     for idx, line in enumerate(footer_lines):
         fs = font_sizes["ticks"] if idx == 0 else font_sizes["ticks"] - 1
         fig.text(0.5, y, line, ha="center", fontsize=fs, wrap=True)
-        y -= 0.015
+        y -= line_height
 
     model_comparison_name = f"{lcdm_plugin.MODEL_NAME}-vs-{alt_model_plugin.MODEL_NAME}"
     filename = generate_filename(
@@ -450,6 +464,12 @@ def plot_bao_observables(
         "ticks": 12,
     }
 
+    info_gap = 0.02
+    left = 0.08
+    right = 0.75
+    top = 0.90
+    box_height = 0.33
+
     fig, axs = plt.subplots(
         2,
         1,
@@ -459,7 +479,16 @@ def plot_bao_observables(
     )
     ax = axs[0]
     res_ax = axs[1]
-    plt.subplots_adjust(left=0.08, bottom=0.24, right=0.75, top=0.90)
+
+    footer_lines = compose_footer(
+        f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | Copernican Suite {COPERNICAN_VERSION} | {timestamp or get_timestamp()}",
+        bao_data_df.attrs,
+    )
+    line_height = 0.015
+    footer_height = len(footer_lines) * line_height
+    plt.subplots_adjust(
+        left=left, right=right, top=top, bottom=left + footer_height + info_gap
+    )
 
     obs_types = bao_data_df["observable_type"].unique()
     cmap = plt.get_cmap("viridis")
@@ -630,9 +659,11 @@ def plot_bao_observables(
 
     bbox_lcdm = dict(boxstyle="round,pad=0.5", fc="#FFEEEE", ec="darkred", alpha=0.8)
     bbox_alt = dict(boxstyle="round,pad=0.5", fc="#EEF2FF", ec="darkblue", alpha=0.8)
+    red_y = top - info_gap
+    blue_y = red_y - box_height - info_gap
     fig.text(
         0.77,
-        0.90,
+        red_y,
         format_model_summary_text(
             lcdm_plugin,
             "bao",
@@ -647,7 +678,7 @@ def plot_bao_observables(
     )
     fig.text(
         0.77,
-        0.55,
+        blue_y,
         format_model_summary_text(
             alt_model_plugin,
             "bao",
@@ -661,17 +692,11 @@ def plot_bao_observables(
         bbox=bbox_alt,
     )
 
-    ts = timestamp or get_timestamp()
-    base_line = (
-        f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | "
-        f"Copernican Suite {COPERNICAN_VERSION} | {ts}"
-    )
-    footer_lines = compose_footer(base_line, bao_data_df.attrs)
-    y = 0.07
+    y = left + footer_height
     for idx, line in enumerate(footer_lines):
         fs = font_sizes["ticks"] if idx == 0 else font_sizes["ticks"] - 1
         fig.text(0.5, y, line, ha="center", fontsize=fs, wrap=True)
-        y -= 0.015
+        y -= line_height
 
     model_comparison_name = f"{lcdm_plugin.MODEL_NAME}-vs-{alt_model_plugin.MODEL_NAME}"
     filename = generate_filename(
@@ -688,8 +713,6 @@ def plot_bao_observables(
         logger.error(f"Error saving BAO plot: {exc}")
     finally:
         plt.close(fig)
-
-
 
 
 def plot_cmb_spectrum(
@@ -738,14 +761,29 @@ def plot_cmb_spectrum(
     if "Dl_ee_obs" in cmb_data_df.columns:
         components.append("EE")
 
+    info_gap = 0.02
+    left = 0.08
+    right = 0.75
+    top = 0.92
+    box_height = 0.33
+
     fig, axs = plt.subplots(
         len(components) * 2,
         1,
         figsize=(17, 6 * len(components)),
         sharex=True,
-        gridspec_kw={"height_ratios": [3, 1.5] * len(components), "hspace": 0.05},
+        gridspec_kw={"height_ratios": [4, 1.5] * len(components), "hspace": 0.05},
     )
-    plt.subplots_adjust(left=0.08, bottom=0.24, right=0.75, top=0.92)
+
+    footer_lines = compose_footer(
+        f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | Copernican Suite {COPERNICAN_VERSION} | {timestamp or get_timestamp()}",
+        cmb_data_df.attrs,
+    )
+    line_height = 0.015
+    footer_height = len(footer_lines) * line_height
+    plt.subplots_adjust(
+        left=left, right=right, top=top, bottom=left + footer_height + info_gap
+    )
 
     lcdm_theory = None
     alt_theory = None
@@ -890,14 +928,19 @@ def plot_cmb_spectrum(
         if comp in ("TT", "EE"):
             axs[idx_main].set_yscale("log")
         axs[idx_main].legend(fontsize=font_sizes["legend"], loc="best")
+        title_pad = 20 if i > 0 else 10
         axs[idx_main].set_title(
-            f"CMB {comp} Power Spectrum: {dataset_name}", fontsize=font_sizes["title"]
+            f"CMB {comp} Power Spectrum: {dataset_name}",
+            fontsize=font_sizes["title"],
+            pad=title_pad,
         )
         axs[idx_main].minorticks_on()
         axs[idx_main].tick_params(
             axis="both", which="major", labelsize=font_sizes["ticks"]
         )
-        axs[idx_main].grid(True, which="both", color="#E0E0E0", linestyle="-", linewidth=0.5)
+        axs[idx_main].grid(
+            True, which="both", color="#E0E0E0", linestyle="-", linewidth=0.5
+        )
 
         axs[idx_res].axhline(0, color="black", ls="--", lw=1)
         if i == len(components) - 1:
@@ -911,13 +954,17 @@ def plot_cmb_spectrum(
         axs[idx_res].tick_params(
             axis="both", which="major", labelsize=font_sizes["ticks"]
         )
-        axs[idx_res].grid(True, which="both", color="#E0E0E0", linestyle="-", linewidth=0.5)
+        axs[idx_res].grid(
+            True, which="both", color="#E0E0E0", linestyle="-", linewidth=0.5
+        )
 
     bbox_lcdm = dict(boxstyle="round,pad=0.5", fc="#FFEEEE", ec="darkred", alpha=0.8)
     bbox_alt = dict(boxstyle="round,pad=0.5", fc="#EEF2FF", ec="darkblue", alpha=0.8)
+    red_y = top - info_gap
+    blue_y = red_y - box_height - info_gap
     fig.text(
         0.77,
-        0.90,
+        red_y,
         format_model_summary_text(
             lcdm_plugin,
             "cmb",
@@ -933,7 +980,7 @@ def plot_cmb_spectrum(
     )
     fig.text(
         0.77,
-        0.55,
+        blue_y,
         format_model_summary_text(
             alt_model_plugin,
             "cmb",
@@ -948,17 +995,11 @@ def plot_cmb_spectrum(
         bbox=bbox_alt,
     )
 
-    ts = timestamp or get_timestamp()
-    base_line = (
-        f"\u039bCDM vs {alt_model_plugin.MODEL_NAME} | "
-        f"Copernican Suite {COPERNICAN_VERSION} | {ts}"
-    )
-    footer_lines = compose_footer(base_line, cmb_data_df.attrs)
-    y = 0.07
+    y = left + footer_height
     for idx, line in enumerate(footer_lines):
         fs = font_sizes["ticks"] if idx == 0 else font_sizes["ticks"] - 1
         fig.text(0.5, y, line, ha="center", fontsize=fs, wrap=True)
-        y -= 0.015
+        y -= line_height
 
     model_comparison_name = f"{lcdm_plugin.MODEL_NAME}-vs-{alt_model_plugin.MODEL_NAME}"
     filename = generate_filename(

--- a/data/sne/jla2014/cosmo_parser_jla2014.py
+++ b/data/sne/jla2014/cosmo_parser_jla2014.py
@@ -1,4 +1,9 @@
-"""Parser for the JLA 2014 supernova sample with full covariance matrix."""
+"""Parser for the JLA 2014 supernova sample.
+
+The covariance matrix from `tablef4.fit` is loaded but usually
+discarded because its inversion is ill-conditioned. The parser therefore
+falls back to using only diagonal errors for chi-squared evaluation and
+plots."""
 
 import os
 import pandas as pd
@@ -40,39 +45,83 @@ def parse_jla2014(
     filepath = os.path.join(data_dir, "tablef3.dat")
     covpath = os.path.join(data_dir, "tablef4.fit")
     col_specs = [
-        (0, 12), (12, 21), (21, 30), (30, 31), (31, 41), (41, 50),
-        (50, 60), (60, 69), (69, 79), (79, 88), (88, 98), (98, 108),
-        (108, 121), (121, 130), (130, 140), (140, 150), (150, 160),
-        (160, 161), (161, 172), (172, 183), (183, 193)
+        (0, 12),
+        (12, 21),
+        (21, 30),
+        (30, 31),
+        (31, 41),
+        (41, 50),
+        (50, 60),
+        (60, 69),
+        (69, 79),
+        (79, 88),
+        (88, 98),
+        (98, 108),
+        (108, 121),
+        (121, 130),
+        (130, 140),
+        (140, 150),
+        (150, 160),
+        (160, 161),
+        (161, 172),
+        (172, 183),
+        (183, 193),
     ]
     col_names = [
-        'Name','zcmb_str','zhel_str','e_z_str','mb_str','e_mb_str','x1_str','e_x1_str',
-        'c_str','e_c_str','logMst_str','e_logMst_str','tmax_str','e_tmax_str',
-        'cov_mb_x1_str','cov_mb_c_str','cov_x1_c_str','set_str','RAdeg_str','DEdeg_str',
-        'bias_str'
+        "Name",
+        "zcmb_str",
+        "zhel_str",
+        "e_z_str",
+        "mb_str",
+        "e_mb_str",
+        "x1_str",
+        "e_x1_str",
+        "c_str",
+        "e_c_str",
+        "logMst_str",
+        "e_logMst_str",
+        "tmax_str",
+        "e_tmax_str",
+        "cov_mb_x1_str",
+        "cov_mb_c_str",
+        "cov_x1_c_str",
+        "set_str",
+        "RAdeg_str",
+        "DEdeg_str",
+        "bias_str",
     ]
     try:
-        df = pd.read_fwf(filepath, colspecs=col_specs, names=col_names, dtype=str, comment="#")
+        df = pd.read_fwf(
+            filepath, colspecs=col_specs, names=col_names, dtype=str, comment="#"
+        )
     except Exception as e:
         logger.error(f"Error reading JLA data file: {e}")
         return None
 
     parsed = pd.DataFrame()
-    parsed['Name'] = df['Name'].str.strip()
-    for new_col, old in {'zcmb':'zcmb_str','mb':'mb_str','e_mb':'e_mb_str','x1':'x1_str','c':'c_str'}.items():
-        parsed[new_col] = pd.to_numeric(df[old], errors='coerce')
+    parsed["Name"] = df["Name"].str.strip()
+    for new_col, old in {
+        "zcmb": "zcmb_str",
+        "mb": "mb_str",
+        "e_mb": "e_mb_str",
+        "x1": "x1_str",
+        "c": "c_str",
+    }.items():
+        parsed[new_col] = pd.to_numeric(df[old], errors="coerce")
 
-    if parsed[['mb','x1','c']].isnull().any().any():
+    if parsed[["mb", "x1", "c"]].isnull().any().any():
         logger.error("JLA data missing mb, x1 or c values")
         return None
 
-    parsed['mu_obs'] = (
-        parsed['mb'] - salt2_m_abs_fixed +
-        salt2_alpha_fixed * parsed['x1'] - salt2_beta_fixed * parsed['c']
+    parsed["mu_obs"] = (
+        parsed["mb"]
+        - salt2_m_abs_fixed
+        + salt2_alpha_fixed * parsed["x1"]
+        - salt2_beta_fixed * parsed["c"]
     )
-    parsed['e_mu_obs'] = pd.to_numeric(df['e_mb_str'], errors='coerce')
+    parsed["e_mu_obs"] = pd.to_numeric(df["e_mb_str"], errors="coerce")
 
-    essential_cols = ['Name','zcmb','mu_obs','e_mu_obs']
+    essential_cols = ["Name", "zcmb", "mu_obs", "e_mu_obs"]
     parsed = parsed[essential_cols].dropna().copy()
     if parsed.empty:
         logger.error("No valid SNe after parsing JLA data")
@@ -86,7 +135,7 @@ def parse_jla2014(
         cov_params = None
 
     covariance_matrix_inv = None
-    diag_errors_for_plot = parsed['e_mu_obs'].values
+    diag_errors_for_plot = parsed["e_mu_obs"].values
     if cov_params is not None:
         try:
             n_sne = len(parsed)
@@ -110,20 +159,22 @@ def parse_jla2014(
             logger.warning(f"Could not process JLA covariance matrix: {e}")
             covariance_matrix_inv = None
 
-    sort_idx = np.argsort(parsed['zcmb'].values)
+    sort_idx = np.argsort(parsed["zcmb"].values)
     parsed = parsed.iloc[sort_idx].reset_index(drop=True)
     diag_errors_for_plot = diag_errors_for_plot[sort_idx]
     if covariance_matrix_inv is not None:
         covariance_matrix_inv = covariance_matrix_inv[sort_idx][:, sort_idx]
 
-    parsed.attrs['covariance_matrix_inv'] = covariance_matrix_inv
-    parsed.attrs['diag_errors_for_plot'] = diag_errors_for_plot
-    parsed.attrs['salt2_m_abs_fixed'] = salt2_m_abs_fixed
-    parsed.attrs['salt2_alpha_fixed'] = salt2_alpha_fixed
-    parsed.attrs['salt2_beta_fixed'] = salt2_beta_fixed
-    parsed.attrs['dataset_long_name'] = META.get('dataset_name', 'JLA2014')
-    parsed.attrs['dataset_name_attr'] = parsed.attrs['dataset_long_name'].replace(' ', '_')
-    parsed.attrs['citation'] = META.get('citation', '')
-    parsed.attrs['notes'] = META.get('notes', '')
-    parsed.attrs['description'] = META.get('description', '')
+    parsed.attrs["covariance_matrix_inv"] = covariance_matrix_inv
+    parsed.attrs["diag_errors_for_plot"] = diag_errors_for_plot
+    parsed.attrs["salt2_m_abs_fixed"] = salt2_m_abs_fixed
+    parsed.attrs["salt2_alpha_fixed"] = salt2_alpha_fixed
+    parsed.attrs["salt2_beta_fixed"] = salt2_beta_fixed
+    parsed.attrs["dataset_long_name"] = META.get("dataset_name", "JLA2014")
+    parsed.attrs["dataset_name_attr"] = parsed.attrs["dataset_long_name"].replace(
+        " ", "_"
+    )
+    parsed.attrs["citation"] = META.get("citation", "")
+    parsed.attrs["notes"] = META.get("notes", "")
+    parsed.attrs["description"] = META.get("description", "")
     return parsed

--- a/data/sne/jla2014/metadata_jla2014.json
+++ b/data/sne/jla2014/metadata_jla2014.json
@@ -1,7 +1,7 @@
 {
-  "dataset_name": "JLA 2014 (Betoule et al.)",
-  "description": "Joint SDSS-II and SNLS supernova sample providing 740 standardized SNe Ia with full covariance matrix",
-  "citation": "Betoule M. , Kessler R., Guy J. et.al 2014, J/A+A/568/A22",
-  "authors_all": "Betoule M. , Kessler R., Guy J., Mosher J., Hardin D., Biswas R., Astier P., El-Hage P., Konig M., Kuhlmann S., Marriner J., Pain R., Regnault N., Balland C., Bassett B.A., Brown P.J., Campbell H., Carlberg R.G., Cellier-Holzem F., Cinabro D., Conley A., D'Andrea C.B., DePoy D.L., Doi M., Ellis R.S., Fabbro S., Filippenko A.V., Foley R.J., Frieman J.A., Fouchez D., Galbany L., Goobar A., Gupta R.R., Hill G.J., Hlozek R., Hogan C.J., Hook I.M., Howell D.A., Jha S.W., Le Guillou L., Leloudas G., Lidman C., Marshall J.L., Moller A., Mourao A.M., Neveu J., Nichol R., Olmstead M.D., Palanque-Delabrouille N., Perlmutter S., Prieto J.L., Pritchet C.J., Richmond M., Riess A.G., Ruhlmann-Kleider V., Sako M., Schahmaneche K., Schneider D.P., Smith M., Sollerman J., Sullivan M., Walton N.A., Wheeler C.J.",
-  "notes": "Light-curve parameters converted to distance moduli using fixed SALT2 nuisance parameters"
+    "dataset_name": "JLA 2014 (Betoule et al.)",
+    "description": "Joint SDSS-II and SNLS supernova sample providing 740 standardized SNe Ia. The covariance matrix is loaded but typically discarded as nearly singular, so diagonal errors are used for fits",
+    "citation": "Betoule M. , Kessler R., Guy J. et.al 2014, J/A+A/568/A22",
+    "authors_all": "Betoule M. , Kessler R., Guy J., Mosher J., Hardin D., Biswas R., Astier P., El-Hage P., Konig M., Kuhlmann S., Marriner J., Pain R., Regnault N., Balland C., Bassett B.A., Brown P.J., Campbell H., Carlberg R.G., Cellier-Holzem F., Cinabro D., Conley A., D'Andrea C.B., DePoy D.L., Doi M., Ellis R.S., Fabbro S., Filippenko A.V., Foley R.J., Frieman J.A., Fouchez D., Galbany L., Goobar A., Gupta R.R., Hill G.J., Hlozek R., Hogan C.J., Hook I.M., Howell D.A., Jha S.W., Le Guillou L., Leloudas G., Lidman C., Marshall J.L., Moller A., Mourao A.M., Neveu J., Nichol R., Olmstead M.D., Palanque-Delabrouille N., Perlmutter S., Prieto J.L., Pritchet C.J., Richmond M., Riess A.G., Ruhlmann-Kleider V., Sako M., Schahmaneche K., Schneider D.P., Smith M., Sollerman J., Sullivan M., Walton N.A., Wheeler C.J.",
+  "notes": "Light-curve parameters converted to distance moduli using fixed SALT2 nuisance parameters. Full covariance matrix loaded but inverse is rarely stable; diagonal errors are used"
 }

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -20,10 +20,10 @@ Every dataset folder also provides a `metadata_*.json` describing the source. Th
 ### JLA Betoule+2014
 *Source:* "Improved cosmological constraints from a joint analysis of the SDSS-II and SNLS supernova samples" (Betoule et al. 2014).
 *Location:* `data/sne/jla2014/`.
-*Parser:* `cosmo_parser_jla2014.py` reads `tablef3.dat` together with the full covariance matrix in `tablef4.fit` to provide distance moduli with systematic uncertainties.
-If the covariance matrix is nearly singular the parser logs a warning and
-falls back to the diagonal errors only. This ensures chi-squared values remain
-well-behaved when the full matrix cannot be inverted reliably.
+*Parser:* `cosmo_parser_jla2014.py` reads `tablef3.dat` and attempts to use the full covariance matrix from `tablef4.fit`.
+However the matrix is almost singular. The parser therefore logs a warning and
+discards it, returning only diagonal uncertainties. The loaded matrix is kept on
+disk for reference but is not used in fits or plots.
 
 ### Pantheon+ 2022 (Scolnic et al.)
 *Source:* Pantheon+SH0ES data release (Scolnic et al. 2022).


### PR DESCRIPTION
## Summary
- document that the JLA 2014 parser falls back to diagonal errors
- clarify fallback behaviour in the data overview docs
- tune layout spacing for info boxes, footers and CMB plot sizing
- bump version to 1.14.5

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6884ab48ee38832f97d1ac530782ac2d