### PR TITLE
Update JLA covariance handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.6**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.7**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes below and keep the line after this one empty:
 
+## Version 1.14.7
+- 2025-07-26: Combined JLA systematic and statistical covariances and updated parser logic (AI assistant)
+
 ## Version 1.14.6
 - 2025-07-26: Unified info box spacing with margins, adjusted footer placement and fixed CMB title overlap (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.14.6
-**Last Updated:** 2025-07-27
+**Version:** 1.14.7
+**Last Updated:** 2025-07-26
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.

--- a/copernican.py
+++ b/copernican.py
@@ -50,7 +50,7 @@ data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
 # outdated. Automatic releases are not yet enabled.
-COPERNICAN_VERSION = "1.14.6"
+COPERNICAN_VERSION = "1.14.7"
 CURRENT_LOG_FILE = None
 
 

--- a/data/sne/jla2014/cosmo_parser_jla2014.py
+++ b/data/sne/jla2014/cosmo_parser_jla2014.py
@@ -145,18 +145,21 @@ def parse_jla2014(
                 A[i, idx] = 1.0
                 A[i, idx + 1] = salt2_alpha_fixed
                 A[i, idx + 2] = -salt2_beta_fixed
-            mu_cov = A @ cov_params @ A.T
-            diag_errors_for_plot = np.sqrt(np.diag(mu_cov))
-            cond = np.linalg.cond(mu_cov)
+            mu_cov_sys = A @ cov_params @ A.T
+            stat_cov = np.diag(parsed["e_mu_obs"].values ** 2)
+            mu_cov_total = mu_cov_sys + stat_cov
+            cond = np.linalg.cond(mu_cov_total)
             if np.isfinite(cond) and cond < 1e8:
-                covariance_matrix_inv = np.linalg.inv(mu_cov)
+                covariance_matrix_inv = np.linalg.inv(mu_cov_total)
+                diag_errors_for_plot = np.sqrt(np.diag(mu_cov_total))
             else:
-                logger.warning(
-                    "JLA covariance matrix nearly singular; falling back to diagonal errors"
+                logger.error(
+                    "JLA total covariance matrix is ill-conditioned; using diagonal errors only."
                 )
                 covariance_matrix_inv = None
+                diag_errors_for_plot = parsed["e_mu_obs"].values
         except Exception as e:
-            logger.warning(f"Could not process JLA covariance matrix: {e}")
+            logger.error(f"Could not process JLA covariance matrix: {e}")
             covariance_matrix_inv = None
 
     sort_idx = np.argsort(parsed["zcmb"].values)

--- a/data/sne/jla2014/metadata_jla2014.json
+++ b/data/sne/jla2014/metadata_jla2014.json
@@ -1,7 +1,7 @@
 {
     "dataset_name": "JLA 2014 (Betoule et al.)",
-    "description": "Joint SDSS-II and SNLS supernova sample providing 740 standardized SNe Ia. The covariance matrix is loaded but typically discarded as nearly singular, so diagonal errors are used for fits",
+    "description": "Joint SDSS-II and SNLS supernova sample providing 740 standardized SNe Ia. The systematic covariance is projected to distance-modulus space and combined with statistical errors. The inverse is used when well-conditioned",
     "citation": "Betoule M. , Kessler R., Guy J. et.al 2014, J/A+A/568/A22",
     "authors_all": "Betoule M. , Kessler R., Guy J., Mosher J., Hardin D., Biswas R., Astier P., El-Hage P., Konig M., Kuhlmann S., Marriner J., Pain R., Regnault N., Balland C., Bassett B.A., Brown P.J., Campbell H., Carlberg R.G., Cellier-Holzem F., Cinabro D., Conley A., D'Andrea C.B., DePoy D.L., Doi M., Ellis R.S., Fabbro S., Filippenko A.V., Foley R.J., Frieman J.A., Fouchez D., Galbany L., Goobar A., Gupta R.R., Hill G.J., Hlozek R., Hogan C.J., Hook I.M., Howell D.A., Jha S.W., Le Guillou L., Leloudas G., Lidman C., Marshall J.L., Moller A., Mourao A.M., Neveu J., Nichol R., Olmstead M.D., Palanque-Delabrouille N., Perlmutter S., Prieto J.L., Pritchet C.J., Richmond M., Riess A.G., Ruhlmann-Kleider V., Sako M., Schahmaneche K., Schneider D.P., Smith M., Sollerman J., Sullivan M., Walton N.A., Wheeler C.J.",
-  "notes": "Light-curve parameters converted to distance moduli using fixed SALT2 nuisance parameters. Full covariance matrix loaded but inverse is rarely stable; diagonal errors are used"
+  "notes": "Light-curve parameters converted to distance moduli using fixed SALT2 nuisance parameters. Systematic and statistical covariance matrices are combined and inverted when possible; otherwise diagonal errors are used"
 }

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -20,10 +20,7 @@ Every dataset folder also provides a `metadata_*.json` describing the source. Th
 ### JLA Betoule+2014
 *Source:* "Improved cosmological constraints from a joint analysis of the SDSS-II and SNLS supernova samples" (Betoule et al. 2014).
 *Location:* `data/sne/jla2014/`.
-*Parser:* `cosmo_parser_jla2014.py` reads `tablef3.dat` and attempts to use the full covariance matrix from `tablef4.fit`.
-However the matrix is almost singular. The parser therefore logs a warning and
-discards it, returning only diagonal uncertainties. The loaded matrix is kept on
-disk for reference but is not used in fits or plots.
+*Parser:* `cosmo_parser_jla2014.py` reads `tablef3.dat`, projects the SALT2 parameter covariance from `tablef4.fit` to distance-modulus space and adds the diagonal statistical errors. The total covariance is inverted when well-conditioned; otherwise diagonal errors are used.
 
 ### Pantheon+ 2022 (Scolnic et al.)
 *Source:* Pantheon+SH0ES data release (Scolnic et al. 2022).


### PR DESCRIPTION
## Summary
- combine statistical and systematic uncertainties for JLA 2014
- update parser logic to invert the full covariance when well conditioned
- revise dataset metadata and documentation
- bump version to 1.14.7

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6884bc3a26ec832f87d997b717f05ba5