### PR TITLE
Improve plot spacing and data loader reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.7**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.8**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes below and keep the line after this one empty:
 
+## Version 1.14.8
+- 2025-07-26: Improved footer spacing, unified CMB legends and added verbose dataset summaries (AI assistant)
+
 ## Version 1.14.7
 - 2025-07-26: Combined JLA systematic and statistical covariances and updated parser logic (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.14.7
+**Version:** 1.14.8
 **Last Updated:** 2025-07-26
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -43,6 +43,9 @@ plots.
 Dataset names, descriptions and citations are read from `metadata_*.json` files stored
 next to each dataset. The program never hard-codes these values; instead the metadata
 is attached to the parsed DataFrame and used for plot footers and CSV headers.
+During configuration each loader prints a short summary including whether the
+dataset's covariance matrix was inverted successfully or if diagonal errors are
+being used.
 When generating file names the suite sanitizes dataset names, replacing spaces and
 characters like `/` with hyphens so output paths remain valid on all platforms.
 

--- a/copernican.py
+++ b/copernican.py
@@ -50,7 +50,7 @@ data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
 # outdated. Automatic releases are not yet enabled.
-COPERNICAN_VERSION = "1.14.7"
+COPERNICAN_VERSION = "1.14.8"
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -130,6 +130,19 @@ def _select_source(parser_registry, data_type_name):
         except ValueError:
             print("Invalid input. Please enter a number or 'c'.")
 
+# --- Verbose dataset info helper ---
+def _log_dataset_info(df, data_type, logger):
+    """Log summary and covariance usage for ``df``."""
+    if df is None or df.empty:
+        return
+    name = df.attrs.get("dataset_long_name", df.attrs.get("dataset_name_attr", ""))
+    logger.info(f"Loaded {data_type} dataset '{name}' with {len(df)} rows.")
+    if "covariance_matrix_inv" in df.attrs:
+        if df.attrs["covariance_matrix_inv"] is not None:
+            logger.info(f"{data_type} covariance matrix inverted successfully.")
+        else:
+            logger.info(f"{data_type} parser provided no usable covariance matrix; using diagonal errors only.")
+
 # --- Main Loading Functions ---
 def load_sne_data(source_key=None, **kwargs):
     """Loads SNe data for the chosen source."""
@@ -155,6 +168,7 @@ def load_sne_data(source_key=None, **kwargs):
             if 'dataset_name_attr' not in data_df.attrs:
                 data_df.attrs['dataset_name_attr'] = f"SNe_{source_key.replace(' ', '_')}"
             logger.info(f"Successfully loaded {len(data_df)} SNe data points.")
+            _log_dataset_info(data_df, "SNe", logger)
         elif data_df is None:
              logger.error(f"SNe parser '{source_key}' returned None.")
         else:
@@ -188,6 +202,7 @@ def load_bao_data(source_key=None, **kwargs):
             if 'dataset_name_attr' not in data_df.attrs:
                 data_df.attrs['dataset_name_attr'] = f"BAO_{source_key.replace(' ', '_')}"
             logger.info(f"Successfully loaded {len(data_df)} BAO data points.")
+            _log_dataset_info(data_df, "BAO", logger)
         elif data_df is None:
             logger.error(f"BAO parser '{source_key}' returned None.")
         else:
@@ -221,6 +236,7 @@ def load_cmb_data(source_key=None, **kwargs):
             if 'dataset_name_attr' not in data_df.attrs:
                 data_df.attrs['dataset_name_attr'] = f"CMB_{source_key.replace(' ', '_')}"
             logger.info(f"Successfully loaded {len(data_df)} CMB data points.")
+            _log_dataset_info(data_df, "CMB", logger)
         elif data_df is None:
             logger.error(f"CMB parser '{source_key}' returned None.")
         else:
@@ -254,6 +270,7 @@ def load_gw_data(source_key=None, **kwargs):
             if 'dataset_name_attr' not in data_df.attrs:
                 data_df.attrs['dataset_name_attr'] = f"GW_{source_key.replace(' ', '_')}"
             logger.info(f"Successfully loaded {len(data_df)} GW data points.")
+            _log_dataset_info(data_df, "GW", logger)
         elif data_df is None:
             logger.error(f"GW parser '{source_key}' returned None.")
         else:
@@ -287,6 +304,7 @@ def load_siren_data(source_key=None, **kwargs):
             if 'dataset_name_attr' not in data_df.attrs:
                 data_df.attrs['dataset_name_attr'] = f"SIREN_{source_key.replace(' ', '_')}"
             logger.info(f"Successfully loaded {len(data_df)} standard siren data points.")
+            _log_dataset_info(data_df, "SIREN", logger)
         elif data_df is None:
             logger.error(f"Standard siren parser '{source_key}' returned None.")
         else:

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -262,11 +262,12 @@ def plot_hubble_diagram(
     )
     line_height = 0.015
     start_y = left + (len(footer_lines) - 1) * line_height
+    footer_pad = 0.03
     plt.subplots_adjust(
         left=left,
         right=right,
         top=top,
-        bottom=start_y + info_gap,
+        bottom=start_y + info_gap + footer_pad,
     )
 
     axs[0].errorbar(
@@ -488,11 +489,12 @@ def plot_bao_observables(
     )
     line_height = 0.015
     start_y = left + (len(footer_lines) - 1) * line_height
+    footer_pad = 0.03
     plt.subplots_adjust(
         left=left,
         right=right,
         top=top,
-        bottom=start_y + info_gap,
+        bottom=start_y + info_gap + footer_pad,
     )
 
     obs_types = bao_data_df["observable_type"].unique()
@@ -778,7 +780,7 @@ def plot_cmb_spectrum(
         1,
         figsize=(17, 6 * len(components)),
         sharex=True,
-        gridspec_kw={"height_ratios": [4, 1.5] * len(components), "hspace": 0.05},
+        gridspec_kw={"height_ratios": [4, 1.5] * len(components), "hspace": 0.25},
     )
 
     footer_lines = compose_footer(
@@ -787,11 +789,12 @@ def plot_cmb_spectrum(
     )
     line_height = 0.015
     start_y = left + (len(footer_lines) - 1) * line_height
+    footer_pad = 0.03
     plt.subplots_adjust(
         left=left,
         right=right,
         top=top,
-        bottom=start_y + info_gap,
+        bottom=start_y + info_gap + footer_pad,
     )
 
     lcdm_theory = None
@@ -936,8 +939,9 @@ def plot_cmb_spectrum(
         axs[idx_main].set_ylabel(r"$D_\ell\ (\mu K^2)$", fontsize=font_sizes["label"])
         if comp in ("TT", "EE"):
             axs[idx_main].set_yscale("log")
-        axs[idx_main].legend(fontsize=font_sizes["legend"], loc="best")
-        title_pad = 35 if i > 0 else 10
+        if i == 0:
+            axs[idx_main].legend(fontsize=font_sizes["legend"], loc="best")
+        title_pad = 20
         axs[idx_main].set_title(
             f"CMB {comp} Power Spectrum: {dataset_name}",
             fontsize=font_sizes["title"],

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -10,8 +10,10 @@ The suite exposes a small API intended for advanced scripting. The
 - `engine_interface.build_plugin(parsed_json, funcs)` – construct a plugin object
   with attributes `MODEL_NAME`, `MODEL_DESCRIPTION`, `MODEL_ABSTRACT` and the
   distance and CMB functions required by engines.
-- `data_loaders.load_sne_data(name)`, `load_bao_data(name)`,
-  `load_cmb_data(name)` – load datasets by their registered names.
+  - `data_loaders.load_sne_data(name)`, `load_bao_data(name)`,
+    `load_cmb_data(name)` – load datasets by their registered names. Each loader
+    logs a short summary describing the dataset and whether its covariance matrix
+    was used or diagonal errors were applied.
 - `engines.cosmo_engine_comb` – reference engine providing
   `fit_sne_parameters`, `fit_combined_parameters`, `calculate_bao_observables`
   and `chi_squared_*` helpers.


### PR DESCRIPTION
## Summary
- bump version to 1.14.8
- move plot footers lower and widen CMB subplot spacing
- show only one legend on CMB plots
- log covariance usage when loading data
- document new behaviour

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ce0a8ae8832f92dee9f7a0a6f455