### PR TITLE
Fix CMB plot title spacing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.8**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.9**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes below and keep the line after this one empty:
 
+## Version 1.14.9
+- 2025-07-26: Reduced CMB title padding to avoid overlap with residual plots (AI assistant)
+
 ## Version 1.14.8
 - 2025-07-26: Improved footer spacing, unified CMB legends and added verbose dataset summaries (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.14.8
+**Version:** 1.14.9
 **Last Updated:** 2025-07-26
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -258,7 +258,8 @@ listing the CAMB parameter order—including `omnuh2` when relevant. The engine
 combines this list with `get_camb_params` to evaluate the power spectrum and
 chi-squared. The CMB plotter draws separate TT, TE and EE panels with
 residuals, uses a logarithmic scale for temperature and $E$-mode spectra and
-shows cosmic-variance and observational uncertainty bands.
+shows cosmic-variance and observational uncertainty bands. Titles now use
+minimal padding so each label fits neatly between CMB subplots.
 `model_parser.py` accepts unknown keys and simply copies them to the sanitized
 cache. This allows the domain-specific JSON language to evolve while remaining
 compatible with older models.

--- a/copernican.py
+++ b/copernican.py
@@ -50,7 +50,7 @@ data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
 # outdated. Automatic releases are not yet enabled.
-COPERNICAN_VERSION = "1.14.8"
+COPERNICAN_VERSION = "1.14.9"
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -941,7 +941,9 @@ def plot_cmb_spectrum(
             axs[idx_main].set_yscale("log")
         if i == 0:
             axs[idx_main].legend(fontsize=font_sizes["legend"], loc="best")
-        title_pad = 20
+        # Reduce padding so titles fit in the vertical gaps between
+        # spectrum and residual panels without overlapping.
+        title_pad = 6
         axs[idx_main].set_title(
             f"CMB {comp} Power Spectrum: {dataset_name}",
             fontsize=font_sizes["title"],


### PR DESCRIPTION
## Summary
- shrink title padding on CMB spectra so labels stay within subplot gaps
- note tighter CMB spacing in README
- bump version to 1.14.9
- document change in AGENTS.md and CHANGELOG

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_6884e01cf468832fba17de8616c39f99