### PR TITLE
Improve LaTeX macro support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Add one line for each substantive commit or pull request directly under the late
 
 ## Version 1.14.9
 - 2025-07-26: Reduced CMB title padding to avoid overlap with residual plots (AI assistant)
+- 2025-07-27: Improved LaTeX parsing for additional macros (AI assistant)
+- 2025-07-27: Fixed bracket handling in LaTeX parser to avoid parse failures (AI assistant)
+- 2025-07-27: Documented JSON escape requirement for LaTeX macros (AI assistant)
 
 ## Version 1.14.8
 - 2025-07-26: Improved footer spacing, unified CMB legends and added verbose dataset summaries (AI assistant)

--- a/README.md
+++ b/README.md
@@ -193,12 +193,21 @@ See `cosmo_model_guide.json` for a detailed template.
  recombination or include the parameters `Ob`, `Og` and `z_recomb`. The suite will then
    derive `r_s` automatically using a numerical integral.
 5. Python code must never appear in `cosmo_model_*.json`; all expressions are written in LaTeX.
-6. Expressions may include `Integral(...)` terms. These are evaluated
+6. Backslashes must be doubled inside JSON strings. Use `\\` to escape a single `\` so
+   macros like `\frac` remain valid.
+7. Expressions may include `Integral(...)` terms. These are evaluated
    numerically with SciPy's `quad` when the model is loaded.
-7. Parameter initial guesses are calculated automatically as the midpoint of
+8. Parameter initial guesses are calculated automatically as the midpoint of
    each parameter's bounds.
-8. `latex_name` values do not require `$` delimiters. Plots automatically wrap
+9. `latex_name` values do not require `$` delimiters. Plots automatically wrap
    parameter names in math mode.
+   
+The LaTeX parser supports a subset of math syntax including `\frac`,
+subscripts and superscripts, common functions (`\log`, `\ln`, `\exp`, `\sin`,
+`\cos`, `\tan`, `\sqrt`), Greek letters such as `\alpha` and `\beta`, and
+macros that adjust bracket size like `\left`, `\right`, `\bigl` and `\bigr`.
+Thin spaces (`\,`) and font switches (`\rm`) are ignored. Expressions may also
+contain `Integral` constructs which are numerically evaluated with SciPy.
 The suite validates the JSON, stores a sanitized copy under `models/cache/`, and
 auto-generates the necessary Python functions.
 

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -41,6 +41,10 @@ def _latex_to_sympy_str(expr: str) -> str:
     replacements = [
         (r"\\left", ""),
         (r"\\right", ""),
+        (r"\\bigl", ""),
+        (r"\\bigr", ""),
+        (r"\\,", ""),
+        (r"\\rm\s*", ""),
         (r"\\Omega_{m0}", "Omega_m0"),
         (r"\\Omega_{b0}", "Omega_b0"),
         (r"\\Omega_{r0}", "Omega_r0"),
@@ -74,6 +78,9 @@ def _latex_to_sympy_str(expr: str) -> str:
     expr = re.sub(r"\^([\w\.]+)", r"**\1", expr)
     expr = expr.replace("\\", "")
     expr = expr.replace("{", "(").replace("}", ")")
+    # Convert bracketed groups like [a+b] to parentheses for SymPy
+    expr = expr.replace("[", "(").replace("]", ")")
+    expr = re.sub(r"\s{2,}", " ", expr)
     return expr.strip()
 
 


### PR DESCRIPTION
## Summary
- support `\bigl`, `\bigr`, `\,` and `\rm` in the model LaTeX parser
- normalize square brackets to parentheses when parsing LaTeX
- document supported LaTeX syntax in the new-model guide
- clarify that JSON strings must escape backslashes
- note improved LaTeX parsing in the changelog

## Testing
- `python3.12 copernican.py --run-tests`


------
https://chatgpt.com/codex/tasks/task_e_68868091ec74832fb1d496b275bd9da4