### PR TITLE
Improve model JSON guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes below and keep the line after this one empty:
 
+## Version 1.14.10
+- 2025-07-28: Expanded model JSON guide with supported functions and common mistakes (AI assistant)
+
 ## Version 1.14.9
 - 2025-07-26: Reduced CMB title padding to avoid overlap with residual plots (AI assistant)
 - 2025-07-27: Improved LaTeX parsing for additional macros (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.14.9
-**Last Updated:** 2025-07-26
+**Version:** 1.14.10
+**Last Updated:** 2025-07-28
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.
@@ -188,26 +188,35 @@ See `cosmo_model_guide.json` for a detailed template.
 2. *(Optional)* Create `cosmo_model_name.md` if you want a human-friendly
    summary of the same content. The suite does not read this file.
 3. Include an `Hz_expression` written in LaTeX math form defining `H(z)` using
-   your model parameters. This enables BAO and distance-based predictions.
+   your model parameters. Always place `*` between symbols (e.g. `H0*(1+z)`),
+   otherwise SymPy will treat the expression as a function call.
 4. Optionally provide an `rs_expression` in LaTeX for the sound horizon at
- recombination or include the parameters `Ob`, `Og` and `z_recomb`. The suite will then
-   derive `r_s` automatically using a numerical integral.
+   recombination or include the parameters `Ob`, `Og` and `z_recomb`. The suite will then
+   derive `r_s` automatically using a numerical integral. Use `sympy.oo` when an
+   integral extends to infinity.
 5. Python code must never appear in `cosmo_model_*.json`; all expressions are written in LaTeX.
 6. Backslashes must be doubled inside JSON strings. Use `\\` to escape a single `\` so
    macros like `\frac` remain valid.
-7. Expressions may include `Integral(...)` terms. These are evaluated
-   numerically with SciPy's `quad` when the model is loaded.
+7. Expressions may include `Integral(...)` terms with explicit limits. They are
+   evaluated numerically with SciPy's `quad` when the model is loaded.
 8. Parameter initial guesses are calculated automatically as the midpoint of
    each parameter's bounds.
 9. `latex_name` values do not require `$` delimiters. Plots automatically wrap
    parameter names in math mode.
+
+**Common mistakes**
+* Missing `*` between variables and parentheses results in a `'Symbol' object is not callable` error.
+* Using `oo` for infinite limits fails; write `sympy.oo` instead.
+* Referencing `H(z)` inside `rs_expression` is unsupported—repeat the formula or rely on the fallback parameters.
    
 The LaTeX parser supports a subset of math syntax including `\frac`,
 subscripts and superscripts, common functions (`\log`, `\ln`, `\exp`, `\sin`,
 `\cos`, `\tan`, `\sqrt`), Greek letters such as `\alpha` and `\beta`, and
 macros that adjust bracket size like `\left`, `\right`, `\bigl` and `\bigr`.
 Thin spaces (`\,`) and font switches (`\rm`) are ignored. Expressions may also
-contain `Integral` constructs which are numerically evaluated with SciPy.
+contain `Integral` constructs with explicit limits which are numerically
+evaluated with SciPy. Use `sympy.oo` for an infinite upper bound and avoid
+referencing `H(z)` inside other expressions—repeat the formula instead.
 The suite validates the JSON, stores a sanitized copy under `models/cache/`, and
 auto-generates the necessary Python functions.
 

--- a/cosmo_model_guide.json
+++ b/cosmo_model_guide.json
@@ -1,12 +1,13 @@
 {
   "guide_title": "Copernican Suite cosmo_model_*.json Definition Guide",
-  "guide_version": "1.1",
-  "overview": "This guide explains how to write valid cosmo_model JSON files for the Copernican Suite.  Each cosmo_model_*.json defines a cosmological model by declaring metadata, parameters, H(z) and r_s expressions, and display equations for SNe Ia and BAO.",
+  "guide_version": "1.2",
+  "overview": "This guide explains how to create valid cosmo_model JSON files for the Copernican Suite. Every cosmo_model_*.json fully describes a cosmological theory using metadata, parameters, LaTeX expressions for H(z) and the sound horizon, and optional display equations for SNe Ia and BAO.  All information required to build a working model is contained here and in README.md.",
   "requirements": "Every cosmo_model JSON must include these top-level keys: model_name (string), version (string), description (string), abstract (string), parameters (array), equations (object). If you supply r_s, include rs_expression (string) and set predicts_bao to true. Models that support CMB predictions must provide a cmb.param_map describing how variables map to CAMB parameters. Set valid_for_cmb to false when a CMB spectrum is unavailable.",
   "parameter_definition": "The parameters array contains objects with these fields: name (human-readable string), python_var (valid Python identifier), bounds ([min, max]), and optional unit (string) and latex_name (string).  All symbols used in Hz_expression and rs_expression must be declared here.  To define a fixed constant (e.g. c), give identical bounds. Parameter latex_name values are automatically wrapped in math mode when displayed.",
   "expressions": {
-    "Hz_expression": "A LaTeX math expression for H(z). Include explicit * for multiplication and use only declared parameters and z.",
-    "rs_expression": "A LaTeX expression for the sound horizon r_s. Reference only declared parameters (no z). If omitted or predicts_bao=false, BAO predictions are disabled."
+    "Hz_expression": "A LaTeX math expression for H(z). Always place * between symbols, e.g. H0*(1+z)^2, and use only declared parameters and z.",
+    "rs_expression": "A LaTeX expression for the sound horizon r_s. Do not call H(z) here—repeat the formula if needed. Reference only declared parameters (no z). If omitted or predicts_bao=false, BAO predictions are disabled.",
+    "allowed_functions": "Supported functions include \\log, \\ln, \\exp, \\sin, \\cos, \\tan, \\sqrt and Integral(...) with explicit limits. Use sympy.oo for infinity."
   },
   "display_equations": {
     "sne": [
@@ -20,7 +21,9 @@
     ]
   },
   "edge_cases": [
-    "Do not include symbolic Integrals in rs_expression—Sympy cannot lambdify them.",
+    "Use sympy.oo for infinite integral limits; a bare 'oo' will fail to parse.",
+    "Always include * between variables and parentheses. Omitting it turns symbols into function calls.",
+    "Do not reference H(z) inside rs_expression; replicate the formula instead or rely on the Ob/Og/z_recomb fallback.",
     "Avoid Python list syntax in expressions; use parentheses for grouping.",
     "LaTeX in description and abstract may include math (double-escaped backslashes).",
     "All parameter names in expressions must exactly match python_var entries."


### PR DESCRIPTION
## Summary
- expand cosmo_model_guide.json with supported LaTeX functions, explicit multiplication rules and common mistakes
- document these points in README
- bump docs version and changelog

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68871dd1c5d4832fa236cf787ef0a835