### PR TITLE
Fix latex macros in plot text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.9**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.14.11**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes below and keep the line after this one empty:
 
+## Version 1.14.11
+- 2025-07-28: Stripped size macros from plot labels and bumped version to 1.14.11 (AI assistant)
+
 ## Version 1.14.10
 - 2025-07-28: Expanded model JSON guide with supported functions and common mistakes (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.14.10
+**Version:** 1.14.11
 **Last Updated:** 2025-07-28
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -213,7 +213,9 @@ The LaTeX parser supports a subset of math syntax including `\frac`,
 subscripts and superscripts, common functions (`\log`, `\ln`, `\exp`, `\sin`,
 `\cos`, `\tan`, `\sqrt`), Greek letters such as `\alpha` and `\beta`, and
 macros that adjust bracket size like `\left`, `\right`, `\bigl` and `\bigr`.
-Thin spaces (`\,`) and font switches (`\rm`) are ignored. Expressions may also
+Thin spaces (`\,`) and font switches (`\rm`) are ignored. Unsupported sizing
+macros such as `\bigl` and `\bigr` are removed from plot labels to keep
+Matplotlib's MathText parser happy. Expressions may also
 contain `Integral` constructs with explicit limits which are numerically
 evaluated with SciPy. Use `sympy.oo` for an infinite upper bound and avoid
 referencing `H(z)` inside other expressions—repeat the formula instead.

--- a/copernican.py
+++ b/copernican.py
@@ -50,7 +50,7 @@ data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
 # outdated. Automatic releases are not yet enabled.
-COPERNICAN_VERSION = "1.14.9"
+COPERNICAN_VERSION = "1.14.11"
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -21,6 +21,12 @@ def _wrap_math(text: str) -> str:
     if text is None:
         return ""
     cleaned = re.sub(r"^\$+|\$+$", "", str(text).strip())
+    # Matplotlib's MathText does not understand sizing macros like ``\bigl``
+    # or ``\bigr``. Remove them to avoid parse errors when rendering.
+    cleaned = re.sub(r"\\(bigl|bigr|Bigl|Bigr|biggl|biggr|left|right)", "", cleaned)
+    cleaned = re.sub(r"\\,", "", cleaned)
+    cleaned = re.sub(r"\\rm\s*", "", cleaned)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned)
     return f"${cleaned}$" if cleaned else ""
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -99,5 +99,21 @@ class FunctionalTestCase(unittest.TestCase):
         np.testing.assert_allclose(result, ref[:,0][ells], rtol=1e-7)
 
 
+class PlotterUtilTestCase(unittest.TestCase):
+    """Test helper utilities in ``plotter``."""
+
+    def test_wrap_math_removes_size_macros(self):
+        import sys
+        import importlib
+        from types import SimpleNamespace
+
+        sys.modules['copernican'] = SimpleNamespace(COPERNICAN_VERSION='test')
+        plotter = importlib.import_module('copernican_lib.plotter')
+
+        expr = r"\mu(z) = 5\log_{10}\bigl[d_L(z)/\mathrm{Mpc}\bigr] + 25"
+        expected = r"$\mu(z) = 5\log_{10}[d_L(z)/\mathrm{Mpc}] + 25$"
+        self.assertEqual(plotter._wrap_math(expr), expected)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- strip unsupported sizing macros for matplotlib mathtext
- bump Copernican version to 1.14.11
- document macro removal for plots
- add regression test for `_wrap_math`

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_68872a573c04832f88ae6baa7dc09e1e