### PR TITLE
Support raw LaTeX in model JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development notes were previously kept at the top of this file. That history now
 lives in `CHANGELOG.md`. New modifications must update the changelog, and legacy
 `dev_note` headers embedded in source files have been fully phased out.
 
-This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.17.0**.
+This document is the authoritative reference for contributors and AI systems working on the Copernican Suite. It replaces all previous specifications. The current development release is **version 1.18.0**.
 
 ## 1. Program Overview
 The helper modules previously stored under `scripts/` now live in the `copernican_lib/` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Add one line for each substantive commit or pull request directly under the late
 ## Version 1.17.0
 - 2025-07-28: Extended latex_mappings with extra symbols, functions and macros; bumped version (AI assistant)
 
+## Version 1.18.0
+- 2025-07-28: Added implicit multiplication, optional math delimiters and automatic backslash escaping (AI assistant)
+
 ## Version 1.16.0
 
 - 2025-07-28: Centralized LaTeX mappings and added latex_utils module (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 1.17.0
+**Version:** 1.18.0
 **Last Updated:** 2025-07-28
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -195,8 +195,8 @@ See `cosmo_model_guide.json` for a detailed template.
    derive `r_s` automatically using a numerical integral. Use `\infty` when an
    integral extends to infinity.
 5. Python code must never appear in `cosmo_model_*.json`; all expressions are written in LaTeX.
-6. Backslashes must be doubled inside JSON strings. Use `\\` to escape a single `\` so
-   macros like `\frac` remain valid.
+6. LaTeX in `cosmo_model_*.json` may use single backslashes. The parser
+   automatically escapes them when sanitizing the JSON.
 7. Expressions may include `Integral(...)` terms with explicit limits. They are
    evaluated numerically with SciPy's `quad` when the model is loaded.
 8. Parameter initial guesses are calculated automatically as the midpoint of
@@ -235,17 +235,17 @@ The required top-level keys are `model_name`, `version`, `parameters`,
     {"name": "H0", "bounds": [50, 100], "latex_name": "H_0"},
     {"name": "Omega_m0", "bounds": [0.1, 0.5], "latex_name": "\\Omega_{m0}"}
   ],
-  "Hz_expression": "$$H(z) = H_0 * \\sqrt{Om0*(1+z)^3 + Ol0}$$",
- "rs_expression": "$$r_s = custom\_expression$$",
+  "Hz_expression": "H(z) = H_0 * \sqrt{Om0*(1+z)^3 + Ol0}",
+ "rs_expression": "r_s = custom_expression",
   "equations": {
     "sne": [
-      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$\\mu(z) = 5\\log_{10}[d_L(z)/{\\rm Mpc}] + 25$$"
+      "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+      "\mu(z) = 5\log_{10}[d_L(z)/{\rm Mpc}] + 25"
     ],
     "bao": [
-      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$D_H(z) = \\frac{c}{H(z)}$$",
-      "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+      "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+      "D_H(z) = \frac{c}{H(z)}",
+      "D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}"
     ]
   },
   "valid_for_cmb": true,

--- a/copernican.py
+++ b/copernican.py
@@ -50,7 +50,7 @@ data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
 # outdated. Automatic releases are not yet enabled.
-COPERNICAN_VERSION = "1.17.0"
+COPERNICAN_VERSION = "1.18.0"
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/latex_utils.py
+++ b/copernican_lib/latex_utils.py
@@ -46,6 +46,8 @@ def latex_to_sympy(expr: str) -> str:
     expr = expr.strip()
     if expr.startswith("$$") and expr.endswith("$$"):
         expr = expr[2:-2]
+    elif expr.startswith("$") and expr.endswith("$"):
+        expr = expr[1:-1]
     if "=" in expr:
         expr = expr.split("=", 1)[1]
 

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -11,6 +11,11 @@ import numpy as np
 from scipy.integrate import quad
 import logging
 from sympy.printing.numpy import NumPyPrinter
+from sympy.parsing.sympy_parser import (
+    parse_expr,
+    standard_transformations,
+    implicit_multiplication_application,
+)
 from . import error_handler
 from . import engine_interface
 from . import latex_utils
@@ -33,6 +38,9 @@ class QuadPrinter(NumPyPrinter):
 def _latex_to_sympy_str(expr: str) -> str:
     """Convert a LaTeX-style expression to a SymPy-friendly string."""
     return latex_utils.latex_to_sympy(expr)
+
+
+_TRANSFORMS = standard_transformations + (implicit_multiplication_application,)
 
 
 def _compile_sympy_expr(sym_expr, args):
@@ -82,7 +90,7 @@ def generate_callables(cache_path):
     if hz_expr_str:
         try:
             parsed_hz = _latex_to_sympy_str(hz_expr_str)
-            hz_sym = sp.sympify(parsed_hz, locals=local_dict)
+            hz_sym = parse_expr(parsed_hz, local_dict=local_dict, transformations=_TRANSFORMS)
             used_syms = {str(s) for s in hz_sym.free_symbols if s != z}
             param_names = {p['python_var'] for p in model_data['parameters']}
             missing = used_syms - param_names
@@ -150,7 +158,7 @@ def generate_callables(cache_path):
             if rs_expr_str:
                 try:
                     parsed_rs = _latex_to_sympy_str(rs_expr_str)
-                    rs_sym = sp.sympify(parsed_rs, locals=local_dict)
+                    rs_sym = parse_expr(parsed_rs, local_dict=local_dict, transformations=_TRANSFORMS)
                     used = {str(s) for s in rs_sym.free_symbols} - {'z'}
                     missing_rs = used - param_names
                     if missing_rs:
@@ -214,7 +222,11 @@ def generate_callables(cache_path):
             # Textual equations are preserved but not parsed into functions
             continue
         try:
-            sym_expr = sp.sympify(expr, locals=local_dict)
+            sym_expr = parse_expr(
+                _latex_to_sympy_str(expr),
+                local_dict=local_dict,
+                transformations=_TRANSFORMS,
+            )
             # Convert SymPy expression to a callable, numerically evaluating
             # ``Integral`` constructs if present.
             fn = _compile_sympy_expr(sym_expr, (z, *param_syms))

--- a/copernican_lib/model_parser.py
+++ b/copernican_lib/model_parser.py
@@ -75,9 +75,15 @@ def parse_model_json(path, cache_dir):
         Path to the sanitized cache file.
     """
     path = Path(path)
+    def _escape_loose_backslashes(text: str) -> str:
+        """Double unescaped backslashes so ``json.loads`` accepts LaTeX strings."""
+        pattern = re.compile(r"(?<!\\)\\(?![\\\"/bfnrtu])")
+        return pattern.sub(r"\\\\", text)
+
     try:
-        with path.open("r") as f:
-            data = json.load(f)
+        raw_text = path.read_text()
+        raw_text = _escape_loose_backslashes(raw_text)
+        data = json.loads(raw_text)
     except (OSError, json.JSONDecodeError) as e:
         error_handler.report_error(f"Failed to read model JSON '{path}': {e}")
         raise
@@ -113,6 +119,25 @@ def parse_model_json(path, cache_dir):
     cache_dir = Path(cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)
     cache_path = cache_dir / f"cache_{path.name}"
+    def _wrap(expr: str | None) -> str | None:
+        if expr is None:
+            return expr
+        expr = expr.strip()
+        if not expr.startswith("$"):
+            return f"$${expr}$$"
+        return expr
+
+    if isinstance(data.get("equations"), dict):
+        for key, val in data["equations"].items():
+            if isinstance(val, list):
+                data["equations"][key] = [_wrap(v) for v in val]
+            elif isinstance(val, str):
+                data["equations"][key] = _wrap(val)
+    if "Hz_expression" in data:
+        data["Hz_expression"] = _wrap(data["Hz_expression"])
+    if "rs_expression" in data:
+        data["rs_expression"] = _wrap(data["rs_expression"])
+
     with cache_path.open("w") as f:
         json.dump(data, f, indent=2)
     return str(cache_path)

--- a/cosmo_model_guide.json
+++ b/cosmo_model_guide.json
@@ -11,13 +11,13 @@
   },
   "display_equations": {
     "sne": [
-      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$\\mu(z) = 5\\log_{10}[d_L(z)/{\\rm Mpc}] + 25$$"
+      "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+      "\mu(z) = 5\log_{10}[d_L(z)/{\rm Mpc}] + 25"
     ],
     "bao": [
-      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$D_H(z) = \\frac{c}{H(z)}$$",
-      "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+      "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+      "D_H(z) = \frac{c}{H(z)}",
+      "D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}"
     ]
   },
   "edge_cases": [
@@ -25,7 +25,7 @@
     "Always include * between variables and parentheses. Omitting it turns symbols into function calls.",
     "Do not reference H(z) inside rs_expression; replicate the formula instead or rely on the Ob/Og/z_recomb fallback.",
     "Avoid Python list syntax in expressions; use parentheses for grouping.",
-    "LaTeX in description and abstract may include math (double-escaped backslashes).",
+    "LaTeX in description and abstract may include math; single backslashes are fine.",
     "All parameter names in expressions must exactly match the derived python_var names."
   ],
   "template": {
@@ -47,16 +47,16 @@
         "latex_name": "\\Omega_{m0}"
       }
     ],
-    "Hz_expression": "$$H(z) = H_0 * \\sqrt{\\Omega_{m0}*(1+z)^3 + /* additional model terms */}$$",
+    "Hz_expression": "H(z) = H_0 * \sqrt{\Omega_{m0}*(1+z)^3 + /* additional model terms */}",
     "equations": {
       "sne": [
-        "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-        "$$\\mu(z) = 5\\log_{10}[d_L(z)/{\\rm Mpc}] + 25$$"
+        "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+        "\mu(z) = 5\log_{10}[d_L(z)/{\rm Mpc}] + 25"
       ],
       "bao": [
-        "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-        "$$D_H(z) = \\frac{c}{H(z)}$$",
-        "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+        "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+        "D_H(z) = \frac{c}{H(z)}",
+        "D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}"
       ]
     },
     "rs_expression": "rs0*(1 + B*z_recomb*exp(-gamma*z_recomb))",

--- a/models/cosmo_model_cfsc.json
+++ b/models/cosmo_model_cfsc.json
@@ -3,7 +3,7 @@
   "version": "1.0",
   "description": "Conformal Stationary Field Cosmology (CSFC) is a static-universe model in which the observed redshift of light and the apparent cosmic distances arise entirely from photons interacting with a universal, stationary field—there is no spatial expansion and no dark energy or dark matter.  In CSFC, the field imparts a red-shift “rate” that combines:  (1) a small effective matter mimic \n   M_eff·(1+z)^3 (recovering Newton’s law at low redshift),  (2) simple linear and quadratic z-terms L·z + D·z^2 (further matching low-z gravity tests), and (3) two damped oscillatory modes A₁e^{–α₁z}cos(ω₁z+φ₀₁) and A₂e^{–α₂z}cos(ω₂z+φ₀₂) that reproduce the subtle wiggles seen in supernova brightness.  The same interaction also sets the BAO scale via a drag-epoch sound horizon r_s(z_drag)=rs0[1 + B·z_drag·e^{–γz_drag} + C·log(1+z_drag)], allowing a precise fit to galaxy-clustering distances.  Twelve free parameters are simultaneously optimized to match both Type Ia supernova Hubble diagrams and BAO distance ratios, all while preserving the Newtonian limit at z≪1 and doing away with any notion of cosmic expansion or unseen dark components.",
   "abstract": "CSFC replaces the Big Bang and cosmic expansion with a permanent conformal field that redshifts photons as they travel.  The effective redshift rate H_eff(z)=H₀√[M_eff(1+z)^3 + 1 + L·z + D·z^2 + A₁e^{–α₁z}cos(ω₁z+φ₀₁) + A₂e^{–α₂z}cos(ω₂z+φ₀₂)] smoothly recovers Newtonian dynamics at low z and adds two damped waves to capture supernova residuals.  The baryon acoustic scale emerges from a hybrid sound horizon r_s(z_drag)=r_{s0}[1 + B·z_drag·e^{–γz_drag} + C·ln(1+z_drag)], giving the necessary freedom to fit galaxy-clustering distances without any expansion.  CSFC thus unifies supernova and BAO observations in a single, timeless framework free of dark matter and dark energy.",
-  "Hz_expression": "$$H(z) = H0 * \\sqrt{M_eff*(1+z)^3 + 1 + L*z + D*z^2 + A1*\\exp(-alpha1*z)*\\cos(omega1*z + phi01) + A2*\\exp(-alpha2*z)*\\cos(omega2*z + phi02)}$$",
+  "Hz_expression": "H(z) = H0 * \sqrt{M_eff*(1+z)^3 + 1 + L*z + D*z^2 + A1*\exp(-alpha1*z)*\cos(omega1*z + phi01) + A2*\exp(-alpha2*z)*\cos(omega2*z + phi02)}",
   "parameters": [
     {
       "name": "Hubble-scale rate",
@@ -48,7 +48,7 @@
         10.0
       ],
       "unit": "",
-      "latex_name": "\\alpha_1"
+      "latex_name": "\alpha_1"
     },
     {
       "name": "Mode-1 frequency",
@@ -57,7 +57,7 @@
         20.0
       ],
       "unit": "",
-      "latex_name": "\\omega_1"
+      "latex_name": "\omega_1"
     },
     {
       "name": "Mode-1 phase",
@@ -66,7 +66,7 @@
         6.283
       ],
       "unit": "rad",
-      "latex_name": "\\varphi_{0,1}"
+      "latex_name": "\varphi_{0,1}"
     },
     {
       "name": "Mode-2 amplitude",
@@ -84,7 +84,7 @@
         10.0
       ],
       "unit": "",
-      "latex_name": "\\alpha_2"
+      "latex_name": "\alpha_2"
     },
     {
       "name": "Mode-2 frequency",
@@ -93,7 +93,7 @@
         50.0
       ],
       "unit": "",
-      "latex_name": "\\omega_2"
+      "latex_name": "\omega_2"
     },
     {
       "name": "Mode-2 phase",
@@ -102,7 +102,7 @@
         6.283
       ],
       "unit": "rad",
-      "latex_name": "\\varphi_{0,2}"
+      "latex_name": "\varphi_{0,2}"
     },
     {
       "name": "Effective matter term",
@@ -111,7 +111,7 @@
         0.05
       ],
       "unit": "",
-      "latex_name": "M_{\\rm eff}"
+      "latex_name": "M_{\rm eff}"
     },
     {
       "name": "Sound horizon base",
@@ -138,7 +138,7 @@
         5.0
       ],
       "unit": "",
-      "latex_name": "\\gamma"
+      "latex_name": "\gamma"
     },
     {
       "name": "BAO log-term amp.",
@@ -156,7 +156,7 @@
         1500
       ],
       "unit": "",
-      "latex_name": "z_{\\rm drag}"
+      "latex_name": "z_{\rm drag}"
     },
     {
       "name": "Speed of light",
@@ -170,16 +170,16 @@
   ],
   "equations": {
     "sne": [
-      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$\\mu(z) = 5\\log_{10}[d_L(z)/{\\rm Mpc}] + 25$$"
+      "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+      "\mu(z) = 5\log_{10}[d_L(z)/{\rm Mpc}] + 25"
     ],
     "bao": [
-      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$D_H(z) = \\frac{c}{H(z)}$$",
-      "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+      "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+      "D_H(z) = \frac{c}{H(z)}",
+      "D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}"
     ]
   },
-  "rs_expression": "$$r_s = rs0*(1 + B*z_recomb*\\exp(-gamma*z_recomb) + C*\\log(1+z_recomb))$$",
+  "rs_expression": "r_s = rs0*(1 + B*z_recomb*\exp(-gamma*z_recomb) + C*\log(1+z_recomb))",
   "predicts_bao": true,
   "valid_for_cmb": false
 }

--- a/models/cosmo_model_cpc.json
+++ b/models/cosmo_model_cpc.json
@@ -1,8 +1,8 @@
 {
   "model_name": "CPCfRGravityCosmology",
   "version": "1.0",
-  "description": "CPC-f(R) Gravity Cosmology combines a modified gravity action f(R)=R+αR²−βR^{−n} with a CP-violating curvature coupling ξR F\\tilde F in the Standard Model gauge sector. This framework recovers standard radiation-dominated expansion (R→0→f(R)≈R) for BBN, features late-time cosmic acceleration from the R^{-n} term without a cosmological constant, and mediates Newtonian gravity plus Yukawa corrections at galactic scales. The CP term generates baryon asymmetry during the QCD phase transition, eliminating the need for extra baryogenesis fields.",
-  "abstract": "We propose a CP-coupled f(R) gravity model: S⊃∫d⁴x√−g [M_{Pl}²/2 f(R) + (ξ/4)R F\\tilde F + L_{SM}], with f(R)=R+αR²−βR^{−n}. In the radiation era R→0, yielding standard H∝√ρ behavior for BBN. At late times the −βR^{−n} term drives self-acceleration without Λ. We include a CP-violating term ξR F\\tilde F to generate n_B/s∼10^{−10} at T∼150 MeV. This model unifies cosmic acceleration, baryogenesis, and structure formation in a pure gravitational framework.",
+  "description": "CPC-f(R) Gravity Cosmology combines a modified gravity action f(R)=R+αR²−βR^{−n} with a CP-violating curvature coupling ξR F\tilde F in the Standard Model gauge sector. This framework recovers standard radiation-dominated expansion (R→0→f(R)≈R) for BBN, features late-time cosmic acceleration from the R^{-n} term without a cosmological constant, and mediates Newtonian gravity plus Yukawa corrections at galactic scales. The CP term generates baryon asymmetry during the QCD phase transition, eliminating the need for extra baryogenesis fields.",
+  "abstract": "We propose a CP-coupled f(R) gravity model: S⊃∫d⁴x√−g [M_{Pl}²/2 f(R) + (ξ/4)R F\tilde F + L_{SM}], with f(R)=R+αR²−βR^{−n}. In the radiation era R→0, yielding standard H∝√ρ behavior for BBN. At late times the −βR^{−n} term drives self-acceleration without Λ. We include a CP-violating term ξR F\tilde F to generate n_B/s∼10^{−10} at T∼150 MeV. This model unifies cosmic acceleration, baryogenesis, and structure formation in a pure gravitational framework.",
   "parameters": [
     {
       "name": "Hubble constant",
@@ -20,7 +20,7 @@
         0.5
       ],
       "unit": "",
-      "latex_name": "\\Omega_{m0}"
+      "latex_name": "\Omega_{m0}"
     },
     {
       "name": "Radiation density",
@@ -29,7 +29,7 @@
         0.0001
       ],
       "unit": "",
-      "latex_name": "\\Omega_{r0}"
+      "latex_name": "\Omega_{r0}"
     },
     {
       "name": "R² coefficient",
@@ -38,7 +38,7 @@
         1E+6
       ],
       "unit": "",
-      "latex_name": "\\alpha"
+      "latex_name": "\alpha"
     },
     {
       "name": "Inverse-power coefficient",
@@ -47,7 +47,7 @@
         1.0
       ],
       "unit": "",
-      "latex_name": "\\beta"
+      "latex_name": "\beta"
     },
     {
       "name": "Inverse-power exponent",
@@ -65,7 +65,7 @@
         1.0
       ],
       "unit": "",
-      "latex_name": "\\xi"
+      "latex_name": "\xi"
     },
     {
       "name": "Sound horizon base",
@@ -83,7 +83,7 @@
         1500
       ],
       "unit": "",
-      "latex_name": "z_{\\rm drag}"
+      "latex_name": "z_{\rm drag}"
     },
     {
       "name": "Speed of light",
@@ -95,18 +95,18 @@
       "latex_name": "c"
     }
   ],
-  "Hz_expression": "$$H(z) = H0 * \\sqrt{\\Omega_{m0}*(1+z)^3 + \\Omega_{r0}*(1+z)^4 + \\beta*(1+z)^{-n}}$$",
+  "Hz_expression": "H(z) = H0 * \sqrt{\Omega_{m0}*(1+z)^3 + \Omega_{r0}*(1+z)^4 + \beta*(1+z)^{-n}}",
   "equations": {
     "sne": [
-      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$\\mu(z) = 5\\log_{10}[d_L(z)/{\\rm Mpc}] + 25$$"
+      "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+      "\mu(z) = 5\log_{10}[d_L(z)/{\rm Mpc}] + 25"
     ],
     "bao": [
-      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$D_H(z) = \\frac{c}{H(z)}$$",
-      "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+      "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+      "D_H(z) = \frac{c}{H(z)}",
+      "D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}"
     ]
   },
-  "rs_expression": "$$r_s = rs0$$",
+  "rs_expression": "r_s = rs0",
   "predicts_bao": true
 }

--- a/models/cosmo_model_lcdm.json
+++ b/models/cosmo_model_lcdm.json
@@ -48,16 +48,16 @@
       ]
     }
   ],
-  "Hz_expression": "$$H(z) = H0 * \\sqrt{\\Omega_{m0}*(1+z)^3 + (1 - \\Omega_{m0})}$$",
+  "Hz_expression": "H(z) = H0 * \sqrt{\Omega_{m0}*(1+z)^3 + (1 - \Omega_{m0})}",
   "equations": {
     "sne": [
-      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$\\mu(z) = 5\\log_{10}[d_L(z)/{\\rm Mpc}] + 25$$"
+      "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+      "\mu(z) = 5\log_{10}[d_L(z)/{\rm Mpc}] + 25"
     ],
     "bao": [
-      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$D_H(z) = \\frac{c}{H(z)}$$",
-      "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+      "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+      "D_H(z) = \frac{c}{H(z)}",
+      "D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}"
     ]
   },
   "predicts_bao": true,

--- a/models/cosmo_model_qauc.json
+++ b/models/cosmo_model_qauc.json
@@ -2,7 +2,7 @@
   "model_name": "QuantumAttractorUnifiedCosmology",
   "version": "1.0",
   "description": "Quantum Attractor Unified Cosmology (QAUC) enhances ΛCDM with a scalar–tensor attractor whose exponential envelope and sinusoidal modulation alter the dark-energy sector. Ordinary matter and radiation follow their standard evolution while the oscillating dark-energy wave hints at a link between acceleration and quantum topology.",
-  "Hz_expression": "$$H(z) = H0 * \\sqrt{\\Omega_{m0}*(1+z)^3 + \\Omega_{r0}*(1+z)^4 + (1 - \\Omega_{m0} - \\Omega_{r0})*(1 + A*\\exp(-alpha*z)*\\cos(omega*z + phi0))}$$",
+  "Hz_expression": "H(z) = H0 * \sqrt{\Omega_{m0}*(1+z)^3 + \Omega_{r0}*(1+z)^4 + (1 - \Omega_{m0} - \Omega_{r0})*(1 + A*\exp(-alpha*z)*\cos(omega*z + phi0))}",
   "parameters": [
     {
       "name": "Hubble constant",
@@ -20,7 +20,7 @@
         0.5
       ],
       "unit": "",
-      "latex_name": "$\\Omega_{m0}$"
+      "latex_name": "$\Omega_{m0}$"
     },
     {
       "name": "Radiation density",
@@ -29,7 +29,7 @@
         0.001
       ],
       "unit": "",
-      "latex_name": "$\\Omega_{r0}$"
+      "latex_name": "$\Omega_{r0}$"
     },
     {
       "name": "Baryon density",
@@ -38,7 +38,7 @@
         0.1
       ],
       "unit": "",
-      "latex_name": "$\\Omega_{b0}$"
+      "latex_name": "$\Omega_{b0}$"
     },
     {
       "name": "Photon density",
@@ -47,7 +47,7 @@
         0.0001
       ],
       "unit": "",
-      "latex_name": "$\\Omega_{\\gamma0}$"
+      "latex_name": "$\Omega_{\gamma0}$"
     },
     {
       "name": "Recombination redshift",
@@ -56,7 +56,7 @@
         1500
       ],
       "unit": "",
-      "latex_name": "$z_{\\rm recomb}$"
+      "latex_name": "$z_{\rm recomb}$"
     },
     {
       "name": "Sound horizon at drag epoch",
@@ -83,7 +83,7 @@
         10.0
       ],
       "unit": "",
-      "latex_name": "$\\alpha$"
+      "latex_name": "$\alpha$"
     },
     {
       "name": "Oscillation frequency",
@@ -92,7 +92,7 @@
         20.0
       ],
       "unit": "",
-      "latex_name": "$\\omega$"
+      "latex_name": "$\omega$"
     },
     {
       "name": "Phase offset",
@@ -101,21 +101,21 @@
         6.283
       ],
       "unit": "rad",
-      "latex_name": "$\\varphi_0$"
+      "latex_name": "$\varphi_0$"
     }
   ],
   "equations": {
     "sne": [
-      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$\\mu(z) = 5\\log_{10}\\bigl[d_L(z)/{\\rm Mpc}\\bigr] + 25$$"
+      "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+      "\mu(z) = 5\log_{10}\bigl[d_L(z)/{\rm Mpc}\bigr] + 25"
     ],
     "bao": [
-      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$D_H(z) = \\frac{c}{H(z)}$$",
-      "$$D_V(z) = \\bigl[D_M(z)^2 \\tfrac{c\\,z}{H(z)}\\bigr]^{1/3}$$"
+      "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+      "D_H(z) = \frac{c}{H(z)}",
+      "D_V(z) = \bigl[D_M(z)^2 \tfrac{c\,z}{H(z)}\bigr]^{1/3}"
     ]
   },
-  "rs_expression": "$$r_s = rs$$",
+  "rs_expression": "r_s = rs",
   "predicts_bao": true,
   "valid_for_cmb": true,
   "cmb": {

--- a/models/cosmo_model_usmf2.json
+++ b/models/cosmo_model_usmf2.json
@@ -1,7 +1,7 @@
 {
   "model_name": "USMFv2",
   "version": "2.0",
-  "description": "### 1. Introduction\nModern cosmology, while remarkably successful, faces fundamental challenges centered around the concepts of dark energy and dark matter, hypothetical entities comprising ~95% of the Universe's energy density. The observed accelerated expansion of the Universe [1, 2] and anomalous galactic and cluster dynamics [3, 4] are the primary evidence for their existence. The Unified Shrinking Matter Framework (USMF) offers an alternative perspective, positing that these phenomena are not due to new fundamental entities but are rather illusions. These illusions arise from a continuous, inhomogeneous shrinking of matter and physical scales within dense regions of the Universe, when observations are made with locally shrinking instruments and interpreted against a presumed static background.\nThis framework aims to explain the apparent cosmic acceleration and the effects attributed to dark matter by re-evaluating the nature of our reference frames and the evolution of physical scales over cosmic time. This updated document (Version 2) incorporates further elaborations on the model's theoretical underpinnings, mathematical extensions for early universe compatibility, and more detailed unique predictions.\n### 2. Core Concepts of the Unified Shrinking Matter Framework\nUSMF is built upon several foundational ideas that distinguish it from standard cosmological models.\n#### 2.1. Dual Reference Frames\nA central tenet of USMF is the existence of two distinct types of reference frames:\n* A **Universal Coordinate System** ($X, Y, Z, T_{univ}$): This is a static, non-shrinking, four-dimensional Cartesian framework representing the Universe at its largest scales. Universal time is denoted as $t_{univ}$ or simply $t$.\n* **Local Coordinate Systems** ($x, y, z, t_{local}$): These are tied to dense regions of matter, such as galaxies and galaxy clusters. Within these local frames, spacetime itself, along with all matter, energy, and measuring instruments, undergoes a process of shrinking over cosmic time relative to the universal coordinates.\nObservations made from Earth are inherently from within such a local, shrinking frame.\n#### 2.2. Inhomogeneous Shrinking and its Quantification\nThe process of shrinking is not uniform throughout the Universe. It is posited to occur primarily within regions of significant matter density. Cosmic voids, being largely devoid of matter, are assumed to retain their original scales (established at a \"Universal Creation Event\" or UDE) in the universal coordinate system. As dense regions contract, voids effectively appear to expand or \"empty out\" relative to these shrinking zones. This inhomogeneity is crucial for explaining the apparent distribution of \"dark matter\" effects.\n**Quantifying Inhomogeneous Shrinking**: The Universal Scaling Factor $\\alpha_U$ becomes a function of local environment: $\\alpha_U(\\rho, t_{univ}, \\mathbf{x}) = \\alpha_{U,bg}(t_{univ}) \\cdot f(\\rho_{local}(\\mathbf{x}, t_{univ}), \\text{history})$. Here, $\\alpha_{U,bg}(t_{univ})$ is the background cosmological shrinking factor, and $f$ describes the modulation due to local density $\\rho_{local}$ and potentially its history.\n#### 2.3. The Metric in Dense Regions\nWithin a local, dense, shrinking region, the spacetime metric is proposed to take the form:\n$$ds^2 = -c^2 dt_{local}^2 + \\alpha_U(t_{univ}, env)^2 \\delta_{ij} dx^i dx^j$$\nwhere $c$ is the speed of light, $dt_{local}$ is the local time interval, $dx^i$ are local Cartesian spatial coordinate intervals, $\\delta_{ij}$ is the Kronecker delta, and $\\alpha_U(t_{univ}, env)$ is the Universal Scaling Factor. This factor $\\alpha_U$ describes the magnitude of spatial shrinking as a function of universal time $t_{univ}$ and potentially local environmental factors ($env$) such as density $\\rho$. For the background cosmological model, we primarily consider its temporal evolution $\\alpha_U(t_{univ})$. The shrinking implies that $\\alpha_U(t_{univ})$ is a decreasing function of cosmic time.\n*(... The rest of the theoretical sections from the JSON would follow here, formatted with Markdown headings ...)*",
+  "description": "### 1. Introduction\nModern cosmology, while remarkably successful, faces fundamental challenges centered around the concepts of dark energy and dark matter, hypothetical entities comprising ~95% of the Universe's energy density. The observed accelerated expansion of the Universe [1, 2] and anomalous galactic and cluster dynamics [3, 4] are the primary evidence for their existence. The Unified Shrinking Matter Framework (USMF) offers an alternative perspective, positing that these phenomena are not due to new fundamental entities but are rather illusions. These illusions arise from a continuous, inhomogeneous shrinking of matter and physical scales within dense regions of the Universe, when observations are made with locally shrinking instruments and interpreted against a presumed static background.\nThis framework aims to explain the apparent cosmic acceleration and the effects attributed to dark matter by re-evaluating the nature of our reference frames and the evolution of physical scales over cosmic time. This updated document (Version 2) incorporates further elaborations on the model's theoretical underpinnings, mathematical extensions for early universe compatibility, and more detailed unique predictions.\n### 2. Core Concepts of the Unified Shrinking Matter Framework\nUSMF is built upon several foundational ideas that distinguish it from standard cosmological models.\n#### 2.1. Dual Reference Frames\nA central tenet of USMF is the existence of two distinct types of reference frames:\n* A **Universal Coordinate System** ($X, Y, Z, T_{univ}$): This is a static, non-shrinking, four-dimensional Cartesian framework representing the Universe at its largest scales. Universal time is denoted as $t_{univ}$ or simply $t$.\n* **Local Coordinate Systems** ($x, y, z, t_{local}$): These are tied to dense regions of matter, such as galaxies and galaxy clusters. Within these local frames, spacetime itself, along with all matter, energy, and measuring instruments, undergoes a process of shrinking over cosmic time relative to the universal coordinates.\nObservations made from Earth are inherently from within such a local, shrinking frame.\n#### 2.2. Inhomogeneous Shrinking and its Quantification\nThe process of shrinking is not uniform throughout the Universe. It is posited to occur primarily within regions of significant matter density. Cosmic voids, being largely devoid of matter, are assumed to retain their original scales (established at a \"Universal Creation Event\" or UDE) in the universal coordinate system. As dense regions contract, voids effectively appear to expand or \"empty out\" relative to these shrinking zones. This inhomogeneity is crucial for explaining the apparent distribution of \"dark matter\" effects.\n**Quantifying Inhomogeneous Shrinking**: The Universal Scaling Factor $\alpha_U$ becomes a function of local environment: $\alpha_U(\rho, t_{univ}, \mathbf{x}) = \alpha_{U,bg}(t_{univ}) \cdot f(\rho_{local}(\mathbf{x}, t_{univ}), \text{history})$. Here, $\alpha_{U,bg}(t_{univ})$ is the background cosmological shrinking factor, and $f$ describes the modulation due to local density $\rho_{local}$ and potentially its history.\n#### 2.3. The Metric in Dense Regions\nWithin a local, dense, shrinking region, the spacetime metric is proposed to take the form:\nds^2 = -c^2 dt_{local}^2 + \alpha_U(t_{univ}, env)^2 \delta_{ij} dx^i dx^j\nwhere $c$ is the speed of light, $dt_{local}$ is the local time interval, $dx^i$ are local Cartesian spatial coordinate intervals, $\delta_{ij}$ is the Kronecker delta, and $\alpha_U(t_{univ}, env)$ is the Universal Scaling Factor. This factor $\alpha_U$ describes the magnitude of spatial shrinking as a function of universal time $t_{univ}$ and potentially local environmental factors ($env$) such as density $\rho$. For the background cosmological model, we primarily consider its temporal evolution $\alpha_U(t_{univ})$. The shrinking implies that $\alpha_U(t_{univ})$ is a decreasing function of cosmic time.\n*(... The rest of the theoretical sections from the JSON would follow here, formatted with Markdown headings ...)*",
   "abstract": "The Unified Shrinking Matter Framework (USMF) is a cosmological model proposing that the observed accelerated expansion of the Universe and phenomena attributed to dark matter and dark energy are apparent effects. These arise from observations made from within dense cosmic structures (like galaxies) that are themselves shrinking over cosmic time relative to a static universal coordinate system. This paper details the core concepts of USMF, its refined mathematical formulation including considerations for early universe evolution, the mechanisms for inhomogeneous shrinking, its implications for key cosmological observations such as Type Ia supernovae, Big Bang Nucleosynthesis, Baryon Acoustic Oscillations, and the matter-antimatter asymmetry. The framework suggests a dynamic evolution of fundamental scales and the effective gravitational constant ($G_{univ}(t)$), proposing specific modifications to gravitational field equations and offering novel explanations and unique testable predictions for cosmic puzzles without invoking new undiscovered particles or energy fields.",
   "parameters": [
     {
@@ -20,7 +20,7 @@
         1.5
       ],
       "unit": "",
-      "latex_name": "$p_{\\alpha}$"
+      "latex_name": "$p_{\alpha}$"
     },
     {
       "name": "k_exp",
@@ -65,7 +65,7 @@
         10.0
       ],
       "unit": "rad/log(time_ratio)",
-      "latex_name": "$\\omega_{osc}$"
+      "latex_name": "$\omega_{osc}$"
     },
     {
       "name": "ti_osc_Gyr",
@@ -83,7 +83,7 @@
         3.1416
       ],
       "unit": "rad",
-      "latex_name": "$\\phi_{osc}$"
+      "latex_name": "$\phi_{osc}$"
     },
     {
       "name": "Ob",
@@ -107,18 +107,18 @@
       ]
     }
   ],
-  "Hz_expression": "$$H(z) = H_A*(1+z)$$",
+  "Hz_expression": "H(z) = H_A*(1+z)",
   "equations": {
     "sne": [
-      "$$1+z = \\frac{\\alpha(t_e)}{\\alpha(t_0)}$$",
-      "$$r = \\int_{t_e}^{t_0} \\frac{c}{\\alpha(t')} dt'$$",
-      "$$d_L(z) = |r| \\cdot (1+z)^2 \\cdot \\frac{70.0}{H_A}$$",
-      "$$\\mu = 5 \\log_{10}(d_L) + 25$$"
+      "1+z = \frac{\alpha(t_e)}{\alpha(t_0)}",
+      "r = \int_{t_e}^{t_0} \frac{c}{\alpha(t')} dt'",
+      "d_L(z) = |r| \cdot (1+z)^2 \cdot \frac{70.0}{H_A}",
+      "\mu = 5 \log_{10}(d_L) + 25"
     ],
     "bao": [
-      "$$D_A(z) = |r| \\cdot \\frac{70.0}{H_A}$$",
-      "$$H_{USMF}(z) = - \\frac{1}{\\alpha(t_e)} \\left. \\frac{d\\alpha}{dt} \\right|_{t_e}$$",
-      "$$D_V(z) = \\left[ (1+z)^2 D_A(z)^2 \\frac{cz}{H(z)} \\right]^{1/3}$$"
+      "D_A(z) = |r| \cdot \frac{70.0}{H_A}",
+      "H_{USMF}(z) = - \frac{1}{\alpha(t_e)} \left. \frac{d\alpha}{dt} \right|_{t_e}",
+      "D_V(z) = \left[ (1+z)^2 D_A(z)^2 \frac{cz}{H(z)} \right]^{1/3}"
     ]
   },
   "predicts_bao": true,

--- a/models/cosmo_model_usmf3.json
+++ b/models/cosmo_model_usmf3.json
@@ -20,7 +20,7 @@
         1.5
       ],
       "unit": "",
-      "latex_name": "$p_\\alpha$"
+      "latex_name": "$p_\alpha$"
     },
     {
       "name": "k_exp",
@@ -29,7 +29,7 @@
         5.0
       ],
       "unit": "",
-      "latex_name": "$k_{\\rm exp}$"
+      "latex_name": "$k_{\rm exp}$"
     },
     {
       "name": "s_exp",
@@ -38,7 +38,7 @@
         3.0
       ],
       "unit": "",
-      "latex_name": "$s_{\\rm exp}$"
+      "latex_name": "$s_{\rm exp}$"
     },
     {
       "name": "t0_age_Gyr",
@@ -47,7 +47,7 @@
         20.0
       ],
       "unit": "Gyr",
-      "latex_name": "$t_{0,\\rm age}$"
+      "latex_name": "$t_{0,\rm age}$"
     },
     {
       "name": "A_osc",
@@ -56,7 +56,7 @@
         0.1
       ],
       "unit": "",
-      "latex_name": "$A_{\\rm osc}$"
+      "latex_name": "$A_{\rm osc}$"
     },
     {
       "name": "w_osc",
@@ -65,7 +65,7 @@
         10.0
       ],
       "unit": "",
-      "latex_name": "$w_{\\rm osc}$"
+      "latex_name": "$w_{\rm osc}$"
     },
     {
       "name": "ti_osc_Gyr",
@@ -74,7 +74,7 @@
         20.0
       ],
       "unit": "Gyr",
-      "latex_name": "$t_{i,\\rm osc}$"
+      "latex_name": "$t_{i,\rm osc}$"
     },
     {
       "name": "phi_osc",
@@ -83,7 +83,7 @@
         3.1416
       ],
       "unit": "rad",
-      "latex_name": "$\\phi_{\\rm osc}$"
+      "latex_name": "$\phi_{\rm osc}$"
     },
     {
       "name": "Ob",
@@ -92,7 +92,7 @@
         0.1
       ],
       "unit": "",
-      "latex_name": "$\\Omega_b$"
+      "latex_name": "$\Omega_b$"
     },
     {
       "name": "Og",
@@ -101,7 +101,7 @@
         0.001
       ],
       "unit": "",
-      "latex_name": "$\\Omega_\\gamma$"
+      "latex_name": "$\Omega_\gamma$"
     },
     {
       "name": "z_recomb",
@@ -110,7 +110,7 @@
         1200
       ],
       "unit": "",
-      "latex_name": "$z_{\\rm rec}$"
+      "latex_name": "$z_{\rm rec}$"
     },
     {
       "name": "O_eff",
@@ -119,21 +119,21 @@
         0.5
       ],
       "unit": "",
-      "latex_name": "$\\Omega_{\\rm eff}$"
+      "latex_name": "$\Omega_{\rm eff}$"
     }
   ],
-  "Hz_expression": "$$H(z)=H_A\\,(1+z)^{p_\\alpha}\\bigl[1 + k_{\\rm exp}\\,(1+z)^{s_{\\rm exp}}\\bigr]$$",
+  "Hz_expression": "H(z)=H_A\,(1+z)^{p_\alpha}\bigl[1 + k_{\rm exp}\,(1+z)^{s_{\rm exp}}\bigr]",
   "equations": {
     "sne": [
-      "$$1+z = \\frac{\\alpha(t_e)}{\\alpha(t_0)}$$",
-      "$$r = \\int_{t_e}^{t_0} \\frac{c}{\\alpha(t')} dt'$$",
-      "$$d_L(z) = |r|\\,(1+z)^2\\,\\frac{70.0}{H_A}$$",
-      "$$\\mu = 5\\log_{10}(d_L) + 25$$"
+      "1+z = \frac{\alpha(t_e)}{\alpha(t_0)}",
+      "r = \int_{t_e}^{t_0} \frac{c}{\alpha(t')} dt'",
+      "d_L(z) = |r|\,(1+z)^2\,\frac{70.0}{H_A}",
+      "\mu = 5\log_{10}(d_L) + 25"
     ],
     "bao": [
-      "$$D_A(z) = |r|\\,\\frac{70.0}{H_A}$$",
-      "$$H_{USMF}(z) = H(z)$$",
-      "$$D_V(z) = \\bigl[(1+z)^2\\,D_A(z)^2\\,\\frac{cz}{H(z)}\\bigr]^{1/3}$$"
+      "D_A(z) = |r|\,\frac{70.0}{H_A}",
+      "H_{USMF}(z) = H(z)",
+      "D_V(z) = \bigl[(1+z)^2\,D_A(z)^2\,\frac{cz}{H(z)}\bigr]^{1/3}"
     ]
   },
   "predicts_bao": true,

--- a/models/cosmo_model_usmf4.json
+++ b/models/cosmo_model_usmf4.json
@@ -31,7 +31,7 @@
         1.5
       ],
       "unit": "",
-      "latex_name": "p_{\\alpha}"
+      "latex_name": "p_{\alpha}"
     },
     {
       "name": "Extra-term amplitude",
@@ -40,7 +40,7 @@
         5.0
       ],
       "unit": "",
-      "latex_name": "k_{\\rm exp}"
+      "latex_name": "k_{\rm exp}"
     },
     {
       "name": "Extra-term slope",
@@ -49,7 +49,7 @@
         3.0
       ],
       "unit": "",
-      "latex_name": "s_{\\rm exp}"
+      "latex_name": "s_{\rm exp}"
     },
     {
       "name": "Present-day age",
@@ -58,7 +58,7 @@
         20.0
       ],
       "unit": "Gyr",
-      "latex_name": "t_{0,\\rm age}"
+      "latex_name": "t_{0,\rm age}"
     },
     {
       "name": "Baryon density Ω_b",
@@ -67,7 +67,7 @@
         0.055
       ],
       "unit": "",
-      "latex_name": "\\Omega_b"
+      "latex_name": "\Omega_b"
     },
     {
       "name": "Photon density Ω_γ",
@@ -76,7 +76,7 @@
         0.00004186
       ],
       "unit": "",
-      "latex_name": "\\Omega_{\\gamma}"
+      "latex_name": "\Omega_{\gamma}"
     },
     {
       "name": "Recombination redshift",
@@ -85,7 +85,7 @@
         1100
       ],
       "unit": "",
-      "latex_name": "z_{\\rm rec}"
+      "latex_name": "z_{\rm rec}"
     },
     {
       "name": "Primordial amplitude A_s",
@@ -112,21 +112,21 @@
         0.5
       ],
       "unit": "",
-      "latex_name": "\\Omega_{\\rm eff}"
+      "latex_name": "\Omega_{\rm eff}"
     }
   ],
-  "Hz_expression": "$$H(z) = H_A * \\sqrt{ \\left((1+z)^{p_{\\alpha}} * \\left(1 + k_{\\rm exp} * (1+z)^{s_{\\rm exp}}\\right)\\right)^2 + Og * (1+z)^4 }$$",
+  "Hz_expression": "H(z) = H_A * \sqrt{ \left((1+z)^{p_{\alpha}} * \left(1 + k_{\rm exp} * (1+z)^{s_{\rm exp}}\right)\right)^2 + Og * (1+z)^4 }",
   "predicts_bao": true,
   "valid_for_cmb": true,
   "equations": {
     "sne": [
-      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$\\mu(z) = 5\\log_{10}\\bigl(d_L(z)/\\mathrm{Mpc}\\bigr) + 25$$"
+      "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+      "\mu(z) = 5\log_{10}\bigl(d_L(z)/\mathrm{Mpc}\bigr) + 25"
     ],
     "bao": [
-      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$D_H(z) = \\frac{c}{H(z)}$$",
-      "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+      "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+      "D_H(z) = \frac{c}{H(z)}",
+      "D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}"
     ]
   },
   "cmb": {

--- a/models/cosmo_model_usmf5.json
+++ b/models/cosmo_model_usmf5.json
@@ -31,7 +31,7 @@
         2.0
       ],
       "unit": "",
-      "latex_name": "p_{\\alpha}"
+      "latex_name": "p_{\alpha}"
     },
     {
       "name": "Quantum amplitude",
@@ -40,7 +40,7 @@
         2.0
       ],
       "unit": "",
-      "latex_name": "k_{\\rm exp}"
+      "latex_name": "k_{\rm exp}"
     },
     {
       "name": "Quantum slope",
@@ -49,7 +49,7 @@
         5.0
       ],
       "unit": "",
-      "latex_name": "s_{\\rm exp}"
+      "latex_name": "s_{\rm exp}"
     },
     {
       "name": "Emergent matter density",
@@ -58,7 +58,7 @@
         0.5
       ],
       "unit": "",
-      "latex_name": "\\Omega_{\\rm eff}"
+      "latex_name": "\Omega_{\rm eff}"
     },
     {
       "name": "Photon density",
@@ -67,7 +67,7 @@
         0.00004186
       ],
       "unit": "",
-      "latex_name": "\\Omega_{\\gamma}"
+      "latex_name": "\Omega_{\gamma}"
     },
     {
       "name": "Baryon density",
@@ -76,7 +76,7 @@
         0.055
       ],
       "unit": "",
-      "latex_name": "\\Omega_b"
+      "latex_name": "\Omega_b"
     },
     {
       "name": "Recombination redshift",
@@ -85,7 +85,7 @@
         1100
       ],
       "unit": "",
-      "latex_name": "z_{\\rm rec}"
+      "latex_name": "z_{\rm rec}"
     },
     {
       "name": "Primordial amplitude",
@@ -106,18 +106,18 @@
       "latex_name": "n_s"
     }
   ],
-  "Hz_expression": "$$H(z) = H_A * \\sqrt{ (1+z)^{2*p_{\\alpha}}*(1 + k_{\\rm exp}*(1+z)^{s_{\\rm exp}}) + O_{\\rm eff}*(1+z)^3 + Og*(1+z)^4 }$$",
+  "Hz_expression": "H(z) = H_A * \sqrt{ (1+z)^{2*p_{\alpha}}*(1 + k_{\rm exp}*(1+z)^{s_{\rm exp}}) + O_{\rm eff}*(1+z)^3 + Og*(1+z)^4 }",
   "predicts_bao": true,
   "valid_for_cmb": true,
   "equations": {
     "sne": [
-      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$\\mu(z) = 5\\log_{10}[d_L(z)/\\mathrm{Mpc}] + 25$$"
+      "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+      "\mu(z) = 5\log_{10}[d_L(z)/\mathrm{Mpc}] + 25"
     ],
     "bao": [
-      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$D_H(z) = \\frac{c}{H(z)}$$",
-      "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+      "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+      "D_H(z) = \frac{c}{H(z)}",
+      "D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}"
     ]
   },
   "cmb": {
@@ -131,5 +131,5 @@
       "ns": "n_s"
     }
   },
-  "notes": "Added explicit '*' between every factor (e.g. 2*p_alpha), removed any implicit multiplication.  Uses LaTeX \\sqrt for clarity.  Abstract/description are fully self-contained for new readers."
+  "notes": "Added explicit '*' between every factor (e.g. 2*p_alpha), removed any implicit multiplication.  Uses LaTeX \sqrt for clarity.  Abstract/description are fully self-contained for new readers."
 }

--- a/models/cosmo_model_usmf6.json
+++ b/models/cosmo_model_usmf6.json
@@ -31,7 +31,7 @@
         2.0
       ],
       "unit": "",
-      "latex_name": "p_{\\alpha}"
+      "latex_name": "p_{\alpha}"
     },
     {
       "name": "Quantum amplitude",
@@ -40,7 +40,7 @@
         2.0
       ],
       "unit": "",
-      "latex_name": "k_{\\rm exp}"
+      "latex_name": "k_{\rm exp}"
     },
     {
       "name": "Quantum slope",
@@ -49,7 +49,7 @@
         5.0
       ],
       "unit": "",
-      "latex_name": "s_{\\rm exp}"
+      "latex_name": "s_{\rm exp}"
     },
     {
       "name": "Emergent matter density",
@@ -58,7 +58,7 @@
         0.5
       ],
       "unit": "",
-      "latex_name": "\\Omega_{\\rm eff}"
+      "latex_name": "\Omega_{\rm eff}"
     },
     {
       "name": "Photon density",
@@ -67,7 +67,7 @@
         0.00004186
       ],
       "unit": "",
-      "latex_name": "\\Omega_{\\gamma}"
+      "latex_name": "\Omega_{\gamma}"
     },
     {
       "name": "Baryon density",
@@ -76,7 +76,7 @@
         0.055
       ],
       "unit": "",
-      "latex_name": "\\Omega_b"
+      "latex_name": "\Omega_b"
     },
     {
       "name": "Recombination redshift",
@@ -85,7 +85,7 @@
         1100
       ],
       "unit": "",
-      "latex_name": "z_{\\rm rec}"
+      "latex_name": "z_{\rm rec}"
     },
     {
       "name": "Primordial amplitude",
@@ -106,18 +106,18 @@
       "latex_name": "n_s"
     }
   ],
-  "Hz_expression": "$$H(z) = H_A * \\sqrt{ (1+z)^{2*p_{\\alpha}}*(1 + k_{\\rm exp}*(1+z)^{s_{\\rm exp}}) + O_{\\rm eff}*(1+z)^3 + Og*(1+z)^4 }$$",
+  "Hz_expression": "H(z) = H_A * \sqrt{ (1+z)^{2*p_{\alpha}}*(1 + k_{\rm exp}*(1+z)^{s_{\rm exp}}) + O_{\rm eff}*(1+z)^3 + Og*(1+z)^4 }",
   "predicts_bao": true,
   "valid_for_cmb": true,
   "equations": {
     "sne": [
-      "$$d_L(z) = (1+z) \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$\\mu(z) = 5\\log_{10}[d_L(z)/\\mathrm{Mpc}] + 25$$"
+      "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+      "\mu(z) = 5\log_{10}[d_L(z)/\mathrm{Mpc}] + 25"
     ],
     "bao": [
-      "$$D_M(z) = \\int_0^z \\frac{c\\,dz'}{H(z')}$$",
-      "$$D_H(z) = \\frac{c}{H(z)}$$",
-      "$$D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}$$"
+      "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+      "D_H(z) = \frac{c}{H(z)}",
+      "D_V(z) = [D_M(z)^2 D_H(z)]^{1/3}"
     ]
   },
   "cmb": {
@@ -131,5 +131,5 @@
       "ns": "n_s"
     }
   },
-  "notes": "Added explicit '*' between every factor (e.g. 2*p_alpha), removed any implicit multiplication.  Uses LaTeX \\sqrt for clarity.  Abstract/description are fully self-contained for new readers."
+  "notes": "Added explicit '*' between every factor (e.g. 2*p_alpha), removed any implicit multiplication.  Uses LaTeX \sqrt for clarity.  Abstract/description are fully self-contained for new readers."
 }

--- a/models/cosmo_model_usmf7.json
+++ b/models/cosmo_model_usmf7.json
@@ -31,7 +31,7 @@
         2.0
       ],
       "unit": "",
-      "latex_name": "p_{\\alpha}"
+      "latex_name": "p_{\alpha}"
     },
     {
       "name": "Quantum amplitude",
@@ -40,7 +40,7 @@
         2.0
       ],
       "unit": "",
-      "latex_name": "k_{\\rm exp}"
+      "latex_name": "k_{\rm exp}"
     },
     {
       "name": "Quantum slope",
@@ -49,7 +49,7 @@
         5.0
       ],
       "unit": "",
-      "latex_name": "s_{\\rm exp}"
+      "latex_name": "s_{\rm exp}"
     },
     {
       "name": "Matter clustering density",
@@ -58,7 +58,7 @@
         0.5
       ],
       "unit": "",
-      "latex_name": "\\Omega_{\\rm eff}"
+      "latex_name": "\Omega_{\rm eff}"
     },
     {
       "name": "Photon density",
@@ -67,7 +67,7 @@
         0.001
       ],
       "unit": "",
-      "latex_name": "\\Omega_{\\gamma}"
+      "latex_name": "\Omega_{\gamma}"
     },
     {
       "name": "Baryon density",
@@ -76,7 +76,7 @@
         0.070
       ],
       "unit": "",
-      "latex_name": "\\Omega_b"
+      "latex_name": "\Omega_b"
     },
     {
       "name": "Recombination redshift",
@@ -85,7 +85,7 @@
         1500
       ],
       "unit": "",
-      "latex_name": "z_{\\rm rec}"
+      "latex_name": "z_{\rm rec}"
     },
     {
       "name": "Primordial amplitude",
@@ -112,21 +112,21 @@
         0.15
       ],
       "unit": "",
-      "latex_name": "\\tau"
+      "latex_name": "\tau"
     }
   ],
-  "Hz_expression": "$$H(z) = H_A * sqrt((1+z)**(2*p_alpha)*(1 + k_exp*(1+z)**(s_exp)) + O_eff*(1+z)**3 + Og*(1+z)**4)$$",
+  "Hz_expression": "H(z) = H_A * sqrt((1+z)**(2*p_alpha)*(1 + k_exp*(1+z)**(s_exp)) + O_eff*(1+z)**3 + Og*(1+z)**4)",
   "predicts_bao": true,
   "valid_for_cmb": true,
   "equations": {
     "sne": [
-      "$$d_L(z) = (1+z) \\\\int_0^z \\\\frac{c\\\\,dz'}{H(z')}$$",
-      "$$\\\\mu(z) = 5\\\\log_{10}(d_L(z)/\\\\mathrm{Mpc}) + 25$$"
+      "d_L(z) = (1+z) \int_0^z \frac{c\,dz'}{H(z')}",
+      "\mu(z) = 5\log_{10}(d_L(z)/\mathrm{Mpc}) + 25"
     ],
     "bao": [
-      "$$D_M(z) = \\\\int_0^z \\\\frac{c\\\\,dz'}{H(z')}$$",
-      "$$D_H(z) = c/H(z)$$",
-      "$$D_V(z) = [D_M(z)**2 * D_H(z)]**(1/3)$$"
+      "D_M(z) = \int_0^z \frac{c\,dz'}{H(z')}",
+      "D_H(z) = c/H(z)",
+      "D_V(z) = [D_M(z)**2 * D_H(z)]**(1/3)"
     ]
   },
   "cmb": {
@@ -140,5 +140,5 @@
       "ns": "n_s"
     }
   },
-  "notes": "Re-introduced $$…$$ wrappers around each equation and fixed all LaTeX backslashes (e.g. \\int and \\frac and \\\\,dz') so that the plotter and JSON parser accept them without error."
+  "notes": "Re-introduced … wrappers around each equation and fixed all LaTeX backslashes (e.g. \int and \frac and \,dz') so that the plotter and JSON parser accept them without error."
 }


### PR DESCRIPTION
## Summary
- parse models with single backslashes and without math delimiters
- wrap math expressions while writing caches
- allow single `$` math markers
- enable implicit multiplication in expression parser
- document simplified JSON syntax and bump version to 1.18.0
- update all model JSON files to use single backslashes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887fe1faaac832fa137eb94cc117770