### PR TITLE
Fix sound horizon fallback variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Add one line for each substantive commit or pull request directly under the late
 ## Version 1.18.2
 - 2025-07-29: Fixed parsing failures by removing \rm from parameter names in expressions and bumped versions (AI assistant)
 
+## Version 1.18.3
+- 2025-07-29: Fallback sound-horizon integral now looks for `Omega_b`, `Omega_gamma` and `z_rec`/`z_recomb` instead of legacy aliases (AI assistant)
+
 ## Version 1.18.0
 - 2025-07-28: Removed math delimiters and double backslash requirement in model files; added implicit multiplication (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 1.18.2
-**Last Updated:** 2025-07-28
+**Version:** 1.18.3
+**Last Updated:** 2025-07-29
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.
@@ -191,7 +191,8 @@ See `cosmo_model_guide.json` for a detailed template.
    your model parameters. Explicit `*` is optional since implicit multiplication
    is now supported, though adding it can improve readability.
 4. Optionally provide an `rs_expression` in LaTeX for the sound horizon at
-   recombination or include the parameters `Ob`, `Og` and `z_recomb`. The suite will then
+   recombination or include the parameters `Omega_b`, `Omega_gamma` and either
+   `z_rec` or `z_recomb`. The suite will then
    derive `r_s` automatically using a numerical integral. Use `\infty` when an
    integral extends to infinity.
 5. Python code must never appear in `cosmo_model_*.json`; all expressions are written in LaTeX.
@@ -252,8 +253,8 @@ The required top-level keys are `model_name`, `version`, `parameters`,
   "cmb": {
     "param_map": {
       "H0": "H0",
-      "ombh2": "Ob * (H0/100)**2",
-      "omch2": "(Om - Ob) * (H0/100)**2",
+      "ombh2": "Omega_b0 * (H0/100)**2",
+      "omch2": "(Omega_m0 - Omega_b0) * (H0/100)**2",
       "tau": 0.054,
       "As": 2.1e-9,
       "ns": 0.965
@@ -288,8 +289,9 @@ compatible with older models.
 `model_parser.py` validates this structure and `model_coder.py` translates the
 LaTeX expressions into NumPy-ready callables. When `Hz_expression` is present it is
 compiled into `get_Hz_per_Mpc` and related distance functions used by
-`engine_interface.py`. If an `rs_expression` or the parameters `Ob`, `Og` and
-`z_recomb` are provided, a callable `get_sound_horizon_rs_Mpc` is also generated.
+`engine_interface.py`. If an `rs_expression` or the parameters `Omega_b`,
+`Omega_gamma` and either `z_rec` or `z_recomb` are provided, a callable
+`get_sound_horizon_rs_Mpc` is also generated.
 
 ## Developer Guide
 Document every change in `CHANGELOG.md`. Each substantive update must add an entry using the template `- YYYY-MM-DD: short summary (author)`.

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -181,10 +181,16 @@ def generate_callables(cache_path):
                 except Exception as e:
                     error_handler.report_error(f"Failed to parse rs_expression: {e}")
                     raise ValueError(f"Failed to parse rs_expression: {e}") from e
-            elif {'Ob', 'Og', 'z_recomb'}.issubset(param_names) and 'get_Hz_per_Mpc' in funcs:
-                ob_i = param_index['Ob']
-                og_i = param_index['Og']
-                zr_i = param_index['z_recomb']
+            elif (
+                'Omega_b' in param_names
+                and 'Omega_gamma' in param_names
+                and ('z_rec' in param_names or 'z_recomb' in param_names)
+                and 'get_Hz_per_Mpc' in funcs
+            ):
+                ob_i = param_index['Omega_b']
+                og_i = param_index['Omega_gamma']
+                zr_key = 'z_rec' if 'z_rec' in param_names else 'z_recomb'
+                zr_i = param_index[zr_key]
 
                 def _rs(*params):
                     """Numerically compute the sound horizon r_s in Mpc."""

--- a/models/cosmo_model_lcdm.json
+++ b/models/cosmo_model_lcdm.json
@@ -20,21 +20,14 @@
       ]
     },
     {
-      "name": "Omega_b0",
+      "name": "Omega_b",
       "bounds": [
         0.01,
         0.1
       ]
     },
     {
-      "name": "Ob",
-      "bounds": [
-        0.01,
-        0.1
-      ]
-    },
-    {
-      "name": "Og",
+      "name": "Omega_gamma",
       "bounds": [
         0.00001,
         0.0001
@@ -65,9 +58,9 @@
   "cmb": {
     "param_map": {
       "H0": "H0",
-      "ombh2": "Omega_b0 * (H0/100)**2",
-      "omch2": "(Omega_m0 - Omega_b0) * (H0/100)**2",
-      "omnuh2": "Og * (H0/100)**2",
+      "ombh2": "Omega_b * (H0/100)**2",
+      "omch2": "(Omega_m0 - Omega_b) * (H0/100)**2",
+      "omnuh2": "Omega_gamma * (H0/100)**2",
       "tau": 0.054,
       "As": 2.1E-9,
       "ns": 0.965


### PR DESCRIPTION
## Summary
- compute BAO sound horizon when parameters use `Omega_b`, `Omega_gamma` and `z_rec` or `z_recomb`
- update documentation and example parameter map
- bump version to 1.18.3
- update LambdaCDM model to use new parameter names

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_688883382e38832f934cb2d5091bac78