### PR TITLE
Vectorize BAO chi2 and update YAML docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Add one line for each substantive commit or pull request directly under the late
 ## Version 2.0.0
 - 2025-07-30: Migrated all models to YAML and removed JSON support (AI assistant)
 
+## Version 2.0.1
+- 2025-07-30: Vectorised BAO chi-squared and updated YAML documentation (AI assistant)
+
 
 ## Version 1.19.3
 - 2025-07-29: Fixed parsing of LaTeX names containing `\rm` and bumped version (AI assistant)

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ automatically and does not need to be tracked in version control.
 
 ## Directory Layout
 ```
-models/           - JSON model definitions containing all theory text and
+models/           - YAML model definitions containing all theory text and
                     equations. Optional `.md` files may provide human-readable
                     summaries but are not required.
 engines/          - Computational backends (e.g. `cosmo_engine_comb.py` for combined fits)
@@ -222,7 +222,7 @@ extensible mappings stored in `latex_mappings.json`. Expressions may also
 contain `Integral` constructs with explicit limits which are numerically
 evaluated with SciPy. Use `\infty` for an infinite upper bound and avoid
 referencing `H(z)` inside other expressions—repeat the formula instead.
-The suite validates the JSON, stores a sanitized copy under `models/cache/`, and
+The suite validates the YAML, stores a sanitized copy under `models/cache/`, and
 auto-generates the necessary Python functions.
 
 ### JSON Schema
@@ -284,7 +284,7 @@ residuals, uses a logarithmic scale for temperature and $E$-mode spectra and
 shows cosmic-variance and observational uncertainty bands. Titles now use
 minimal padding so each label fits neatly between CMB subplots.
 `model_parser.py` accepts unknown keys and simply copies them to the sanitized
-cache. This allows the domain-specific JSON language to evolve while remaining
+cache. This allows the domain-specific YAML language to evolve while remaining
 compatible with older models.
 `model_parser.py` validates this structure and `model_coder.py` translates the
 LaTeX expressions into NumPy-ready callables. When `Hz_expression` is present it is

--- a/copernican_lib/engine_interface.py
+++ b/copernican_lib/engine_interface.py
@@ -1,7 +1,7 @@
 """Interface to bridge generated model functions with existing engines."""
 
 # Engines expect models in a specific "plugin" format. This module provides
-# helper functions that take the parsed JSON representation of a model and
+# helper functions that take the parsed YAML representation of a model and
 # turn it into a simple object with the required attributes and callables.
 
 from types import SimpleNamespace

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -1,7 +1,7 @@
-"""Model coder that turns validated JSON into callable Python functions."""
+# """Model coder that turns validated YAML into callable Python functions."""
 
-# Every cosmological model is stored as JSON.  This module reads the sanitized
-# JSON and uses SymPy to translate mathematical expressions into efficient
+# Every cosmological model is stored as YAML.  This module reads the sanitized
+# YAML and uses SymPy to translate mathematical expressions into efficient
 # NumPy-friendly functions.
 
 import json
@@ -60,12 +60,12 @@ def generate_callables(cache_path):
     Parameters
     ----------
     cache_path : str or Path
-        Path to the sanitized model JSON produced by :func:`parse_model`.
+        Path to the sanitized model YAML produced by :func:`parse_model`.
 
     Returns
     -------
     tuple(dict, dict)
-        Dictionary of callables and the loaded JSON data.
+        Dictionary of callables and the loaded YAML data.
     """
     cache_path = Path(cache_path)
     with cache_path.open("r") as f:
@@ -77,7 +77,7 @@ def generate_callables(cache_path):
     param_syms = [sp.symbols(p['python_var']) for p in model_data['parameters']]
     local_dict = {p['python_var']: sym for p, sym in zip(model_data['parameters'], param_syms)}
     local_dict['z'] = z
-    # Allow JSON equations to reference the full 'sympy' prefix as well as shorthand
+    # Allow YAML equations to reference the full 'sympy' prefix as well as shorthand
     local_dict['sympy'] = sp
 
     funcs = {}
@@ -150,7 +150,7 @@ def generate_callables(cache_path):
 
                 funcs['get_DV_Mpc'] = _dv
                 code_dict['get_DV_Mpc'] = '((DC^2 * c*z/H)^1/3)'
-            logger.info("Derived distance functions from symbolic Hz_expression in model JSON.")
+            logger.info("Derived distance functions from symbolic Hz_expression in model YAML.")
 
             # --- Derive sound horizon at recombination (r_s) ---
             rs_expr_str = model_data.get('rs_expression')
@@ -177,7 +177,7 @@ def generate_callables(cache_path):
                     funcs['get_sound_horizon_rs_Mpc'] = lambda *p: float(rs_fn_sym(*p))
                     code_dict['get_sound_horizon_rs_Mpc'] = str(rs_sym)
                     model_data['valid_for_bao'] = True
-                    logger.info("Derived r_s from symbolic rs_expression in model JSON.")
+                    logger.info("Derived r_s from symbolic rs_expression in model YAML.")
                 except Exception as e:
                     error_handler.report_error(f"Failed to parse rs_expression: {e}")
                     raise ValueError(f"Failed to parse rs_expression: {e}") from e

--- a/copernican_lib/model_parser.py
+++ b/copernican_lib/model_parser.py
@@ -68,7 +68,7 @@ MODEL_SCHEMA = {
 
 
 def parse_model(path, cache_dir):
-    """Validate ``path`` and write cleaned JSON to ``cache_dir``.
+    """Validate ``path`` and write cleaned YAML to ``cache_dir``.
 
     Validation is performed only in the main process. Worker processes simply
     read the sanitized file produced during program startup.

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -5,9 +5,9 @@ The suite exposes a small API intended for advanced scripting. The
 
 - `model_parser.parse_model(path, cache_dir)` – validate and clean a
   `cosmo_model_*.yml` file.
-- `model_coder.generate_callables(clean_path)` – compile sanitized model JSON
+- `model_coder.generate_callables(clean_path)` – compile sanitized model YAML
   into Python callables.
-- `engine_interface.build_plugin(parsed_json, funcs)` – construct a plugin object
+- `engine_interface.build_plugin(parsed_data, funcs)` – construct a plugin object
   with attributes `MODEL_NAME`, `MODEL_DESCRIPTION`, `MODEL_ABSTRACT` and the
   distance and CMB functions required by engines.
   - `data_loaders.load_sne_data(name)`, `load_bao_data(name)`,

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -73,7 +73,12 @@ def chi_squared_sne(cosmo_params, mu_model_func, sne_data_df):
 
 
 def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
-    """Return chi-squared for BAO observables."""
+    """Return chi-squared for BAO observables.
+
+    The previous implementation iterated row by row which introduced a large
+    Python overhead when evaluating many data points. The calculation is now
+    fully vectorised so that distance functions operate on arrays directly.
+    """
     logger = logging.getLogger()
     engine_interface.validate_plugin(model_plugin)
     if getattr(model_plugin, "valid_for_bao", True) is False:
@@ -85,9 +90,6 @@ def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
     if not (np.isfinite(model_rs_Mpc) and model_rs_Mpc > 0):
         return np.inf
 
-    total = 0.0
-    n_valid = 0
-
     try:
         get_DM = getattr(model_plugin, "get_comoving_distance_Mpc")
         get_Hz = getattr(model_plugin, "get_Hz_per_Mpc")
@@ -97,52 +99,59 @@ def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
         logger.error(f"(chi2_bao): Model plugin missing required function: {e}")
         return np.inf
 
-    for _, row in bao_data_df.iterrows():
-        z_val = row["redshift"]
-        obs_type = row["observable_type"]
-        obs_val = row["value"]
-        obs_err = row["error"]
+    z = bao_data_df["redshift"].to_numpy(dtype=float)
+    obs_type = bao_data_df["observable_type"].to_numpy()
+    obs_val = bao_data_df["value"].to_numpy(dtype=float)
+    obs_err = bao_data_df["error"].to_numpy(dtype=float)
 
-        if obs_err == 0 or not np.isfinite(obs_err) or obs_err < 1e-9:
-            continue
-
-        mod_num = np.nan
-        try:
-            if obs_type == "DM_over_rs":
-                mod_num = get_DM(z_val, *cosmo_params)
-            elif obs_type == "DH_over_rs":
-                hz_val = get_Hz(z_val, *cosmo_params)
-                if np.isfinite(hz_val) and abs(hz_val) > 1e-9:
-                    mod_num = C_LIGHT / hz_val
-            elif obs_type == "DV_over_rs":
-                if get_DV:
-                    mod_num = get_DV(z_val, *cosmo_params)
-                else:
-                    dm_val = get_DM(z_val, *cosmo_params)
-                    hz_val = get_Hz(z_val, *cosmo_params)
-                    if (
-                        np.isfinite(dm_val)
-                        and dm_val >= 0
-                        and np.isfinite(hz_val)
-                        and abs(hz_val) > 1e-9
-                        and z_val > 1e-9
-                    ):
-                        term = (dm_val ** 2) * C_LIGHT * z_val / hz_val
-                        mod_num = term ** (1.0 / 3.0) if term >= 0 else np.nan
-                    elif abs(z_val) < 1e-9:
-                        mod_num = 0.0
-        except Exception:
-            continue
-
-        if np.isfinite(mod_num):
-            total += ((obs_val - mod_num / model_rs_Mpc) / obs_err) ** 2
-            n_valid += 1
-
-    if n_valid == 0:
+    valid = np.isfinite(obs_err) & (obs_err > 1e-9)
+    if not np.any(valid):
         logger.warning("(chi2_bao): No valid BAO points to calculate chi-squared.")
         return np.inf
 
-    return total if np.isfinite(total) else np.inf
+    z = z[valid]
+    obs_type = obs_type[valid]
+    obs_val = obs_val[valid]
+    obs_err = obs_err[valid]
+
+    pred = np.full_like(obs_val, np.nan, dtype=float)
+
+    idx = obs_type == "DM_over_rs"
+    if np.any(idx):
+        pred[idx] = get_DM(z[idx], *cosmo_params) / model_rs_Mpc
+
+    idx = obs_type == "DH_over_rs"
+    if np.any(idx):
+        hz = get_Hz(z[idx], *cosmo_params)
+        dh = np.where(np.isfinite(hz) & (np.abs(hz) > 1e-9), C_LIGHT / hz, np.nan)
+        pred[idx] = dh / model_rs_Mpc
+
+    idx = obs_type == "DV_over_rs"
+    if np.any(idx):
+        if get_DV:
+            dv = get_DV(z[idx], *cosmo_params)
+        else:
+            dm_val = get_DM(z[idx], *cosmo_params)
+            hz_val = get_Hz(z[idx], *cosmo_params)
+            term = dm_val ** 2 * C_LIGHT * z[idx] / hz_val
+            mask = (
+                np.isfinite(dm_val)
+                & (dm_val >= 0)
+                & np.isfinite(hz_val)
+                & (np.abs(hz_val) > 1e-9)
+                & (z[idx] > 1e-9)
+            )
+            dv = np.full_like(dm_val, np.nan, dtype=float)
+            dv[mask] = np.where(term[mask] >= 0, np.power(term[mask], 1.0 / 3.0), np.nan)
+            dv[np.abs(z[idx]) < 1e-9] = 0.0
+        pred[idx] = dv / model_rs_Mpc
+
+    if np.all(~np.isfinite(pred)):
+        logger.warning("(chi2_bao): Model returned no finite BAO predictions.")
+        return np.inf
+
+    chi2 = np.sum(((obs_val - pred) / obs_err) ** 2)
+    return chi2 if np.isfinite(chi2) else np.inf
 
 @lru_cache(maxsize=128)
 def _cached_cmb(key):

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,5 +1,5 @@
 """Namespace package for built-in cosmological models."""
 
-# The JSON files in this directory describe models using a domain specific
+# The YAML files in this directory describe models using a domain specific
 # language. No Python code lives here, but having an ``__init__`` allows the
 # folder to be imported as ``models`` if required.


### PR DESCRIPTION
## Summary
- optimize BAO chi-squared calculation using vectorised numpy operations
- clarify plugin documentation to reference YAML instead of JSON
- update README and API docs to reflect YAML-based model files
- tweak model_coder and engine_interface comments for YAML
- log changes for version 2.0.1 in the changelog

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6889ef5edd4c832f8d3da67ca1fb9117