### PR TITLE
Add unicode parameter display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Add one line for each substantive commit or pull request directly under the late
 ## Version 2.0.1
 - 2025-07-30: Vectorised BAO chi-squared and updated YAML documentation (AI assistant)
 
+## Version 2.0.2
+- 2025-07-30: Console output now renders parameter names with Unicode Greek letters and subscripts (AI assistant)
+
 
 ## Version 1.19.3
 - 2025-07-29: Fixed parsing of LaTeX names containing `\rm` and bumped version (AI assistant)

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ See `cosmo_model_template.yml` for a detailed template.
    omitted, a valid identifier is derived automatically from this LaTeX name.
 10. `latex_name` values do not require `$` delimiters. Plots automatically wrap
    parameter names in math mode.
+11. Console and log outputs display parameter names with Greek letters,
+    subscripts and superscripts when possible for easier reading.
 
 **Common mistakes**
 * Missing `*` between variables and parentheses results in a `'Symbol' object is not callable` error.

--- a/copernican.py
+++ b/copernican.py
@@ -50,7 +50,7 @@ data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
 # outdated. Automatic releases are not yet enabled.
-COPERNICAN_VERSION = "2.0.0"
+COPERNICAN_VERSION = "2.0.2"
 CURRENT_LOG_FILE = None
 
 
@@ -701,11 +701,17 @@ def main_workflow():
             f"{alt_model_plugin.MODEL_NAME} Abstract:\n{alt_model_plugin.MODEL_ABSTRACT}\n"
         )
 
-        def _print_fit(label, sne_res, bao_res, cmb_res):
+        def _print_fit(label, sne_res, bao_res, cmb_res, plugin):
             print(f"--- {label} Fit Report ---\n")
             if sne_res:
-                for name, val in sne_res.get("fitted_cosmological_params", {}).items():
-                    print(f"  {name} = {val:.5g}")
+                from copernican_lib import latex_utils
+                p_names = getattr(plugin, "PARAMETER_NAMES", [])
+                p_latex = getattr(plugin, "PARAMETER_LATEX_NAMES", [])
+                for name, latex_name in zip(p_names, p_latex):
+                    val = sne_res.get("fitted_cosmological_params", {}).get(name)
+                    if val is not None:
+                        disp = latex_utils.latex_to_unicode(latex_name)
+                        print(f"  {disp} = {val:.5g}")
             chi2_sne = sne_res.get("chi2_sne", sne_res.get("chi2_min", float("nan")))
             chi2_total = sne_res.get("chi2_total", float("nan"))
             print(f"  χ²_Total = {chi2_total:.2f}")
@@ -716,12 +722,13 @@ def main_workflow():
                 print(f"  χ²_CMB = {cmb_res.get('chi2_cmb', float('nan')):.2f}")
             print()
 
-        _print_fit("ΛCDM", lcdm_sne_fit_results, lcdm_full_results, lcdm_cmb)
+        _print_fit("ΛCDM", lcdm_sne_fit_results, lcdm_full_results, lcdm_cmb, lcdm)
         _print_fit(
             alt_model_plugin.MODEL_NAME,
             alt_model_sne_fit_results,
             alt_model_full_results,
             alt_cmb,
+            alt_model_plugin,
         )
 
         # The call to the redundant summary CSV has been removed.

--- a/copernican_lib/latex_utils.py
+++ b/copernican_lib/latex_utils.py
@@ -91,3 +91,142 @@ def wrap_math(text: str) -> str:
     cleaned = re.sub(r"\\rm\s*", "", cleaned)
     cleaned = re.sub(r"\s{2,}", " ", cleaned)
     return f"${cleaned}$" if cleaned else ""
+
+
+_UNICODE_SYMBOLS = {
+    r"\alpha": "α",
+    "alpha": "α",
+    r"\beta": "β",
+    "beta": "β",
+    r"\gamma": "γ",
+    "gamma": "γ",
+    r"\delta": "δ",
+    "delta": "δ",
+    r"\epsilon": "ε",
+    r"\zeta": "ζ",
+    r"\eta": "η",
+    r"\theta": "θ",
+    r"\iota": "ι",
+    r"\kappa": "κ",
+    r"\lambda": "λ",
+    r"\mu": "μ",
+    r"\nu": "ν",
+    r"\xi": "ξ",
+    r"\pi": "π",
+    r"\rho": "ρ",
+    r"\sigma": "σ",
+    r"\tau": "τ",
+    r"\upsilon": "υ",
+    r"\phi": "φ",
+    r"\varphi": "φ",
+    r"\chi": "χ",
+    r"\psi": "ψ",
+    r"\omega": "ω",
+    "omega": "ω",
+    r"\Gamma": "Γ",
+    "Gamma": "Γ",
+    r"\Delta": "Δ",
+    "Delta": "Δ",
+    r"\Theta": "Θ",
+    "Theta": "Θ",
+    r"\Lambda": "Λ",
+    "Lambda": "Λ",
+    r"\Xi": "Ξ",
+    "Xi": "Ξ",
+    r"\Pi": "Π",
+    "Pi": "Π",
+    r"\Sigma": "Σ",
+    "Sigma": "Σ",
+    r"\Phi": "Φ",
+    "Phi": "Φ",
+    r"\Psi": "Ψ",
+    "Psi": "Ψ",
+    r"\Omega": "Ω",
+    "Omega": "Ω",
+}
+
+_SUB_MAP = {
+    "0": "₀",
+    "1": "₁",
+    "2": "₂",
+    "3": "₃",
+    "4": "₄",
+    "5": "₅",
+    "6": "₆",
+    "7": "₇",
+    "8": "₈",
+    "9": "₉",
+    "+": "₊",
+    "-": "₋",
+    "=": "₌",
+    "(": "₍",
+    ")": "₎",
+    "a": "ₐ",
+    "e": "ₑ",
+    "h": "ₕ",
+    "i": "ᵢ",
+    "k": "ₖ",
+    "l": "ₗ",
+    "m": "ₘ",
+    "n": "ₙ",
+    "o": "ₒ",
+    "p": "ₚ",
+    "r": "ᵣ",
+    "s": "ₛ",
+    "t": "ₜ",
+    "u": "ᵤ",
+    "v": "ᵥ",
+    "x": "ₓ",
+    "β": "ᵦ",
+    "γ": "ᵧ",
+    "ρ": "ᵨ",
+    "φ": "ᵩ",
+    "χ": "ᵪ",
+}
+
+_SUP_MAP = {
+    "0": "⁰",
+    "1": "¹",
+    "2": "²",
+    "3": "³",
+    "4": "⁴",
+    "5": "⁵",
+    "6": "⁶",
+    "7": "⁷",
+    "8": "⁸",
+    "9": "⁹",
+    "+": "⁺",
+    "-": "⁻",
+    "=": "⁼",
+    "(": "⁽",
+    ")": "⁾",
+    "i": "ⁱ",
+    "n": "ⁿ",
+}
+
+
+def latex_to_unicode(text: str) -> str:
+    r"""Return ``text`` converted to basic Unicode math symbols."""
+    cleaned = re.sub(r"^\$+|\$+$", "", str(text).strip())
+    for pat, repl in _UNICODE_SYMBOLS.items():
+        cleaned = re.sub(re.escape(pat), repl, cleaned)
+
+    def _sub_repl(match: re.Match[str]) -> str:
+        inner = match.group(1)
+        inner = re.sub(r"\\rm\s*", "", inner)
+        inner = inner.replace(" ", "")
+        if inner in _UNICODE_SYMBOLS:
+            inner_char = _UNICODE_SYMBOLS[inner]
+            return _SUB_MAP.get(inner_char, inner_char)
+        return "".join(_SUB_MAP.get(ch, ch) for ch in inner)
+
+    def _sup_repl(match: re.Match[str]) -> str:
+        inner = match.group(1)
+        inner = inner.replace(" ", "")
+        return "".join(_SUP_MAP.get(ch, ch) for ch in inner)
+
+    cleaned = re.sub(r"_\{([^{}]+)\}", _sub_repl, cleaned)
+    cleaned = re.sub(r"\^\{([^{}]+)\}", _sup_repl, cleaned)
+    cleaned = re.sub(r"_([A-Za-z0-9])", lambda m: _SUB_MAP.get(m.group(1), m.group(1)), cleaned)
+    cleaned = re.sub(r"\^([A-Za-z0-9+-])", lambda m: _SUP_MAP.get(m.group(1), m.group(1)), cleaned)
+    return cleaned

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -20,3 +20,5 @@ package name emphasises that these modules are part of the suite's core
 library and not mere scripts.
 
 LaTeX translations rely on `copernican_lib/latex_utils.py` which reads symbol and function mappings from `latex_mappings.json`. New commands can be added there without touching the code.
+The helper also exposes `latex_to_unicode` for rendering parameter names with
+Greek letters and subscripts in console logs.

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -522,8 +522,11 @@ def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin)
             {n: final_params[num_cosmo_params + i] for i, n in enumerate(cmb_extra_names)} if cmb_extra_names else None,
         )
     logger.info(f"Combined fit results for {model_plugin.MODEL_NAME}:")
-    for name, val in zip(param_names, final_params):
-        logger.info(f"  - {name}: {val:.5g}")
+    param_latex = getattr(model_plugin, 'PARAMETER_LATEX_NAMES', [])
+    from copernican_lib import latex_utils
+    for name, latex_name, val in zip(param_names, param_latex, final_params):
+        disp = latex_utils.latex_to_unicode(latex_name)
+        logger.info(f"  - {disp}: {val:.5g}")
     logger.info(
         f"  - Chi2 Total: {chi2_tot:.4f} (SNe={chi2_sne:.4f}, BAO={chi2_bao:.4f}, CMB={chi2_cmb:.4f})"
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -122,6 +122,9 @@ class PlotterUtilTestCase(unittest.TestCase):
         self.assertEqual(
             latex_utils.latex_to_sympy(r"\frac{1}{\infty}"), "(1)/(sympy.oo)"
         )
+        self.assertEqual(latex_utils.latex_to_unicode(r"\Omega_{gamma}"), "Ωᵧ")
+        self.assertEqual(latex_utils.latex_to_unicode("H_0"), "H₀")
+        self.assertEqual(latex_utils.latex_to_unicode(r"z_{\rm rec}"), "zᵣₑc")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- render parameter names with unicode in logs and reports via latex_utils.latex_to_unicode
- use unicode names in engine logging and final reports
- document latex_to_unicode and log behaviour
- bump version to 2.0.2
- test unicode rendering

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_688a082ee8ac832f8fb4bd7de8b148e1