### PR TITLE
Update data docs for GW & siren parser stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Add one line for each substantive commit or pull request directly under the late
 ## Version 2.0.3
 - 2025-07-30: Removed Unicode escape sequences from model YAML files and converted abstracts and descriptions to block scalars (AI assistant)
 
+## Version 2.0.4
+- 2025-07-30: Documented stub GW and siren parsers returning None (AI assistant)
+
 
 ## Version 1.19.3
 - 2025-07-29: Fixed parsing of LaTeX names containing `\rm` and bumped version (AI assistant)

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -11,6 +11,7 @@ data/
   sirens/     - Standard siren events (placeholder)
 ```
 
+Note: The `gw` and `sirens` parsers are stubs that return `None`. Real data support is under development.
 Each subdirectory contains one or more dataset sources. A Python file named `cosmo_parser_*.py` lives inside each source folder and registers a parser function via decorators from `copernican_lib.data_loaders`.
 
 Every dataset folder also provides a `metadata_*.json` describing the source. The fields `dataset_name`, `description`, `citation`, optional `notes` and `authors_all` are loaded dynamically so no parser hard-codes them. Parsed DataFrames expose the same information on their `.attrs` property. The reference files remain read-only.


### PR DESCRIPTION
## Summary
- document that GW and siren parsers are only stubs
- mention real data support is under development
- record changelog entry

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_688a1af67fec832f82df943ed41a0881