### PR TITLE
Improve code comments and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,7 @@ To keep the project maintainable all contributors, human or AI, must follow thes
 6. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in any file.**
 7. **Use raw string literals for regular expressions, docstrings with LaTeX or backslashes, and Windows paths** to avoid Python's "invalid escape sequence" warnings.
 8. **Re-read the "Development laws and protocols for human and AI contributors" section in `README.md` at the start of every development session.** All contributors must implicitly follow those rules without explicit reminders.
+9. **Document every module, function and class with clear "what" and "why" explanations.** Comments and docstrings should describe not only the behaviour but also the rationale behind it.
 
 Failure to follow these guidelines will compromise the Copernican Suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 2.0.7
+- 2025-07-30: Expanded inline comments and documentation to clarify workflow logic (AI assistant)
+
 ## Version 2.0.6
 - 2025-07-30: Expanded comments across the codebase and added a session-start reminder in AGENTS (AI assistant)
 - 2025-07-30: Added RNG seeding, improved SNe chi-squared validation and expanded tests (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 2.0.6
+**Version:** 2.0.7
 **Last Updated:** 2025-07-30
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.

--- a/copernican.py
+++ b/copernican.py
@@ -34,7 +34,10 @@ if sys.version_info < MIN_PYTHON:
     )
     exit_clean(1)
 
-# Delay heavy third-party imports until after the dependency check
+# Delay heavy third-party imports until after the dependency check.
+# Doing so keeps startup quick and lets ``check_dependencies`` provide a
+# clean error message before the interpreter tries to import missing
+# modules.
 np = None
 plt = None
 mp = None
@@ -50,7 +53,7 @@ data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
 # outdated. Automatic releases are not yet enabled.
-COPERNICAN_VERSION = "2.0.6"
+COPERNICAN_VERSION = "2.0.7"
 CURRENT_LOG_FILE = None
 
 
@@ -151,6 +154,10 @@ def show_splash_screen():
 
 def _gather_required_packages():
     """Return external packages imported across project modules."""
+    # Rather than rely on ``pip freeze`` or manual lists this function
+    # walks through the source tree and parses each ``import`` statement
+    # with :mod:`ast`.  This keeps the dependency check accurate even
+    # when new optional modules are added.
     pkg_names = set()
     search_dirs = ["copernican_lib", "engines", "tests", "."]
     ignore_dirs = {
@@ -225,6 +232,10 @@ def _gather_required_packages():
 
 def _print_install_instructions(missing: list[str]) -> None:
     """Show platform-specific commands to install missing packages."""
+    # The messages here intentionally rely on plain ``pip`` so users on
+    # any platform can copy & paste them directly.  Additional hints for
+    # Homebrew, APT or pipx are printed when those tools are available
+    # to guide less experienced users.
     pkgs = " ".join(sorted(set(missing)))
     pip_cmd = f"{Path(sys.executable).name} -m pip install {pkgs}"
     print("Please install them with:")
@@ -345,6 +356,9 @@ def select_from_list(options, prompt):
 
 def parse_model_header(md_path):
     """Read minimal YAML front matter for plugin lookup."""
+    # Only the YAML block at the start of the Markdown file is needed in
+    # order to locate the generated Python module.  This keeps startup
+    # snappy and avoids parsing the entire document.
     data = {}
     try:
         with open(md_path, "r") as f:

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -13,11 +13,15 @@ import logging
 import importlib
 
 # --- Parser Registry ---
-SNE_PARSERS = {}
-BAO_PARSERS = {}
-CMB_PARSERS = {}
-GW_PARSERS = {}
-SIREN_PARSERS = {}
+# Each registry maps a short human readable key to a dictionary
+# describing the parser function, its help text and an optional data
+# directory.  Parser modules populate these registries via the
+# decorators below when they are imported.
+SNE_PARSERS: dict = {}
+BAO_PARSERS: dict = {}
+CMB_PARSERS: dict = {}
+GW_PARSERS: dict = {}
+SIREN_PARSERS: dict = {}
 
 
 # --- Decorators to register parsers ---
@@ -79,6 +83,9 @@ def register_siren_parser(name, description="", data_dir=None):
 # --- Dynamic Discovery of Parser Modules ---
 def _discover_parsers():
     """Imports parser modules stored within ``data/<type>/<source>`` directories."""
+    # Parser modules register themselves in the dictionaries above when
+    # imported.  Automatically scanning the data directory keeps the core
+    # code agnostic to the exact set of available sources.
     base_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data')
     for dtype in ('sne', 'bao', 'cmb', 'gw', 'sirens'):
         type_dir = os.path.join(base_dir, dtype)
@@ -99,7 +106,9 @@ def _discover_parsers():
                     except Exception as e:
                         logging.getLogger().error(f"Failed loading parser module {file_path}: {e}")
 
-# Discover parsers at import time
+# Discover parsers at import time so that functions like
+# ``load_sne_data`` can simply refer to the registries without
+# additional setup.
 _discover_parsers()
 
 # --- Helper to list and select parsers ---
@@ -133,6 +142,10 @@ def _select_source(parser_registry, data_type_name):
 # --- Verbose dataset info helper ---
 def _log_dataset_info(df, data_type, logger):
     """Log summary and covariance usage for ``df``."""
+    # Centralised helper so that every loader reports consistent
+    # information about the dataset and whether a covariance matrix was
+    # actually used.  The attributes are attached by the individual
+    # parser modules.
     if df is None or df.empty:
         return
     name = df.attrs.get("dataset_long_name", df.attrs.get("dataset_name_attr", ""))


### PR DESCRIPTION
## Summary
- add requirement in AGENTS to document modules with what/why explanations
- enrich data loader comments and clarify auto-discovery
- expand startup comments and dependency scanner documentation
- bump version to 2.0.7 and log changes

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_688a5d8990c8832f8b7f1a909e547394