### PR TITLE
Remove JSON dataset support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.0.0
+- 2025-07-30: Dropped all remaining JSON dataset support and expanded documentation (AI assistant)
+
 ## Version 2.1.0
 - 2025-07-30: Switched cached models and LaTeX mappings to YAML and removed JSON usage across the codebase (AI assistant)
 - 2025-07-30: Converted all dataset metadata and the BAO test dataset to YAML (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 2.1.0
+**Version:** 3.0.0
 **Last Updated:** 2025-07-30
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -16,13 +16,14 @@ Additional design notes can be found under the `docs/` directory.
 4. [Design Overview](docs/design_overview.md)
 5. [Data Directory Overview](docs/data_overview.md)
 6. [BAO Test Dataset Format](docs/bao_test_dataset_format.md)
-7. [Using the Suite](#using-the-suite)
-8. [Creating New Models](#creating-new-models)
-9. [Developer Guide](#developer-guide)
-10. [AI-driven and human development laws and protocols](#6-ai-driven-and-human-development-laws-and-protocols)
-11. [License](#license)
-12. [Versioning Policy](#versioning-policy)
-13. [API Overview](docs/api_overview.md)
+7. [Dataset Metadata Fields](docs/dataset_metadata.md)
+8. [Using the Suite](#using-the-suite)
+9. [Creating New Models](#creating-new-models)
+10. [Developer Guide](#developer-guide)
+11. [AI-driven and human development laws and protocols](#6-ai-driven-and-human-development-laws-and-protocols)
+12. [License](#license)
+13. [Versioning Policy](#versioning-policy)
+14. [API Overview](docs/api_overview.md)
 
 ---
 
@@ -142,6 +143,8 @@ copernican_lib/          - Helper modules
   utils.py          - Common helpers
   optim_utils.py    - Shared optimisation wrappers used by engines
 ```
+All dataset tables and metadata are provided **only** as YAML files. JSON
+input is no longer supported as of version 3.0.0.
 **Note:** Files in `data/` are treated as read-only reference datasets and
 should not be modified by AI-driven code changes.
 

--- a/copernican.py
+++ b/copernican.py
@@ -52,8 +52,9 @@ logger = None
 data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
-# outdated. Automatic releases are not yet enabled.
-COPERNICAN_VERSION = "2.1.0"
+# outdated. Automatic releases are not yet enabled. Version 3.0.0 drops all
+# legacy JSON dataset support in favour of YAML-only inputs.
+COPERNICAN_VERSION = "3.0.0"
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/utils.py
+++ b/copernican_lib/utils.py
@@ -1,5 +1,11 @@
 # utils.py
-"""Common utility functions for the Copernican Suite."""
+"""Common utility functions for the Copernican Suite.
+
+This module centralises a handful of small helpers used across the project
+so that engines and parsers remain lightweight.  All dataset metadata and
+tables are now provided in YAML format only; any legacy JSON handling has
+been removed.
+"""
 # These helpers are intentionally tiny but keep repetitive tasks such as
 # timestamp generation and directory creation in one place.
 
@@ -34,11 +40,12 @@ def generate_filename(file_type, dataset_name, ext, model_name="", timestamp=Non
     """
     sanitized_type = file_type.replace('_', '-').lower()
     sanitized_model = model_name.replace('_', '-').replace('.', '')
+    # Remove whitespace, file extensions and unsafe path characters so the
+    # resulting filename is portable across platforms.
     sanitized_dataset = (
         dataset_name.replace('_', '-')
         .replace(' ', '')
         .replace('/', '-')
-        .replace('.json', '')
         .replace('.yml', '')
         .replace('.yaml', '')
         .replace('.dat', '')
@@ -58,13 +65,18 @@ def ensure_dir_exists(directory):
 
 
 def load_metadata_from_dir(data_dir: str) -> dict:
-    """Return dataset metadata from ``data_dir`` if available."""
+    """Return dataset metadata from ``data_dir`` if available.
+
+    The loader looks for a file starting with ``metadata`` and ending in
+    ``.yml`` or ``.yaml``. JSON files were supported in earlier versions but
+    have been removed to keep the format consistent across the project.
+    """
     try:
         meta_files = [
             f
             for f in os.listdir(data_dir)
             if f.startswith("metadata")
-            and f.lower().endswith((".json", ".yml", ".yaml"))
+            and f.lower().endswith((".yml", ".yaml"))
         ]
         if meta_files:
             with open(os.path.join(data_dir, sorted(meta_files)[0]), "r") as fh:
@@ -75,6 +87,10 @@ def load_metadata_from_dir(data_dir: str) -> dict:
 
 
 def set_random_seed(seed: int = 0) -> None:
-    """Seed NumPy's global RNG and log the selected value."""
+    """Seed NumPy's global RNG and log the selected value.
+
+    Engines call this helper so that optimisation results can be
+    reproduced exactly when the same seed is provided.
+    """
     np.random.seed(seed)
     logging.getLogger().info("Global RNG seed set to %s", seed)

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -1,7 +1,9 @@
 # Copernican Suite API Overview
 
-The suite exposes a small API intended for advanced scripting. The
-`copernican_lib` package contains the following key modules:
+The suite exposes a lightweight API intended for advanced scripting.
+Most functionality lives in the ``copernican_lib`` package which can be
+imported directly without using the command-line interface.  The core
+modules are:
 
 - `model_parser.parse_model(path, cache_dir)` – validate and clean a
   `cosmo_model_*.yml` file.
@@ -14,20 +16,28 @@ The suite exposes a small API intended for advanced scripting. The
     `load_cmb_data(name)` – load datasets by their registered names. Each loader
     logs a short summary describing the dataset and whether its covariance matrix
     was used or diagonal errors were applied.
-- `engines.cosmo_engine_comb` – reference engine providing
-  `fit_sne_parameters`, `fit_combined_parameters`, `calculate_bao_observables`
-  and `chi_squared_*` helpers.
+- `engines.cosmo_engine_comb` – reference engine providing high level
+  optimisation routines such as ``fit_sne_parameters``,
+  ``fit_combined_parameters``, ``calculate_bao_observables`` and generic
+  ``chi_squared_*`` helpers.  Engines are regular Python modules that
+  operate purely on data frames and plugin callables so alternative
+  backends can be developed without modifying the rest of the codebase.
 
-Plugins are validated through `engine_interface.validate_plugin` before use.
-Engines expect the attributes listed in `engine_interface.REQUIRED_ATTRIBUTES`.
+Plugins are validated through ``engine_interface.validate_plugin`` before
+use. Engines expect the attributes listed in
+``engine_interface.REQUIRED_ATTRIBUTES``.  The resulting object exposes
+distance functions, CMB helpers and initial parameter guesses derived
+from the model YAML.
 
 ## Standardised Dataset Format
 
-All data parsers return a `pandas.DataFrame` with common columns and
-metadata so that the engines remain agnostic to the origin of the data.
-For supernovae datasets the table contains at minimum `Name`, `zcmb`,
-`mu_obs` and `e_mu_obs`.  Attributes such as `covariance_matrix_inv`,
-`diag_errors_for_plot` and `dataset_name_attr` are attached via the
-``DataFrame.attrs`` dictionary.  BAO and CMB loaders follow the same
-pattern.  New datasets can therefore be added simply by placing them
-under ``data/<type>/<source>/`` and providing a compatible parser.
+All data parsers return a ``pandas.DataFrame`` with common columns and
+metadata so that engines remain agnostic to the origin of the data.
+Metadata is read from ``metadata_*.yml`` files located next to the
+dataset tables and attached via the ``DataFrame.attrs`` dictionary.  For
+supernovae datasets the table contains at minimum ``Name``, ``zcmb``,
+``mu_obs`` and ``e_mu_obs``. Attributes such as ``covariance_matrix_inv``
+and ``diag_errors_for_plot`` are also attached. BAO and CMB loaders
+follow the same pattern. New datasets can therefore be added simply by
+placing them under ``data/<type>/<source>/`` and providing a compatible
+YAML parser.

--- a/docs/bao_test_dataset_format.md
+++ b/docs/bao_test_dataset_format.md
@@ -3,6 +3,8 @@
 This document describes the YAML format used for the **test** BAO dataset
 shipped with the Copernican Suite. The folder is located under
 `data/bao/test/` and mirrors the structure expected for real BAO sources.
+JSON files were supported in early versions but have now been removed so
+that all datasets use a single YAML representation.
 
 Each dataset is stored in its own directory and contains a single YAML file
 with a `data_points` array. The parser also looks for an optional

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -14,7 +14,12 @@ data/
 Note: The `gw` and `sirens` parsers are stubs that return `None`. Real data support is under development.
 Each subdirectory contains one or more dataset sources. A Python file named `cosmo_parser_*.py` lives inside each source folder and registers a parser function via decorators from `copernican_lib.data_loaders`.
 
-Every dataset folder also provides a `metadata_*.yml` describing the source. The fields `dataset_name`, `description`, `citation`, optional `notes` and `authors_all` are loaded dynamically so no parser hard-codes them. Parsed DataFrames expose the same information on their `.attrs` property. The reference files remain read-only.
+Every dataset folder also provides a `metadata_*.yml` describing the
+source. The fields `dataset_name`, `description`, `citation`, optional
+`notes` and `authors_all` are loaded dynamically so no parser hard-codes
+them. Parsed DataFrames expose the same information on their `.attrs`
+property. See `dataset_metadata.md` for a full description of these
+fields. The reference files remain read-only.
 
 ## Supernovae Datasets
 

--- a/docs/dataset_metadata.md
+++ b/docs/dataset_metadata.md
@@ -1,0 +1,17 @@
+# Dataset Metadata Fields
+
+Each dataset folder contains a `metadata_*.yml` file that describes the
+source. All fields are optional except for `dataset_name` and
+`description`.
+
+- `dataset_name` -- Short human-readable identifier used in logs and plot
+  footers.
+- `description` -- Brief explanation of the dataset origin.
+- `citation` -- Reference string cited in plots and CSV headers.
+- `notes` -- Additional free-form comments.
+- `authors_all` -- List of authors for provenance tracking.
+
+The metadata file is loaded automatically by
+`copernican_lib.utils.load_metadata_from_dir` and attached to the parsed
+`DataFrame` through the ``.attrs`` dictionary. Custom fields are preserved
+and can be used by new engines or analysis scripts.

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -14,6 +14,10 @@ focused on numerical work.
 /tests/            - Unit and functional tests
 ```
 
+All observational data and accompanying metadata are stored exclusively
+as YAML files.  Legacy JSON support was removed in version 3.0.0 so that
+all parsers operate on a single consistent format.
+
 `copernican.py` is the command-line entry point that orchestrates model
 selection, data loading, optimisation and result generation.  The new
 package name emphasises that these modules are part of the suite's core


### PR DESCRIPTION
## Summary
- drop all legacy JSON dataset handling in utilities
- bump version to 3.0.0
- document YAML-only datasets throughout docs
- expand API overview and design notes
- add dataset metadata documentation

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_688a8532b124832fa4a1c0d563af9409