### PR TITLE
Fix CAMB param map exponent in USMFv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.0.1
+- 2025-07-31: Fixed CAMB parameter map exponent syntax in cosmo_model_usmf2.yml to prevent runtime errors (AI assistant)
+
 ## Version 3.0.0
 - 2025-07-30: Dropped all remaining JSON dataset support and expanded documentation (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.0.0
-**Last Updated:** 2025-07-30
+**Version:** 3.0.1
+**Last Updated:** 2025-07-31
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.

--- a/copernican.py
+++ b/copernican.py
@@ -52,9 +52,10 @@ logger = None
 data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
-# outdated. Automatic releases are not yet enabled. Version 3.0.0 drops all
+# outdated. Automatic releases are not yet enabled. Version 3.0.1 fixes
+# incorrect exponent syntax in the USMFv2 model YAML and drops all
 # legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.0.0"
+COPERNICAN_VERSION = "3.0.1"
 CURRENT_LOG_FILE = None
 
 

--- a/models/cosmo_model_usmf2.yml
+++ b/models/cosmo_model_usmf2.yml
@@ -127,9 +127,9 @@ valid_for_cmb: true
 cmb:
   param_map:
     H0: H_A
-    ombh2: \Omega_b*(H_A/100)^2
+    ombh2: \Omega_b*(H_A/100)**2
     omch2: 0.0
-    omnuh2: \Omega_{\gamma}*(H_A/100)^2
+    omnuh2: \Omega_{\gamma}*(H_A/100)**2
     tau: 0.054
     As: 2.1e-09
     ns: 0.965


### PR DESCRIPTION
## Summary
- correct exponent syntax in cosmo_model_usmf2.yml
- bump Copernican version to 3.0.1
- update README and CHANGELOG

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_688a8d40e900832fa178f8eb0f65afa1