### PR TITLE
Add universal constants dictionary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ AGENTS.md         - Development specification and contributor rules
 CHANGELOG.md      - Release history
 copernican_lib/optim_utils.py - Shared optimisation helpers used by engines
 copernican_lib/latex_utils.py - LaTeX translation helpers using latex_mappings.yml
+copernican_lib/common_parameters.yml - Universal constants shared across models
 ```
 Installing the suite with `pip` produces a `copernican_suite.egg-info` directory
 containing build metadata. This folder can be safely removed and should not be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Add one line for each substantive commit or pull request directly under the late
 
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
+## Version 3.2.0
+- 2025-07-30: Added common_parameters.yml for standard constants and updated documentation (AI assistant)
+
 
 ## Version 3.1.0
 - 2025-07-30: Replaced `^` with `**` for exponentiation across all model YAML files and documented LaTeX syntax (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.1.0
-**Last Updated:** 2025-07-31
+**Version:** 3.2.0
+**Last Updated:** 2025-07-30
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.
@@ -143,6 +143,8 @@ copernican_lib/          - Helper modules
   data_loaders.py   - Data loading utilities
   utils.py          - Common helpers
   optim_utils.py    - Shared optimisation wrappers used by engines
+  latex_utils.py    - LaTeX helpers using latex_mappings.yml
+  common_parameters.yml - Universal constants shared across models
 ```
 All dataset tables and metadata are provided **only** as YAML files. JSON
 input is no longer supported as of version 3.0.0.
@@ -224,7 +226,8 @@ macros that adjust bracket size like `\left`, `\right`, `\bigl` and `\bigr`.
 Thin spaces (`\,`) and font switches (`\rm`) are ignored. Unsupported sizing
 macros are removed from plot labels to keep Matplotlib's MathText parser happy.
 All sanitisation rules now live in `copernican_lib/latex_utils.py` with
-extensible mappings stored in `latex_mappings.yml`. Expressions may also
+extensible mappings stored in `latex_mappings.yml`. Standard constants are
+available from `common_parameters.yml` in the same directory. Expressions may also
 contain `Integral` constructs with explicit limits which are numerically
 evaluated with SciPy. Use `\infty` for an infinite upper bound and avoid
 referencing `H(z)` inside other expressions—repeat the formula instead.

--- a/copernican.py
+++ b/copernican.py
@@ -52,10 +52,10 @@ logger = None
 data_loaders = None
 
 # Use a fixed version string to avoid confusion when the package metadata is
-# outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
-# unified exponent syntax across model YAML files and drops all
-# legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.1.0"
+# outdated. Automatic releases are not yet enabled. Version 3.2.0 introduces a
+# shared dictionary of common parameters and continues to drop legacy JSON
+# dataset support in favour of YAML-only inputs.
+COPERNICAN_VERSION = "3.2.0"
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/common_parameters.py
+++ b/copernican_lib/common_parameters.py
@@ -1,0 +1,37 @@
+"""Shared mathematical and physical constants for Copernican models."""
+
+from __future__ import annotations
+
+import yaml
+from pathlib import Path
+from typing import List, Dict, Any
+
+import sympy as sp
+from sympy.parsing.sympy_parser import (
+    parse_expr,
+    standard_transformations,
+    implicit_multiplication_application,
+)
+
+from . import latex_utils
+
+_PATH = Path(__file__).with_name("common_parameters.yml")
+try:
+    with _PATH.open("r") as _fh:
+        _DATA: Dict[str, Any] = yaml.safe_load(_fh)
+except OSError as exc:  # pragma: no cover - repo corruption
+    raise RuntimeError(f"Cannot read common parameters: {_PATH}") from exc
+
+PARAMETERS: List[Dict[str, Any]] = _DATA.get("parameters", [])
+
+_TRANSFORMS = standard_transformations + (implicit_multiplication_application,)
+for param in PARAMETERS:
+    val = param.get("value")
+    if isinstance(val, str):
+        try:
+            sym = latex_utils.latex_to_sympy(val)
+            param["value"] = float(parse_expr(sym, transformations=_TRANSFORMS))
+        except Exception:  # pragma: no cover - should rarely fail
+            pass
+
+__all__ = ["PARAMETERS"]

--- a/copernican_lib/common_parameters.yml
+++ b/copernican_lib/common_parameters.yml
@@ -1,0 +1,46 @@
+parameters:
+  - name: Pi
+    definition: Ratio of circle circumference to diameter
+    value: 3.141592653589793
+    unit: ''
+    latex_name: \pi
+  - name: Euler's number
+    definition: Base of natural logarithms
+    value: 2.718281828459045
+    unit: ''
+    latex_name: e
+  - name: Imaginary unit
+    definition: Square root of -1
+    value: null
+    unit: ''
+    latex_name: i
+  - name: Golden ratio
+    definition: (1+\sqrt{5})/2
+    value: (1+\sqrt{5})/2
+    unit: ''
+    latex_name: \phi
+  - name: Speed of light
+    definition: Speed of light in vacuum
+    value: 299792458
+    unit: m/s
+    latex_name: c
+  - name: Planck constant
+    definition: Quantum of action
+    value: 6.62607015e-34
+    unit: J*s
+    latex_name: h
+  - name: Reduced Planck constant
+    definition: h / (2\pi)
+    value: 1.054571817e-34
+    unit: J*s
+    latex_name: \hbar
+  - name: Gravitational constant
+    definition: Newtonian constant of gravitation
+    value: 6.67430e-11
+    unit: m^3/(kg*s^2)
+    latex_name: G
+  - name: Boltzmann constant
+    definition: Relation between energy and temperature
+    value: 1.380649e-23
+    unit: J/K
+    latex_name: k_B

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -23,6 +23,6 @@ selection, data loading, optimisation and result generation.  The new
 package name emphasises that these modules are part of the suite's core
 library and not mere scripts.
 
-LaTeX translations rely on `copernican_lib/latex_utils.py` which reads symbol and function mappings from `latex_mappings.yml`. New commands can be added there without touching the code.
+LaTeX translations rely on `copernican_lib/latex_utils.py` which reads symbol and function mappings from `latex_mappings.yml`. New commands can be added there without touching the code. Standard constants live in `common_parameters.yml` next to this mapping file.
 The helper also exposes `latex_to_unicode` for rendering parameter names with
 Greek letters and subscripts in console logs.

--- a/docs/latex_syntax.md
+++ b/docs/latex_syntax.md
@@ -26,3 +26,4 @@ The parser strips common spacing and sizing commands (`\left`, `\right`, `\!`, `
 - `unicode_symbols` – conversions used by `latex_to_unicode` for log output.
 
 All Greek letters—upper and lower case—and variants such as `\varphi` are included in these tables in alphabetical order.
+Standard constants like `c` and `\hbar` can be loaded from `common_parameters.yml`.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -143,6 +143,15 @@ class PlotterUtilTestCase(unittest.TestCase):
         self.assertEqual(latex_utils.latex_to_unicode("H_0"), "H₀")
         self.assertEqual(latex_utils.latex_to_unicode(r"z_{\rm rec}"), "zᵣₑc")
 
+    def test_common_parameter_phi_value(self):
+        """Verify golden ratio is computed from its expression."""
+        from copernican_lib import common_parameters
+
+        phi_param = next(
+            p for p in common_parameters.PARAMETERS if p.get("latex_name") == r"\phi"
+        )
+        self.assertAlmostEqual(phi_param["value"], (1 + 5 ** 0.5) / 2, places=12)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- create `common_parameters.yml` containing shared physical constants
- load constants via new `common_parameters` module
- document new file in AGENTS, README and docs
- bump version to 3.2.0 and note change in CHANGELOG
- test loading of phi constant

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_688a9a46639c832faba72214855d2e27