### PR TITLE
Implement dynamic universal constants and SI units

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@ copernican_lib/optim_utils.py - Shared optimisation helpers used by engines
 copernican_lib/latex_utils.py - LaTeX translation helpers using latex_mappings.yml
 copernican_lib/common_parameters.yml - Universal constants shared across models
 ```
+Model equations may reference any constant defined in `common_parameters.yml`
+without declaring it as a parameter. If a parameter shares the same LaTeX name,
+the model-provided value overrides the dictionary entry. All numerical values
+must use base SI units (m, s, K, kg, mol, cd, A). Avoid prefixes such as km or
+Gpc when specifying bounds or constants.
 Installing the suite with `pip` produces a `copernican_suite.egg-info` directory
 containing build metadata. This folder can be safely removed and should not be
 edited manually.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Add one line for each substantive commit or pull request directly under the late
 
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
+## Version 3.3.0
+- 2025-07-31: Added automatic constant injection and standardized SI units; updated docs and models (AI assistant)
+
 ## Version 3.2.0
 - 2025-07-30: Added common_parameters.yml for standard constants and updated documentation (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.2.0
-**Last Updated:** 2025-07-30
+**Version:** 3.3.0
+**Last Updated:** 2025-07-31
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.
@@ -148,6 +148,11 @@ copernican_lib/          - Helper modules
 ```
 All dataset tables and metadata are provided **only** as YAML files. JSON
 input is no longer supported as of version 3.0.0.
+All physical quantities are expressed using base SI units (m, s, K, kg, mol,
+cd, A). Constants like the speed of light therefore appear in metres per
+second and the Boltzmann constant is stored in eV/K. Model YAML files must use
+the same convention; prefixes such as km or Gpc are no longer used in parameter
+definitions.
 **Note:** Files in `data/` are treated as read-only reference datasets and
 should not be modified by AI-driven code changes.
 
@@ -227,7 +232,9 @@ Thin spaces (`\,`) and font switches (`\rm`) are ignored. Unsupported sizing
 macros are removed from plot labels to keep Matplotlib's MathText parser happy.
 All sanitisation rules now live in `copernican_lib/latex_utils.py` with
 extensible mappings stored in `latex_mappings.yml`. Standard constants are
-available from `common_parameters.yml` in the same directory. Expressions may also
+loaded automatically from `common_parameters.yml` and may be used in model
+equations without defining them as parameters. If a model declares a parameter
+with the same LaTeX name, that value overrides the dictionary entry. Expressions may also
 contain `Integral` constructs with explicit limits which are numerically
 evaluated with SciPy. Use `\infty` for an infinite upper bound and avoid
 referencing `H(z)` inside other expressions—repeat the formula instead.

--- a/copernican_lib/common_parameters.yml
+++ b/copernican_lib/common_parameters.yml
@@ -41,6 +41,6 @@ parameters:
     latex_name: G
   - name: Boltzmann constant
     definition: Relation between energy and temperature
-    value: 1.380649e-23
-    unit: J/K
+    value: 8.617333262e-05
+    unit: eV/K
     latex_name: k_B

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -19,6 +19,7 @@ from sympy.printing.numpy import NumPyPrinter
 from . import error_handler
 from . import engine_interface
 from . import latex_utils
+from . import common_parameters
 
 
 class QuadPrinter(NumPyPrinter):
@@ -42,6 +43,10 @@ def _latex_to_sympy_str(expr: str) -> str:
 
 def _compile_sympy_expr(sym_expr, args):
     """Compile a SymPy expression into a callable handling ``Integral`` nodes."""
+    # ``sym_expr`` may be a plain number if the equation consists only of a
+    # constant. In that case return a trivial lambda.
+    if not hasattr(sym_expr, "atoms"):
+        return lambda *args: float(sym_expr)
     # SymPy can convert expressions directly to Python functions, but it does
     # not evaluate ``Integral`` objects by default. When an integral is present
     # we expand it into a call to ``scipy.integrate.quad`` so the resulting
@@ -76,6 +81,14 @@ def generate_callables(cache_path):
     z = sp.symbols('z')
     param_syms = [sp.symbols(p['python_var']) for p in model_data['parameters']]
     local_dict = {p['python_var']: sym for p, sym in zip(model_data['parameters'], param_syms)}
+    param_names = set(local_dict)
+    # Populate the namespace with universal constants unless overridden by parameters
+    constants = {
+        latex_utils.sanitize_name(p['latex_name']): p['value']
+        for p in common_parameters.PARAMETERS
+        if latex_utils.sanitize_name(p['latex_name']) not in param_names
+    }
+    local_dict.update(constants)
     local_dict['z'] = z
     # Allow YAML equations to reference the full 'sympy' prefix as well as shorthand
     local_dict['sympy'] = sp
@@ -93,9 +106,13 @@ def generate_callables(cache_path):
                 transformations=standard_transformations
                 + (implicit_multiplication_application,),
             )
-            used_syms = {str(s) for s in hz_sym.free_symbols if s != z}
+            used_syms = {str(s) for s in getattr(hz_sym, "free_symbols", set()) if s != z}
             param_names = {p['python_var'] for p in model_data['parameters']}
-            missing = used_syms - param_names
+            constant_names = {
+                latex_utils.sanitize_name(p['latex_name'])
+                for p in common_parameters.PARAMETERS
+            }
+            missing = used_syms - param_names - constant_names
             if missing:
                 raise ValueError(
                     "Parameter '" + "', '".join(missing) + "' used in Hz_expression is not defined in model parameters."
@@ -109,7 +126,7 @@ def generate_callables(cache_path):
 
             def _dm(z_val, *params):
                 """Comoving distance integral valid for scalars or arrays."""
-                integrand = lambda zp: 299792.458 / hz_fn(zp, *params)
+                integrand = lambda zp: 299792458 / hz_fn(zp, *params)
                 if np.isscalar(z_val):
                     # ``quad`` expects scalar limits; cast to float explicitly.
                     return quad(integrand, 0, float(z_val), limit=100)[0]
@@ -135,7 +152,7 @@ def generate_callables(cache_path):
                     dm_val = _dm(z_val, *params)
                     hz_val = hz_fn(z_val, *params)
 
-                    term = dm_val ** 2 * 299792.458 * z_val / hz_val
+                    term = dm_val ** 2 * 299792458 * z_val / hz_val
 
                     if np.isscalar(z_val):
                         if z_val > 0 and hz_val != 0:
@@ -166,8 +183,12 @@ def generate_callables(cache_path):
                         transformations=standard_transformations
                         + (implicit_multiplication_application,),
                     )
-                    used = {str(s) for s in rs_sym.free_symbols} - {'z'}
-                    missing_rs = used - param_names
+                    used = {str(s) for s in getattr(rs_sym, "free_symbols", set())} - {'z'}
+                    constant_names = {
+                        latex_utils.sanitize_name(p['latex_name'])
+                        for p in common_parameters.PARAMETERS
+                    }
+                    missing_rs = used - param_names - constant_names
                     if missing_rs:
                         raise ValueError(
                             "Parameter '" + "', '".join(missing_rs) + "' used in rs_expression is not defined in model parameters."
@@ -199,7 +220,7 @@ def generate_callables(cache_path):
                     zrec = params[zr_i]
 
                     def sound_speed(zv):
-                        return 299792.458 / np.sqrt(3 * (1 + 3 * Ob_val / (4 * Og_val) / (1 + zv)))
+                        return 299792458 / np.sqrt(3 * (1 + 3 * Ob_val / (4 * Og_val) / (1 + zv)))
 
                     h0_val = hz_fn(0.0, *params)
 

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -23,6 +23,6 @@ selection, data loading, optimisation and result generation.  The new
 package name emphasises that these modules are part of the suite's core
 library and not mere scripts.
 
-LaTeX translations rely on `copernican_lib/latex_utils.py` which reads symbol and function mappings from `latex_mappings.yml`. New commands can be added there without touching the code. Standard constants live in `common_parameters.yml` next to this mapping file.
+LaTeX translations rely on `copernican_lib/latex_utils.py` which reads symbol and function mappings from `latex_mappings.yml`. New commands can be added there without touching the code. Standard constants are loaded automatically from `common_parameters.yml` and may be referenced in model expressions without being redeclared unless overridden by a parameter definition.
 The helper also exposes `latex_to_unicode` for rendering parameter names with
 Greek letters and subscripts in console logs.

--- a/docs/latex_syntax.md
+++ b/docs/latex_syntax.md
@@ -26,4 +26,4 @@ The parser strips common spacing and sizing commands (`\left`, `\right`, `\!`, `
 - `unicode_symbols` – conversions used by `latex_to_unicode` for log output.
 
 All Greek letters—upper and lower case—and variants such as `\varphi` are included in these tables in alphabetical order.
-Standard constants like `c` and `\hbar` can be loaded from `common_parameters.yml`.
+Standard constants like `c` and `\hbar` are loaded automatically from `common_parameters.yml`. They may be referenced in expressions without declaring them as parameters unless the model defines its own value.

--- a/models/cosmo_model_cfsc.yml
+++ b/models/cosmo_model_cfsc.yml
@@ -130,9 +130,9 @@ parameters:
   definition: N/A
 - name: Speed of light
   bounds:
-  - 299792.458
-  - 299792.458
-  unit: km/s
+  - 299792458
+  - 299792458
+  unit: m/s
   latex_name: c
   definition: N/A
 equations:

--- a/models/cosmo_model_cpc.yml
+++ b/models/cosmo_model_cpc.yml
@@ -70,9 +70,9 @@ parameters:
   definition: N/A
 - name: Speed of light
   bounds:
-  - 299792.458
-  - 299792.458
-  unit: km/s
+  - 299792458
+  - 299792458
+  unit: m/s
   latex_name: c
   definition: N/A
 Hz_expression: "H(z) = H_0 * \\sqrt{\\Omega_{m0}*(1+z)**3 + \\Omega_{r0}*(1+z)**4 +

--- a/models/cosmo_model_usmf4.yml
+++ b/models/cosmo_model_usmf4.yml
@@ -21,9 +21,9 @@ description: |-
 parameters:
 - name: Speed of light
   bounds:
-  - 299792.458
-  - 299792.458
-  unit: km/s
+  - 299792458
+  - 299792458
+  unit: m/s
   latex_name: c
   definition: N/A
 - name: Hubble scale today

--- a/models/cosmo_model_usmf5.yml
+++ b/models/cosmo_model_usmf5.yml
@@ -10,8 +10,9 @@ description: |-
 
     H(z) = H_A * sqrt(
       (1+z)**(2*p_alpha) * (1 + k_exp*(1+z)**(s_exp))
-      + Omega_{m eff}*(1+z)**3
-      + Omega_{gamma}*(1+z)**4
+  - 299792458
+  - 299792458
+  unit: m/s
   • **Matter-like term** Omega_{m eff}*(1+z)**3 reproduces structure growth and BAO amplitude without new particles.
   • **Radiation term** Omega_{gamma}*(1+z)**4 enforces the exact early-Universe behaviour.
 

--- a/models/cosmo_model_usmf6.yml
+++ b/models/cosmo_model_usmf6.yml
@@ -10,8 +10,9 @@ description: |-
 
     H(z) = H_A * sqrt(
       (1+z)**(2*p_alpha) * (1 + k_exp*(1+z)**(s_exp))
-      + Omega_{m eff}*(1+z)**3
-      + Omega_{gamma}*(1+z)**4
+  - 299792458
+  - 299792458
+  unit: m/s
   • **Matter-like term** Omega_{m eff}*(1+z)**3 reproduces structure growth and BAO amplitude without new particles.
   • **Radiation term** Omega_{gamma}*(1+z)**4 enforces the exact early-Universe behaviour.
 

--- a/models/cosmo_model_usmf7.yml
+++ b/models/cosmo_model_usmf7.yml
@@ -10,8 +10,9 @@ description: |-
 
     H(z) = H_A * sqrt(
       (1+z)^(2*p_alpha) * (1 + k_exp*(1+z)^(s_exp))
-      + Omega_{m eff}*(1+z)^3
-      + Omega_{gamma}*(1+z)^4
+  - 299792458
+  - 299792458
+  unit: m/s
     )
 
   where:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -152,6 +152,48 @@ class PlotterUtilTestCase(unittest.TestCase):
         )
         self.assertAlmostEqual(phi_param["value"], (1 + 5 ** 0.5) / 2, places=12)
 
+    def test_constants_from_dictionary(self):
+        """Expressions should accept constants from the shared dictionary."""
+        import tempfile
+        import yaml
+
+        model = {
+            "model_name": "ConstModel",
+            "version": "1.0",
+            "parameters": [],
+            "equations": {},
+            "Hz_expression": "H(z) = c"
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "m.yml"
+            with path.open("w") as fh:
+                yaml.safe_dump(model, fh)
+            cache = model_parser.parse_model(path, tmp)
+            funcs, parsed = model_coder.generate_callables(cache)
+            self.assertAlmostEqual(funcs["get_Hz_per_Mpc"](0.0), 299792458, places=6)
+
+    def test_constant_override_by_parameter(self):
+        """Model parameters with matching names override dictionary constants."""
+        import tempfile
+        import yaml
+
+        model = {
+            "model_name": "OverrideModel",
+            "version": "1.0",
+            "parameters": [
+                {"name": "Speed of light", "bounds": [1.0, 1.0], "unit": "m/s", "latex_name": "c"}
+            ],
+            "equations": {},
+            "Hz_expression": "H(z) = c"
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "m.yml"
+            with path.open("w") as fh:
+                yaml.safe_dump(model, fh)
+            cache = model_parser.parse_model(path, tmp)
+            funcs, parsed = model_coder.generate_callables(cache)
+            self.assertAlmostEqual(funcs["get_Hz_per_Mpc"](0.0, 1.0), 1.0, places=6)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- inject universal constants from `common_parameters.yml` into model expressions
- allow models to override constants if desired
- standardize constant units across code and models to SI
- update documentation and development guidelines for automatic constants and SI units
- add tests for constant handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab5119f00832f98bfe26d6ed06fad