### PR TITLE
Update JLA SALT2 constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.1.1
+- 2025-07-31: Updated JLA parser to use published SALT2 parameters and documented them; bumped project version (AI assistant)
+
 ## Version 3.1.0
 - 2025-07-31: Reverted project to version 3.1.0 state and removed universal constants (AI assistant)
 - 2025-07-30: Replaced `^` with `**` for exponentiation across all model YAML files and documented LaTeX syntax (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.1.0
+**Version:** 3.1.1
 **Last Updated:** 2025-07-31
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.

--- a/data/sne/jla2014/cosmo_parser_jla2014.py
+++ b/data/sne/jla2014/cosmo_parser_jla2014.py
@@ -24,9 +24,14 @@ DESCRIPTION = META.get(
     "Joint SDSS-II and SNLS supernova sample (Betoule et al. 2014).",
 )
 
-DEFAULT_SALT2_M_ABS_FIXED = -19.3
-DEFAULT_SALT2_ALPHA_FIXED = 0.14
-DEFAULT_SALT2_BETA_FIXED = 3.1
+# SALT2 nuisance parameters used to convert light-curve fits into
+# distance moduli.  The Betoule et al. analysis reports best-fit
+# values M_B = -19.05, \alpha = 0.141 and \beta = 3.101 at H0=70 km/s/Mpc.
+# Earlier versions of the parser used coarser defaults which shifted
+# the resulting distance moduli downward by about 0.25 mag.
+DEFAULT_SALT2_M_ABS_FIXED = -19.05
+DEFAULT_SALT2_ALPHA_FIXED = 0.141
+DEFAULT_SALT2_BETA_FIXED = 3.101
 
 
 @register_sne_parser(

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -26,7 +26,7 @@ fields. The reference files remain read-only.
 ### JLA Betoule+2014
 *Source:* "Improved cosmological constraints from a joint analysis of the SDSS-II and SNLS supernova samples" (Betoule et al. 2014).
 *Location:* `data/sne/jla2014/`.
-*Parser:* `cosmo_parser_jla2014.py` reads `tablef3.dat`, projects the SALT2 parameter covariance from `tablef4.fit` to distance-modulus space, adds the diagonal statistical errors and stores the inverse of the total covariance matrix.
+*Parser:* `cosmo_parser_jla2014.py` reads `tablef3.dat`, projects the SALT2 parameter covariance from `tablef4.fit` to distance-modulus space, adds the diagonal statistical errors and stores the inverse of the total covariance matrix. The parser uses the published nuisance parameters \(M_B=-19.05\), \(\alpha=0.141\) and \(\beta=3.101\) by default.
 
 ### Pantheon+ 2022 (Scolnic et al.)
 *Source:* Pantheon+SH0ES data release (Scolnic et al. 2022).


### PR DESCRIPTION
## Summary
- adjust JLA parser to use published SALT2 parameters
- document new constants in the data overview docs
- bump version to 3.1.1
- update changelog

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_688b3fd52e5c832f94c9cdccddbb1e53