### PR TITLE
Modular console output and unified logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ AGENTS.md         - Development specification and contributor rules
 CHANGELOG.md      - Release history
 copernican_lib/optim_utils.py - Shared optimisation helpers used by engines
 copernican_lib/latex_utils.py - LaTeX translation helpers using latex_mappings.yml
+copernican_lib/console_output.py - Central console output helpers
 ```
 Installing the suite with `pip` produces a `copernican_suite.egg-info` directory
 containing build metadata. This folder can be safely removed and should not be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.2.0
+- 2025-07-31: Standardized all console output through `console_output.py`, added automatic log renaming and bumped version (AI assistant)
+
 ## Version 3.1.1
 - 2025-07-31: Updated JLA parser to use published SALT2 parameters and documented them; bumped project version (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.1.1
+**Version:** 3.2.0
 **Last Updated:** 2025-07-31
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -75,7 +75,7 @@ Under the hood the program follows a clear pipeline:
    combined optimisation. The chi-squared contribution is then calculated.
 7. **Spectra Caching** – unlensed CAMB spectra are cached using parameter
    keys rounded to six significant digits.
-8. **Output Generation** – `copernican_lib/logger.py`, `copernican_lib/plotter.py` and `copernican_lib/csv_writer.py` handle logs, plots and tables.
+8. **Output Generation** – `copernican_lib/logger.py`, `copernican_lib/plotter.py` and `copernican_lib/csv_writer.py` handle logs, plots and tables. The log file is renamed at the end of each run to match the output timestamp.
 9. **Loop or Exit** – the user may evaluate another model or quit, at which
    point temporary cache files are cleaned automatically.
 
@@ -138,6 +138,7 @@ CONTRIBUTING.md   - Quick checklist for pull requests
 CHANGELOG.md      - Release history
 copernican_lib/          - Helper modules
   logger.py         - Logging setup and helpers
+  console_output.py - Console output helpers
   plotter.py        - Plotting functions
   csv_writer.py     - CSV output helpers
   data_loaders.py   - Data loading utilities

--- a/copernican.py
+++ b/copernican.py
@@ -17,20 +17,22 @@ import datetime
 import argparse
 from pathlib import Path
 
+from copernican_lib import console_output as console
+
 # Verify interpreter version early so users see clear feedback
 MIN_PYTHON = (3, 12)
 
 
 def exit_clean(code: int = 0) -> None:
     """Exit the program after printing a newline."""
-    print()
+    console.write("")
     sys.exit(code)
 
 
 if sys.version_info < MIN_PYTHON:
-    print(
+    console.write(
         f"ERROR: Copernican Suite requires Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]} or later.",
-        file=sys.stderr,
+        error=True,
     )
     exit_clean(1)
 
@@ -55,7 +57,7 @@ data_loaders = None
 # outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
 # unified exponent syntax across model YAML files and drops all
 # legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.1.1"
+COPERNICAN_VERSION = "3.2.0"
 CURRENT_LOG_FILE = None
 
 
@@ -64,7 +66,7 @@ def _delete_log_file(path: str) -> None:
     if path and os.path.isfile(path):
         try:
             os.remove(path)
-            print(f"Removed log file {path}")
+            console.write(f"Removed log file {path}")
         except OSError:
             pass
 
@@ -111,7 +113,7 @@ def run_startup_tests():
     try:
         suite = unittest.defaultTestLoader.discover("tests")
     except Exception as exc:
-        print(f"Error discovering startup tests: {exc}")
+        console.write(f"Error discovering startup tests: {exc}")
         return False
     result = unittest.TextTestRunner(verbosity=1).run(suite)
     return result.wasSuccessful()
@@ -144,9 +146,9 @@ def show_splash_screen():
         "\n",
     ]
     for line in banner:
-        print(line)
+        console.write(line)
     time.sleep(1)
-    print(
+    console.write(
         "Follow the prompts to configure a run. Results are saved in the 'output' directory.\n\n"
     )
 
@@ -239,24 +241,24 @@ def _print_install_instructions(missing: list[str]) -> None:
     # to guide less experienced users.
     pkgs = " ".join(sorted(set(missing)))
     pip_cmd = f"{Path(sys.executable).name} -m pip install {pkgs}"
-    print("Please install them with:")
-    print(f"  {pip_cmd}")
+    console.write("Please install them with:")
+    console.write(f"  {pip_cmd}")
 
     sys_name = platform.system()
     if sys_name == "Darwin" and shutil.which("brew"):
-        print(f"  brew install python && {pip_cmd}")
+        console.write(f"  brew install python && {pip_cmd}")
     elif sys_name == "Linux":
         if shutil.which("apt"):
-            print(f"  sudo apt install python3-pip && {pip_cmd}")
+            console.write(f"  sudo apt install python3-pip && {pip_cmd}")
         elif shutil.which("apt-get"):
-            print(f"  sudo apt-get install python3-pip && {pip_cmd}")
+            console.write(f"  sudo apt-get install python3-pip && {pip_cmd}")
     if shutil.which("pipx"):
-        print(f"  pipx install {pkgs}")
+        console.write(f"  pipx install {pkgs}")
 
 
 def check_dependencies():
     """Ensure all required packages are installed and activate venv if needed."""
-    print("--- Running System Dependency Check ---")
+    console.write("--- Running System Dependency Check ---")
     required = sorted(_gather_required_packages())
     missing = []
     for pkg in required:
@@ -272,11 +274,11 @@ def check_dependencies():
                 missing.append(pkg)
 
     if missing:
-        print(f"Missing packages detected: {', '.join(missing)}")
+        console.write(f"Missing packages detected: {', '.join(missing)}")
         _print_install_instructions(missing)
         exit_clean(1)
     else:
-        print("✅ System Dependency Check Passed. Continuing...\n")
+        console.write("✅ System Dependency Check Passed. Continuing...\n")
 
 
 # Modules that rely on optional packages will be imported in ``main_workflow``
@@ -290,7 +292,7 @@ def get_user_input_filepath(prompt_message, base_dir, must_exist=True):
     # The loop continues until a valid path is provided or the user cancels.
     # This prevents accidental typos from immediately aborting the workflow.
     while True:
-        filename = input(f"{prompt_message} (or 'c' to cancel): ").strip()
+        filename = console.ask(f"{prompt_message} (or 'c' to cancel): ").strip()
         if filename.lower() == "c":
             return None
         filepath = os.path.join(base_dir, filename)
@@ -298,7 +300,7 @@ def get_user_input_filepath(prompt_message, base_dir, must_exist=True):
             return filepath
         else:
             # Inform the user and loop again so they can correct the path.
-            print(f"Error: File not found at '{filepath}'. Please try again.")
+            console.write(f"Error: File not found at '{filepath}'. Please try again.")
 
 
 def load_alternative_model_plugin(model_filepath):
@@ -342,17 +344,17 @@ def select_from_list(options, prompt):
     header = prompt.replace("Select ", "").strip()
     if not header.endswith("s"):
         header += "s"
-    print(f"\nAvailable {header}:")
+    console.write(f"\nAvailable {header}:")
     for i, opt in enumerate(options, 1):
-        print(f"  {i}. {opt}")
-    print("Write the number of your preferred choice or 'c' to cancel:")
+        console.write(f"  {i}. {opt}")
+    console.write("Write the number of your preferred choice or 'c' to cancel:")
     while True:
-        choice = input("> ").strip()
+        choice = console.ask("> ").strip()
         if choice.lower() == "c":
             return None
         if choice.isdigit() and 1 <= int(choice) <= len(options):
             return options[int(choice) - 1]
-        print("Invalid selection. Try again.")
+        console.write("Invalid selection. Try again.")
 
 
 def parse_model_header(md_path):
@@ -483,7 +485,7 @@ def main_workflow():
         if not selected_model:
             _delete_log_file(log_file)
             cleanup_cache(SCRIPT_DIR)
-            print()
+            console.write("")
             return
         yaml_path = os.path.join(models_dir, selected_model)
         cache_dir = os.path.join(models_dir, "cache")
@@ -516,7 +518,7 @@ def main_workflow():
         if not engine_choice:
             _delete_log_file(log_file)
             cleanup_cache(SCRIPT_DIR)
-            print()
+            console.write("")
             return
         engine_module = importlib.import_module(f"engines.{engine_choice[:-3]}")
         cosmo_engine_selected = engine_module
@@ -689,6 +691,15 @@ def main_workflow():
 
         run_end_dt = datetime.datetime.now()
         end_ts = run_end_dt.strftime("%Y%m%d_%H%M%S")
+        new_log = os.path.join(OUTPUT_DIR, f"copernican-run_{end_ts}.txt")
+        if log_file != new_log:
+            try:
+                os.rename(log_file, new_log)
+                CURRENT_LOG_FILE = new_log
+                logger.info(f"Log file renamed to {os.path.basename(new_log)}")
+                log_file = new_log
+            except OSError as e_ren:
+                logger.error(f"Failed renaming log file: {e_ren}")
 
         plotter.plot_hubble_diagram(
             sne_data_df,
@@ -723,14 +734,14 @@ def main_workflow():
                 timestamp=end_ts,
             )
 
-        print("\n--- Theory Abstracts ---\n")
-        print(f"ΛCDM Abstract:\n{lcdm.MODEL_ABSTRACT}\n")
-        print(
+        console.write("\n--- Theory Abstracts ---\n")
+        console.write(f"ΛCDM Abstract:\n{lcdm.MODEL_ABSTRACT}\n")
+        console.write(
             f"{alt_model_plugin.MODEL_NAME} Abstract:\n{alt_model_plugin.MODEL_ABSTRACT}\n"
         )
 
         def _print_fit(label, sne_res, bao_res, cmb_res, plugin):
-            print(f"--- {label} Fit Report ---\n")
+            console.write(f"--- {label} Fit Report ---\n")
             if sne_res:
                 from copernican_lib import latex_utils
                 p_names = getattr(plugin, "PARAMETER_NAMES", [])
@@ -739,16 +750,16 @@ def main_workflow():
                     val = sne_res.get("fitted_cosmological_params", {}).get(name)
                     if val is not None:
                         disp = latex_utils.latex_to_unicode(latex_name)
-                        print(f"  {disp} = {val:.5g}")
+                        console.write(f"  {disp} = {val:.5g}")
             chi2_sne = sne_res.get("chi2_sne", sne_res.get("chi2_min", float("nan")))
             chi2_total = sne_res.get("chi2_total", float("nan"))
-            print(f"  χ²_Total = {chi2_total:.2f}")
-            print(f"  χ²_SNe = {chi2_sne:.2f}")
+            console.write(f"  χ²_Total = {chi2_total:.2f}")
+            console.write(f"  χ²_SNe = {chi2_sne:.2f}")
             if bao_res:
-                print(f"  χ²_BAO = {bao_res.get('chi2_bao', float('nan')):.2f}")
+                console.write(f"  χ²_BAO = {bao_res.get('chi2_bao', float('nan')):.2f}")
             if cmb_res:
-                print(f"  χ²_CMB = {cmb_res.get('chi2_cmb', float('nan')):.2f}")
-            print()
+                console.write(f"  χ²_CMB = {cmb_res.get('chi2_cmb', float('nan')):.2f}")
+            console.write("")
 
         _print_fit("ΛCDM", lcdm_sne_fit_results, lcdm_full_results, lcdm_cmb, lcdm)
         _print_fit(
@@ -792,9 +803,9 @@ def main_workflow():
                 timestamp=end_ts,
             )
 
-        print("\n" + "=" * 50)
-        print("Evaluation complete. All files saved to the 'output' directory.")
-        print("=" * 50 + "\n")
+        console.write("\n" + "=" * 50)
+        console.write("Evaluation complete. All files saved to the 'output' directory.")
+        console.write("=" * 50 + "\n")
 
         total_time = time.perf_counter() - run_start_pc
         cpu_model, cpu_freq = _get_cpu_info()
@@ -802,9 +813,9 @@ def main_workflow():
 
         logger.info(f"Run completed at {end_ts}.")
 
-        print(f"Run started on {run_start_dt.strftime('%Y-%m-%d %H:%M:%S')}")
-        print(f"Run ended on {run_end_dt.strftime('%Y-%m-%d %H:%M:%S')}")
-        print(
+        console.write(f"Run started on {run_start_dt.strftime('%Y-%m-%d %H:%M:%S')}")
+        console.write(f"Run ended on {run_end_dt.strftime('%Y-%m-%d %H:%M:%S')}")
+        console.write(
             f"Run took {lcdm_time:.2f}s for LCDM and {alt_time:.2f}s for {alt_model_plugin.MODEL_NAME}, "
             f"or {total_time:.2f}s in total, on a system with a {cpu_model} {cpu_freq}, "
             f"under {os_info}"
@@ -812,7 +823,7 @@ def main_workflow():
 
         while True:
             another_run = (
-                input("Would you like to run another evaluation? (yes/no): ")
+                console.ask("Would you like to run another evaluation? (yes/no): ")
                 .strip()
                 .lower()
             )
@@ -821,10 +832,10 @@ def main_workflow():
             elif another_run in ["no", "n", "2"]:
                 cleanup_cache(SCRIPT_DIR)
                 logger.info("Exiting Copernican Suite. Goodbye!")
-                print()
+                console.write("")
                 return
             else:
-                print("Invalid input. Please enter 'yes' or 'no'.")
+                console.write("Invalid input. Please enter 'yes' or 'no'.")
 
         cleanup_cache(SCRIPT_DIR)
 
@@ -850,16 +861,16 @@ if __name__ == "__main__":
         if logger_obj and logger_obj.hasHandlers():
             logger_obj.critical("Unhandled exception in main_workflow!", exc_info=True)
         else:
-            print("CRITICAL UNHANDLED EXCEPTION IN MAIN WORKFLOW:")
+            console.write("CRITICAL UNHANDLED EXCEPTION IN MAIN WORKFLOW:")
             import traceback
 
             traceback.print_exc()
     finally:
         # Ensure that any generated plot windows are displayed at the very end
         if plt is not None and hasattr(plt, "get_fignums") and plt.get_fignums():
-            print("\nDisplaying plot(s). Close plot window(s) to exit script fully.")
+            console.write("\nDisplaying plot(s). Close plot window(s) to exit script fully.")
             try:
                 plt.show(block=True)
             except Exception as e_show:
-                print(f"Error during final plt.show(): {e_show}")
-        print()
+                console.write(f"Error during final plt.show(): {e_show}")
+        console.write("")

--- a/copernican_lib/console_output.py
+++ b/copernican_lib/console_output.py
@@ -1,0 +1,24 @@
+"""Console output utilities for the Copernican Suite."""
+
+import sys
+
+
+def write(msg: str = "", *, end: str = "\n", error: bool = False) -> None:
+    """Display ``msg`` on the console and let the logger capture it.
+
+    Parameters
+    ----------
+    msg : str
+        The text to print.
+    end : str, optional
+        String appended after the message. Defaults to a newline.
+    error : bool, optional
+        When ``True`` output is written to ``stderr`` instead of ``stdout``.
+    """
+    stream = sys.stderr if error else sys.stdout
+    print(msg, end=end, file=stream)
+
+
+def ask(prompt: str = "") -> str:
+    """Prompt the user and return their input."""
+    return input(prompt)

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -10,6 +10,7 @@ import numpy as np
 import os
 import logging
 import importlib
+from . import console_output as console
 
 # --- Parser Registry ---
 # Each registry maps a short human readable key to a dictionary
@@ -122,21 +123,21 @@ def _select_source(parser_registry, data_type_name):
     options = list(parser_registry.keys())
     for i, key in enumerate(options):
         desc = parser_registry[key]['description']
-        print(f"  {i+1}. {key} ({desc})" if desc else f"  {i+1}. {key}")
+        console.write(f"  {i+1}. {key} ({desc})" if desc else f"  {i+1}. {key}")
 
-    print("Write the number of your preferred choice or 'c' to cancel:")
+    console.write("Write the number of your preferred choice or 'c' to cancel:")
     while True:
         try:
-            choice = input("> ").strip()
+            choice = console.ask("> ").strip()
             if choice.lower() == 'c':
                 return None
             choice_idx = int(choice) - 1
             if 0 <= choice_idx < len(options):
                 return options[choice_idx]
             else:
-                print("Invalid selection. Please try again.")
+                console.write("Invalid selection. Please try again.")
         except ValueError:
-            print("Invalid input. Please enter a number or 'c'.")
+            console.write("Invalid input. Please enter a number or 'c'.")
 
 # --- Verbose dataset info helper ---
 def _log_dataset_info(df, data_type, logger):

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -18,6 +18,7 @@ import logging
 from sympy.printing.numpy import NumPyPrinter
 from . import error_handler
 from . import engine_interface
+from . import console_output as console
 from . import latex_utils
 
 
@@ -217,7 +218,7 @@ def generate_callables(cache_path):
                 model_data['valid_for_bao'] = True
                 logger.info("Derived r_s using fallback integral from Hz_expression.")
             else:
-                print(
+                console.write(
                     "\u26A0\uFE0F  Model does not define all necessary parameters for computing r_s. BAO scaling may be unavailable."
                 )
                 model_data['valid_for_bao'] = False
@@ -225,7 +226,7 @@ def generate_callables(cache_path):
             error_handler.report_error(f"Failed to parse Hz_expression: {e}")
             raise ValueError(f"Failed to parse Hz_expression: {e}") from e
     else:
-        print(
+        console.write(
             "\u26A0\uFE0F  Model does not define H(z). Distance-based observables such as BAO, comoving distances, and luminosity distances will be unavailable."
         )
         model_data['valid_for_distance_metrics'] = False

--- a/copernican_lib/optim_utils.py
+++ b/copernican_lib/optim_utils.py
@@ -15,6 +15,7 @@ from typing import Iterable, Tuple, Callable, Any, Optional, List
 import sys
 import time
 import logging
+from . import console_output as console
 from scipy.optimize import minimize
 import numpy as np
 
@@ -79,10 +80,10 @@ def minimize_with_progress(
         rate = (
             f"{eval_count['count'] / elapsed:.1f} evals/s" if elapsed > 1e-6 else "--- evals/s"
         )
-        print(
+        console.write(
             f"  {label} Evals: {eval_count['count']:<5} | Best Chi2: {best_val[0]:.4f} | Speed: {rate:<15}",
             end="\r",
-            file=sys.stderr,
+            error=True,
         )
         return val if np.isfinite(val) else 1e12
 
@@ -100,7 +101,7 @@ def minimize_with_progress(
         logger.error(f"Exception during {label.lower()} minimize call: {exc}", exc_info=True)
     finally:
         # Clear the progress line so subsequent prints start on a clean line
-        print(" " * 80, end="\r", file=sys.stderr)
+        console.write(" " * 80, end="\r", error=True)
         logger.info(f"{label} optimization finished. Total evals: {eval_count['count']}.")
 
     return result, eval_count["count"], best_val[0], best_params[0]

--- a/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
+++ b/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
@@ -15,7 +15,7 @@ from copernican_lib.utils import load_metadata_from_dir
 DATA_DIR = os.path.dirname(__file__)
 META = load_metadata_from_dir(DATA_DIR)
 
-DATASET_NAME = META.get("dataset_name", "Planck2018lite")
+DATASET_NAME = META.get("dataset_name", "Planck 2018 Lite TT/TE/EE").replace("\\", "")
 DESCRIPTION = META.get(
     "description",
     "Planck 2018 lite TT/TE/EE spectra.",

--- a/data/sne/jla2014/cosmo_parser_jla2014.py
+++ b/data/sne/jla2014/cosmo_parser_jla2014.py
@@ -18,7 +18,7 @@ from copernican_lib.utils import load_metadata_from_dir
 DATA_DIR = os.path.dirname(__file__)
 META = load_metadata_from_dir(DATA_DIR)
 
-DATASET_NAME = META.get("dataset_name", "JLA 2014")
+DATASET_NAME = META.get("dataset_name", "JLA 2014").replace("\\", "")
 DESCRIPTION = META.get(
     "description",
     "Joint SDSS-II and SNLS supernova sample (Betoule et al. 2014).",
@@ -172,7 +172,8 @@ def parse_jla2014(
     parsed.attrs["salt2_m_abs_fixed"] = salt2_m_abs_fixed
     parsed.attrs["salt2_alpha_fixed"] = salt2_alpha_fixed
     parsed.attrs["salt2_beta_fixed"] = salt2_beta_fixed
-    parsed.attrs["dataset_long_name"] = META.get("dataset_name", "JLA2014")
+    long_name = META.get("dataset_name", "JLA2014").replace("\\", "")
+    parsed.attrs["dataset_long_name"] = long_name
     parsed.attrs["dataset_name_attr"] = parsed.attrs["dataset_long_name"].replace(
         " ", "_"
     )

--- a/data/sne/pantheon/cosmo_parser_pantheon.py
+++ b/data/sne/pantheon/cosmo_parser_pantheon.py
@@ -12,7 +12,7 @@ from copernican_lib.utils import load_metadata_from_dir
 DATA_DIR = os.path.dirname(__file__)
 META = load_metadata_from_dir(DATA_DIR)
 
-DATASET_NAME = META.get("dataset_name", "Pantheon+ dataset")
+DATASET_NAME = META.get("dataset_name", "Pantheon+ dataset").replace("\\", "")
 DESCRIPTION = META.get(
     "description",
     "Supernova distances with full covariance matrix.",
@@ -97,7 +97,8 @@ def parse_pantheon_plus(data_dir, **kwargs):
             logger.warning("Could not invert Pantheon+ covariance matrix. Chi2 will fallback to diagonal errors.")
             output_df.attrs['covariance_matrix_inv'] = None
             output_df.attrs['diag_errors_for_plot'] = output_df['e_mu_obs'].values
-        output_df.attrs['dataset_long_name'] = META.get('dataset_name', 'PantheonPlus2022')
+        long_name = META.get('dataset_name', 'PantheonPlus2022').replace('\\', '')
+        output_df.attrs['dataset_long_name'] = long_name
         output_df.attrs['dataset_name_attr'] = output_df.attrs['dataset_long_name'].replace(' ', '_')
         output_df.attrs['citation'] = META.get('citation', '')
         output_df.attrs['notes'] = META.get('notes', '')

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -16,6 +16,8 @@ modules are:
     `load_cmb_data(name)` – load datasets by their registered names. Each loader
     logs a short summary describing the dataset and whether its covariance matrix
     was used or diagonal errors were applied.
+- `console_output.write(msg)` – unified console printing function that is logged
+  verbatim via `logger`.
 - `engines.cosmo_engine_comb` – reference engine providing high level
   optimisation routines such as ``fit_sne_parameters``,
   ``fit_combined_parameters``, ``calculate_bao_observables`` and generic

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -26,3 +26,6 @@ library and not mere scripts.
 LaTeX translations rely on `copernican_lib/latex_utils.py` which reads symbol and function mappings from `latex_mappings.yml`. New commands can be added there without touching the code.
 The helper also exposes `latex_to_unicode` for rendering parameter names with
 Greek letters and subscripts in console logs.
+Console messages are emitted through `copernican_lib/console_output.py` so that
+all output passes through a single function. The logger patches `print` and
+`input` to capture these messages verbatim.


### PR DESCRIPTION
## Summary
- add `console_output.py` to centralize printing and prompting
- route all console messages through console output helpers
- rename log file at end of each run
- sanitize dataset names in parsers
- update documentation and changelog
- bump version to 3.2.0

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_688b6580a0c8832f9b306c5241cedea2