### PR TITLE
Fix covariance ordering in Pantheon parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.2.1
+- 2025-07-31: Reordered Pantheon+ covariance matrix to match sorted data and updated documentation; bumped version (AI assistant)
+
 ## Version 3.2.0
 - 2025-07-31: Standardized all console output through `console_output.py`, added automatic log renaming and bumped version (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.2.0
+**Version:** 3.2.1
 **Last Updated:** 2025-07-31
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.

--- a/copernican.py
+++ b/copernican.py
@@ -57,7 +57,7 @@ data_loaders = None
 # outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
 # unified exponent syntax across model YAML files and drops all
 # legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.2.0"
+COPERNICAN_VERSION = "3.2.1"
 CURRENT_LOG_FILE = None
 
 
@@ -426,7 +426,13 @@ def main_workflow():
     import matplotlib.pyplot as plt
     import multiprocessing as mp
     from copernican_lib import model_parser, model_coder, engine_interface
-    from copernican_lib import data_loaders, plotter, csv_writer, logger as log_mod, utils
+    from copernican_lib import (
+        data_loaders,
+        plotter,
+        csv_writer,
+        logger as log_mod,
+        utils,
+    )
 
     try:
         SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -744,6 +750,7 @@ def main_workflow():
             console.write(f"--- {label} Fit Report ---\n")
             if sne_res:
                 from copernican_lib import latex_utils
+
                 p_names = getattr(plugin, "PARAMETER_NAMES", [])
                 p_latex = getattr(plugin, "PARAMETER_LATEX_NAMES", [])
                 for name, latex_name in zip(p_names, p_latex):
@@ -868,7 +875,9 @@ if __name__ == "__main__":
     finally:
         # Ensure that any generated plot windows are displayed at the very end
         if plt is not None and hasattr(plt, "get_fignums") and plt.get_fignums():
-            console.write("\nDisplaying plot(s). Close plot window(s) to exit script fully.")
+            console.write(
+                "\nDisplaying plot(s). Close plot window(s) to exit script fully."
+            )
             try:
                 plt.show(block=True)
             except Exception as e_show:

--- a/data/sne/pantheon/cosmo_parser_pantheon.py
+++ b/data/sne/pantheon/cosmo_parser_pantheon.py
@@ -1,4 +1,3 @@
-
 """Parser for the Pantheon+SH0ES 2022 supernova sample."""
 
 import os
@@ -31,8 +30,8 @@ def parse_pantheon_plus(data_dir, **kwargs):
     # depend on a specific release naming convention. Expect exactly one
     # ``*.dat`` file for the supernova data and one ``*.cov`` file for the
     # covariance matrix inside ``data_dir``.
-    dat_files = [f for f in os.listdir(data_dir) if f.lower().endswith('.dat')]
-    cov_files = [f for f in os.listdir(data_dir) if f.lower().endswith('.cov')]
+    dat_files = [f for f in os.listdir(data_dir) if f.lower().endswith(".dat")]
+    cov_files = [f for f in os.listdir(data_dir) if f.lower().endswith(".cov")]
     if not dat_files or not cov_files:
         logger.error("Pantheon+ directory must contain .dat and .cov files")
         return None
@@ -42,67 +41,101 @@ def parse_pantheon_plus(data_dir, **kwargs):
     cov_filepath = os.path.join(data_dir, sorted(cov_files)[0])
 
     try:
-        temp_df = pd.read_csv(filepath, sep=r'\s+', engine='python', comment='#')
+        temp_df = pd.read_csv(filepath, sep=r"\s+", engine="python", comment="#")
         data_df = pd.DataFrame()
         col_map = {
-            'Name': ['CID','SNID','ID','NAME'],
-            'zcmb': ['zCMB','ZCMB','zcmb'],
-            'mu_obs': ['MU_SH0ES','mu'],
-            'mu_sh0es_err_diag': ['MU_SH0ES_ERR_DIAG','e_mu_diag'],
+            "Name": ["CID", "SNID", "ID", "NAME"],
+            "zcmb": ["zCMB", "ZCMB", "zcmb"],
+            "mu_obs": ["MU_SH0ES", "mu"],
+            "mu_sh0es_err_diag": ["MU_SH0ES_ERR_DIAG", "e_mu_diag"],
         }
 
-        with open(cov_filepath,'r') as f:
+        with open(cov_filepath, "r") as f:
             N_cov = int(f.readlines()[0].strip())
 
         for target_col, possible_names in col_map.items():
             found_col = next((p for p in possible_names if p in temp_df.columns), None)
             if found_col:
                 data_df[target_col] = temp_df[found_col]
-            elif target_col not in ['Name', 'mu_sh0es_err_diag']:
-                logger.error(f"Column for '{target_col}' not found in Pantheon+ (mu_cov)."); return None
+            elif target_col not in ["Name", "mu_sh0es_err_diag"]:
+                logger.error(
+                    f"Column for '{target_col}' not found in Pantheon+ (mu_cov)."
+                )
+                return None
 
-        if 'Name' not in data_df:
-            data_df['Name'] = temp_df.get('CID', pd.Series([f"SN_PPlus_mucov_{i}" for i in range(len(temp_df))]))
-        data_df['Name'] = data_df['Name'].astype(str).str.strip()
+        if "Name" not in data_df:
+            data_df["Name"] = temp_df.get(
+                "CID", pd.Series([f"SN_PPlus_mucov_{i}" for i in range(len(temp_df))])
+            )
+        data_df["Name"] = data_df["Name"].astype(str).str.strip()
 
-        essential_cols = ['zcmb','mu_obs']
-        for col in essential_cols + ['mu_sh0es_err_diag']:
+        essential_cols = ["zcmb", "mu_obs"]
+        for col in essential_cols + ["mu_sh0es_err_diag"]:
             if col in data_df:
-                data_df[col] = pd.to_numeric(data_df[col], errors='coerce')
+                data_df[col] = pd.to_numeric(data_df[col], errors="coerce")
 
-        if any(col not in data_df.columns or data_df[col].isnull().all() for col in essential_cols):
-            logger.error("One or more essential columns missing/all NaN in Pantheon+ data."); return None
+        if any(
+            col not in data_df.columns or data_df[col].isnull().all()
+            for col in essential_cols
+        ):
+            logger.error(
+                "One or more essential columns missing/all NaN in Pantheon+ data."
+            )
+            return None
 
         data_df = data_df.dropna(subset=essential_cols).reset_index(drop=True)
         if data_df.empty:
-            logger.error("No valid Pantheon+ SNe data after filtering."); return None
+            logger.error("No valid Pantheon+ SNe data after filtering.")
+            return None
         if len(data_df) != N_cov:
-            logger.critical(f"SNe count for mu_cov: data ({len(data_df)}) vs cov N ({N_cov})."); return None
+            logger.critical(
+                f"SNe count for mu_cov: data ({len(data_df)}) vs cov N ({N_cov})."
+            )
+            return None
 
         cov_matrix_flat = np.loadtxt(cov_filepath, skiprows=1)
-        if len(cov_matrix_flat) != N_cov*N_cov:
-            logger.error(f"Cov matrix len ({len(cov_matrix_flat)}) != N*N ({N_cov*N_cov})."); return None
-        cov_matrix_pantheon = cov_matrix_flat.reshape((N_cov,N_cov))
+        if len(cov_matrix_flat) != N_cov * N_cov:
+            logger.error(
+                f"Cov matrix len ({len(cov_matrix_flat)}) != N*N ({N_cov * N_cov})."
+            )
+            return None
+        cov_matrix_pantheon = cov_matrix_flat.reshape((N_cov, N_cov))
 
-        if 'mu_sh0es_err_diag' in data_df and data_df['mu_sh0es_err_diag'].notna().any():
-            data_df['e_mu_obs'] = data_df['mu_sh0es_err_diag']
+        if (
+            "mu_sh0es_err_diag" in data_df
+            and data_df["mu_sh0es_err_diag"].notna().any()
+        ):
+            data_df["e_mu_obs"] = data_df["mu_sh0es_err_diag"]
         else:
-            data_df['e_mu_obs'] = np.sqrt(np.diag(cov_matrix_pantheon))
+            data_df["e_mu_obs"] = np.sqrt(np.diag(cov_matrix_pantheon))
 
-        output_df = data_df[['Name', 'zcmb', 'mu_obs', 'e_mu_obs']].copy().sort_values(by='zcmb').reset_index(drop=True)
+        sort_idx = np.argsort(data_df["zcmb"].values)
+        data_df = data_df.iloc[sort_idx].reset_index(drop=True)
+        cov_matrix_pantheon = cov_matrix_pantheon[sort_idx][:, sort_idx]
+
+        output_df = data_df[["Name", "zcmb", "mu_obs", "e_mu_obs"]].copy()
         try:
-            output_df.attrs['covariance_matrix_inv'] = np.linalg.inv(cov_matrix_pantheon)
-            output_df.attrs['diag_errors_for_plot'] = np.sqrt(np.diag(cov_matrix_pantheon))
+            output_df.attrs["covariance_matrix_inv"] = np.linalg.inv(
+                cov_matrix_pantheon
+            )
+            output_df.attrs["diag_errors_for_plot"] = np.sqrt(
+                np.diag(cov_matrix_pantheon)
+            )
         except np.linalg.LinAlgError:
-            logger.warning("Could not invert Pantheon+ covariance matrix. Chi2 will fallback to diagonal errors.")
-            output_df.attrs['covariance_matrix_inv'] = None
-            output_df.attrs['diag_errors_for_plot'] = output_df['e_mu_obs'].values
-        long_name = META.get('dataset_name', 'PantheonPlus2022').replace('\\', '')
-        output_df.attrs['dataset_long_name'] = long_name
-        output_df.attrs['dataset_name_attr'] = output_df.attrs['dataset_long_name'].replace(' ', '_')
-        output_df.attrs['citation'] = META.get('citation', '')
-        output_df.attrs['notes'] = META.get('notes', '')
-        output_df.attrs['description'] = META.get('description', '')
+            logger.warning(
+                "Could not invert Pantheon+ covariance matrix. Chi2 will fallback to diagonal errors."
+            )
+            output_df.attrs["covariance_matrix_inv"] = None
+            output_df.attrs["diag_errors_for_plot"] = output_df["e_mu_obs"].values
+        long_name = META.get("dataset_name", "PantheonPlus2022").replace("\\", "")
+        output_df.attrs["dataset_long_name"] = long_name
+        output_df.attrs["dataset_name_attr"] = output_df.attrs[
+            "dataset_long_name"
+        ].replace(" ", "_")
+        output_df.attrs["citation"] = META.get("citation", "")
+        output_df.attrs["notes"] = META.get("notes", "")
+        output_df.attrs["description"] = META.get("description", "")
         return output_df
     except Exception as e:
-        logger.error(f"Error processing Pantheon+ data: {e}", exc_info=True); return None
+        logger.error(f"Error processing Pantheon+ data: {e}", exc_info=True)
+        return None

--- a/data/sne/pantheon/metadata_pantheon.yml
+++ b/data/sne/pantheon/metadata_pantheon.yml
@@ -4,3 +4,6 @@ description: Combined sample of 1701 Type Ia supernovae distances with full cova
 citation: Scolnic et al. 2022, ApJ 938, 113; Riess et al. 2022, ApJ 934, L7
 authors_all: Dan Scolnic, Dillon Brout, Brodie Popovic, Adam G. Riess, Joe Zuntz, Rick Kessler, Anthony Carr, Tamara M. Davis, Samuel Hinton, David Jones, W. D'Arcy Kenworthy, Erik R. Peterson, Khaled Said, Georgie Taylor, Noor Ali, Patrick Armstrong, Pranav Charvu, Arianna Dwomoh, Antonella Palmese, Helen Qu, Benjamin M. Rose, Christopher W. Stubbs, Maria Vincenzi, Charlotte M. Wood, Peter J. Brown, Rebecca Chen, Ken Chambers, David A. Coulter, Mi Dai, Georgios Dimitriadis, Alexei V. Filippenko, Ryan J. Foley, Saurabh W. Jha, Lisa Kelsey, Robert P. Kirshner, Anais Möller, Jessie Muir, Seshadri Nadathur, Yen-Chen Pan, Armin Rest, Cesar Rojas-Bravo, Masao Sako, Matthew R. Siebert, Mat Smith, Benjamin E. Stahl, Phil Wiseman.
 notes: Distance moduli for supernovae with full statistical and systematic covariance.
+  The parser sorts the sample by redshift and reorders the covariance matrix to
+  match. Duplicate entries correspond to alternate calibrations and are
+  intentionally preserved.

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -30,4 +30,8 @@ fields. The reference files remain read-only.
 
 ### Pantheon+ 2022 (Scolnic et al.)
 *Source:* Pantheon+SH0ES data release (Scolnic et al. 2022).
-*Parser:* `cosmo_parser_pantheon.py` loads `Pantheon+SH0ES.dat` together with its full covariance matrix. The inverse covariance is stored on the returned DataFrame.
+*Parser:* `cosmo_parser_pantheon.py` loads `Pantheon+SH0ES.dat` together with its
+full covariance matrix.  Unlike JLA, the distance moduli are already provided so
+no SALT2 nuisance parameters are required. The parser sorts the supernovae by
+redshift and reorders the covariance matrix accordingly before inverting it. The
+inverse covariance is stored on the returned DataFrame.


### PR DESCRIPTION
## Summary
- reorder Pantheon+ covariance matrix to match the sorted supernova sample
- document Pantheon+ parser behaviour and duplicates
- note covariance handling in metadata
- bump version to 3.2.1

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_688b7dcaa8ac832f9df8fc3ecbc4db2d