### PR TITLE
Fix BAO parsing and document escape sequence policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ To keep the project maintainable all contributors, human or AI, must follow thes
 7. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in any file.**
 8. **Re-read the "Development laws and protocols for human and AI contributors" section in `README.md` at the start of every development session.**
 9. **Document every module, function and class with clear "what" and "why" explanations.** Comments and docstrings should describe not only the behaviour but also the rationale behind it.
+10. **Escape backslashes or prefix string literals with `r` to prevent invalid escape sequence warnings.** This is especially important for docstrings containing LaTeX commands or file paths.
 
 Failure to follow these guidelines will compromise the Copernican Suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.3.2
+- 2025-08-03: Corrected compound BAO parser to preserve dimensionless measurements, overhauled BOSS DR12 parser to use dM and Hz inputs with full covariance propagation, documented raw-string guideline, and bumped version (AI assistant)
+
 ## Version 3.3.1
 - 2025-08-03: Renamed BAO test dataset to compound dataset, improved BAO parsers and documentation, and bumped version (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ See `CHANGELOG.md` for complete version history.
 > 7. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in any file.**
 > 8. **Re-read the "Development laws and protocols for human and AI contributors" section in `README.md` at the start of every development session.**
 > 9. **Document every module, function and class with clear "what" and "why" explanations.** Comments and docstrings should describe not only the behaviour but also the rationale behind it.
+> 10. **Escape backslashes or prefix string literals with `r` to prevent invalid escape sequence warnings.** This is especially important for docstrings containing LaTeX commands or file paths.
 >
 > Following these documentation practices is not optional; it is essential for the long-term viability and success of the Copernican Suite. Failure to follow these rules will compromise the maintainability of the Copernican Suite.
 

--- a/copernican.py
+++ b/copernican.py
@@ -57,7 +57,7 @@ data_loaders = None
 # outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
 # unified exponent syntax across model YAML files and drops all
 # legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.3.1"
+COPERNICAN_VERSION = "3.3.2"
 CURRENT_LOG_FILE = None
 
 

--- a/data/bao/bossdr12/cosmo_parser_bossdr12.py
+++ b/data/bao/bossdr12/cosmo_parser_bossdr12.py
@@ -1,13 +1,15 @@
-"""Parse BOSS DR12 consensus BAO measurements.
+r"""Parse BOSS DR12 consensus BAO measurements.
 
-The public BOSS DR12 release tabulates the spherically averaged distance
-``D_V/rs`` and the Alcock--Paczyński parameter ``F_AP`` for three redshift
-bins.  This parser converts those quantities into ``D_M/rs``, ``D_H/rs`` and
-``D_V/rs`` so they can be consumed by the engine's generic BAO routines.
-The accompanying covariance matrix is propagated through the variable
-transformation and the inverse covariance is attached to the resulting
-:class:`pandas.DataFrame`.
+The SDSS-III BOSS DR12 release tabulates the transverse comoving distance
+``dM(rsfid/rs)`` in megaparsecs and the scaled Hubble parameter
+``Hz(rs/rsfid)`` for three effective redshifts.  This parser converts those
+quantities into the dimensionless observables ``DM_over_rs``, ``DH_over_rs`` and
+``DV_over_rs`` expected by the engine.  The published covariance matrix is
+propagated through the variable transformation so downstream code receives
+uncertainties in the correct space.
 """
+
+from __future__ import annotations
 
 import os
 import logging
@@ -26,14 +28,21 @@ DESCRIPTION = META.get(
     "BOSS DR12 consensus BAO distances with full covariance.",
 )
 
+# Fiducial sound horizon used by the BOSS DR12 analysis (Alam et al. 2017)
+RS_FIDUCIAL_MPC = 147.78
+# Speed of light in km/s for converting ``H(z)`` to ``D_H``
+C_LIGHT_KMS = 299792.458
+
 
 @register_bao_parser(DATASET_NAME, DESCRIPTION, data_dir=DATA_DIR)
-def parse_boss_dr12(data_dir, **kwargs):
+def parse_boss_dr12(data_dir: str, **kwargs) -> pd.DataFrame | None:
     """Return BAO observables and covariance from the BOSS DR12 release."""
+
     logger = logging.getLogger()
 
-    results_path = os.path.join(data_dir, "BAO_consensus_results_dV_FAP.txt")
-    cov_path = os.path.join(data_dir, "BAO_consensus_covtot_dV_FAP.txt")
+    results_path = os.path.join(data_dir, "BAO_consensus_results_dM_Hz.txt")
+    cov_path = os.path.join(data_dir, "BAO_consensus_covtot_dM_Hz.txt")
+
     try:
         table = pd.read_csv(
             results_path,
@@ -42,28 +51,30 @@ def parse_boss_dr12(data_dir, **kwargs):
             header=None,
             names=["z", "label", "value"],
         )
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - I/O failure
         logger.error(f"Failed reading BOSS DR12 results file: {exc}")
         return None
 
-    # Extract ``D_V/rs`` and ``F_AP`` pairs while preserving redshift order.
-    redshifts = []
-    dv_vals = []
-    fap_vals = []
+    # Extract ``dM(rsfid/rs)`` and ``Hz(rs/rsfid)`` pairs while preserving
+    # redshift order.
+    redshifts: list[float] = []
+    dm_fid: list[float] = []
+    hz_scaled: list[float] = []
     for _, row in table.iterrows():
-        if isinstance(row["label"], str) and row["label"].startswith("dV/rs"):
+        label = str(row["label"])
+        if label.startswith("dM"):
             redshifts.append(float(row["z"]))
-            dv_vals.append(float(row["value"]))
-        elif isinstance(row["label"], str) and row["label"].startswith("F_AP"):
-            fap_vals.append(float(row["value"]))
+            dm_fid.append(float(row["value"]))
+        elif label.startswith("Hz"):
+            hz_scaled.append(float(row["value"]))
 
-    if not (len(redshifts) == len(dv_vals) == len(fap_vals)):
+    if not (len(redshifts) == len(dm_fid) == len(hz_scaled)):
         logger.error("BOSS DR12 results file is malformed.")
         return None
 
     try:
         cov_x = np.loadtxt(cov_path)
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - I/O failure
         logger.error(f"Failed reading BOSS DR12 covariance: {exc}")
         return None
 
@@ -71,55 +82,52 @@ def parse_boss_dr12(data_dir, **kwargs):
         logger.error("Unexpected BOSS DR12 covariance matrix size.")
         return None
 
-    # Vector ordering in the files: [DV1, FAP1, DV2, FAP2, DV3, FAP3]
-    x_vec = np.empty(6)
-    x_vec[0::2] = dv_vals
-    x_vec[1::2] = fap_vals
-
     n_z = len(redshifts)
     y_vec = np.empty(n_z * 3)
     jac = np.zeros((n_z * 3, 6))
 
     for i in range(n_z):
-        dv = x_vec[2 * i]
-        fap = x_vec[2 * i + 1]
+        dm = dm_fid[i]  # ``D_M * (r_s^fid / r_s)`` in Mpc
+        hz = hz_scaled[i]  # ``H(z) * (r_s / r_s^fid)`` in km/s/Mpc
 
-        # Recover the transverse and radial distances.  The relationships
-        # follow from :math:`D_V^3 = D_M^2 D_H` and ``F_AP = D_M / D_H``.
-        dm = dv * fap ** (1.0 / 3.0)
-        dh = dv / fap ** (2.0 / 3.0)
-        y_vec[3 * i : 3 * i + 3] = [dm, dh, dv]
+        dm_over_rs = dm / RS_FIDUCIAL_MPC
+        dh_over_rs = C_LIGHT_KMS / (hz * RS_FIDUCIAL_MPC)
+        dv_over_rs = (dm_over_rs ** 2 * dh_over_rs) ** (1.0 / 3.0)
 
-        # Jacobian for covariance propagation.  Each block maps the original
-        # ``[DV, F_AP]`` pair to ``[DM, DH, DV]`` at the same redshift.
-        jac[3 * i, 2 * i] = fap ** (1.0 / 3.0)
-        jac[3 * i, 2 * i + 1] = (1.0 / 3.0) * dv * fap ** (-2.0 / 3.0)
-        jac[3 * i + 1, 2 * i] = fap ** (-2.0 / 3.0)
-        jac[3 * i + 1, 2 * i + 1] = (-2.0 / 3.0) * dv * fap ** (-5.0 / 3.0)
-        jac[3 * i + 2, 2 * i] = 1.0
-        jac[3 * i + 2, 2 * i + 1] = 0.0
+        y_vec[3 * i : 3 * i + 3] = [dm_over_rs, dh_over_rs, dv_over_rs]
 
-    # Propagate covariance and attempt to invert
+        # Jacobian for covariance propagation.  Each 3x2 block maps the
+        # original ``[dM, Hz]`` pair to ``[DM_over_rs, DH_over_rs, DV_over_rs]``
+        # at the same redshift.  Analytic derivatives are used for stability.
+        jac[3 * i, 2 * i] = 1.0 / RS_FIDUCIAL_MPC
+        jac[3 * i + 1, 2 * i + 1] = -C_LIGHT_KMS / (hz ** 2 * RS_FIDUCIAL_MPC)
+        jac[3 * i + 2, 2 * i] = (
+            (2.0 / 3.0) * (dv_over_rs / dm_over_rs) / RS_FIDUCIAL_MPC
+        )
+        jac[3 * i + 2, 2 * i + 1] = -(
+            (1.0 / 3.0) * dv_over_rs / hz
+        )
+
+    # Propagate covariance into the transformed space and try to invert.
     cov_y = jac @ cov_x @ jac.T
     diag = np.sqrt(np.diag(cov_y))
     try:
-        cond = np.linalg.cond(cov_y)
-        cov_inv = np.linalg.inv(cov_y) if np.isfinite(cond) and cond < 1e12 else None
-    except Exception as exc:
-        logger.warning(f"BOSS DR12 covariance inversion failed: {exc}")
+        cov_inv = np.linalg.inv(cov_y)
+    except np.linalg.LinAlgError:
+        logger.warning("BOSS DR12 covariance inversion failed; proceeding without inverse")
         cov_inv = None
 
-    records = []
+    records: list[dict[str, float]] = []
     for i, z in enumerate(redshifts):
-        dm = y_vec[3 * i]
-        dh = y_vec[3 * i + 1]
-        dv = y_vec[3 * i + 2]
+        dm_over_rs = y_vec[3 * i]
+        dh_over_rs = y_vec[3 * i + 1]
+        dv_over_rs = y_vec[3 * i + 2]
         records.append(
             {
                 "name": f"BOSS DR12 z={z} (DM/rs)",
                 "redshift": z,
                 "observable_type": "DM_over_rs",
-                "value": dm,
+                "value": dm_over_rs,
                 "error": diag[3 * i],
             }
         )
@@ -128,7 +136,7 @@ def parse_boss_dr12(data_dir, **kwargs):
                 "name": f"BOSS DR12 z={z} (DH/rs)",
                 "redshift": z,
                 "observable_type": "DH_over_rs",
-                "value": dh,
+                "value": dh_over_rs,
                 "error": diag[3 * i + 1],
             }
         )
@@ -137,13 +145,14 @@ def parse_boss_dr12(data_dir, **kwargs):
                 "name": f"BOSS DR12 z={z} (DV/rs)",
                 "redshift": z,
                 "observable_type": "DV_over_rs",
-                "value": dv,
+                "value": dv_over_rs,
                 "error": diag[3 * i + 2],
             }
         )
 
     df = pd.DataFrame.from_records(records)
-    df.sort_values('redshift', inplace=True, ignore_index=True)
+    df.sort_values("redshift", inplace=True, ignore_index=True)
+
     df.attrs["covariance_matrix_inv"] = cov_inv
     df.attrs["diag_errors_for_plot"] = diag
     df.attrs["dataset_long_name"] = META.get("dataset_name", DATASET_NAME)
@@ -152,3 +161,4 @@ def parse_boss_dr12(data_dir, **kwargs):
     df.attrs["notes"] = META.get("notes", "")
     df.attrs["description"] = META.get("description", "")
     return df
+

--- a/data/bao/compound/cosmo_parser_compound.py
+++ b/data/bao/compound/cosmo_parser_compound.py
@@ -1,5 +1,5 @@
 
-"""Parse the *compound* BAO dataset and attach metadata.
+r"""Parse the *compound* BAO dataset and attach metadata.
 
 This parser is intentionally lightweight and makes no assumptions about the
 cosmological model.  It simply reads the YAML table located in ``data_dir``
@@ -8,9 +8,9 @@ and returns a :class:`pandas.DataFrame` with the expected columns.  A matching
 documentation strings.  The compound dataset does **not** ship with a
 covariance matrix; uncertainties are therefore treated as uncorrelated and the
 engine falls back to a diagonal covariance during the :math:`\chi^2`
-evaluation.  When a fiducial sound horizon ``rs_fiducial_Mpc`` is provided the
-values are converted to true ``*_over_rs`` observables so the engine remains
-agnostic of any fiducial scaling.
+evaluation.  Any published fiducial sound horizon ``rs_fiducial_Mpc`` is
+preserved for reference only; the tabulated ``*_over_rs`` observables are
+already dimensionless and require no additional scaling.
 """
 
 import os
@@ -67,15 +67,11 @@ def parse_bao_v1(data_dir, **kwargs):
             if col in df.columns:
                 df[col] = pd.to_numeric(df[col], errors='coerce')
 
-        # Some literature quotes distances multiplied by ``r_s^fid / r_s``. If
-        # a fiducial sound horizon is specified we divide the measurement and
-        # its uncertainty by that value to recover the dimensionless
-        # ``*_over_rs`` form expected by the engine.  Entries without a fiducial
-        # value are assumed to already be in the correct units.
-        if 'rs_fiducial_Mpc' in df.columns:
-            mask = df['rs_fiducial_Mpc'].notna()
-            df.loc[mask, 'value'] /= df.loc[mask, 'rs_fiducial_Mpc']
-            df.loc[mask, 'error'] /= df.loc[mask, 'rs_fiducial_Mpc']
+        # The optional ``rs_fiducial_Mpc`` column records the sound horizon
+        # assumed by the original authors.  The compound sample already lists
+        # observables in ``*_over_rs`` form, so no rescaling is performed here.
+        # Entries with a fiducial value keep it as metadata without affecting
+        # the numerical measurements.
 
         df.dropna(subset=required_cols, inplace=True)
         if df.empty:

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -41,4 +41,4 @@ inverse covariance is stored on the returned DataFrame.
 ### BOSS DR12 BAO Consensus (Alam et al. 2017)
 *Source:* "The clustering of galaxies in the completed SDSS-III Baryon Oscillation Spectroscopic Survey" (Alam et al. 2017).
 *Location:* `data/bao/bossdr12/`.
-*Parser:* `cosmo_parser_bossdr12.py` reads consensus $D_V/r_s$ and $F_{AP}$ values, converts them to $D_M/r_s$ and $D_H/r_s$, and propagates the published covariance matrix.
+*Parser:* `cosmo_parser_bossdr12.py` ingests the published $dM(r_s^{fid}/r_s)$ and $H(z)(r_s/r_s^{fid})$ values, derives $D_M/r_s$, $D_H/r_s$ and $D_V/r_s$, and propagates the covariance matrix into the transformed space.


### PR DESCRIPTION
## Summary
- avoid scaling compound BAO measurements and silence docstring escape warnings
- derive BOSS DR12 BAO observables from dM/H(z) inputs with covariance propagation
- document new escape-sequence guideline and bump to v3.3.2

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_688f48fbc940832faea035b291a7e9fd