### PR TITLE
Fix BAO parser scaling and add escape-sequence guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ To keep the project maintainable all contributors, human or AI, must follow thes
 7. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in any file.**
 8. **Re-read the "Development laws and protocols for human and AI contributors" section in `README.md` at the start of every development session.**
 9. **Document every module, function and class with clear "what" and "why" explanations.** Comments and docstrings should describe not only the behaviour but also the rationale behind it.
+10. **Use raw strings or escape backslashes explicitly to avoid invalid escape sequence warnings in docstrings or string literals.**
 
 Failure to follow these guidelines will compromise the Copernican Suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.3.2
+- 2025-08-03: Corrected BOSS DR12 BAO conversion to include redshift scaling, fixed compound parser scaling bug and added escape-sequence guideline; bumped version (AI assistant)
+
 ## Version 3.3.1
 - 2025-08-03: Renamed BAO test dataset to compound dataset, improved BAO parsers and documentation, and bumped version (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.2.1
-**Last Updated:** 2025-07-31
+**Version:** 3.3.2
+**Last Updated:** 2025-08-03
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.

--- a/data/bao/bossdr12/cosmo_parser_bossdr12.py
+++ b/data/bao/bossdr12/cosmo_parser_bossdr12.py
@@ -1,12 +1,13 @@
-"""Parse BOSS DR12 consensus BAO measurements.
+r"""Parse BOSS DR12 consensus BAO measurements.
 
 The public BOSS DR12 release tabulates the spherically averaged distance
 ``D_V/rs`` and the Alcock--Paczyński parameter ``F_AP`` for three redshift
-bins.  This parser converts those quantities into ``D_M/rs``, ``D_H/rs`` and
+bins. This parser converts those quantities into ``D_M/rs``, ``D_H/rs`` and
 ``D_V/rs`` so they can be consumed by the engine's generic BAO routines.
-The accompanying covariance matrix is propagated through the variable
-transformation and the inverse covariance is attached to the resulting
-:class:`pandas.DataFrame`.
+The conversion explicitly accounts for the relation :math:`D_V^3 = D_M^2 D_H z`
+and ``F_AP = D_M / D_H``. The accompanying covariance matrix is propagated
+through the variable transformation and the inverse covariance is attached to
+the resulting :class:`pandas.DataFrame`.
 """
 
 import os
@@ -83,19 +84,21 @@ def parse_boss_dr12(data_dir, **kwargs):
     for i in range(n_z):
         dv = x_vec[2 * i]
         fap = x_vec[2 * i + 1]
+        z = redshifts[i]
+        z_factor = z ** (1.0 / 3.0)
 
         # Recover the transverse and radial distances.  The relationships
-        # follow from :math:`D_V^3 = D_M^2 D_H` and ``F_AP = D_M / D_H``.
-        dm = dv * fap ** (1.0 / 3.0)
-        dh = dv / fap ** (2.0 / 3.0)
+        # follow from :math:`D_V^3 = D_M^2 D_H z` and ``F_AP = D_M / D_H``.
+        dm = dv * fap ** (1.0 / 3.0) / z_factor
+        dh = dv * fap ** (-2.0 / 3.0) / z_factor
         y_vec[3 * i : 3 * i + 3] = [dm, dh, dv]
 
-        # Jacobian for covariance propagation.  Each block maps the original
+        # Jacobian for covariance propagation. Each block maps the original
         # ``[DV, F_AP]`` pair to ``[DM, DH, DV]`` at the same redshift.
-        jac[3 * i, 2 * i] = fap ** (1.0 / 3.0)
-        jac[3 * i, 2 * i + 1] = (1.0 / 3.0) * dv * fap ** (-2.0 / 3.0)
-        jac[3 * i + 1, 2 * i] = fap ** (-2.0 / 3.0)
-        jac[3 * i + 1, 2 * i + 1] = (-2.0 / 3.0) * dv * fap ** (-5.0 / 3.0)
+        jac[3 * i, 2 * i] = fap ** (1.0 / 3.0) / z_factor
+        jac[3 * i, 2 * i + 1] = (1.0 / 3.0) * dv * fap ** (-2.0 / 3.0) / z_factor
+        jac[3 * i + 1, 2 * i] = fap ** (-2.0 / 3.0) / z_factor
+        jac[3 * i + 1, 2 * i + 1] = (-2.0 / 3.0) * dv * fap ** (-5.0 / 3.0) / z_factor
         jac[3 * i + 2, 2 * i] = 1.0
         jac[3 * i + 2, 2 * i + 1] = 0.0
 

--- a/data/bao/compound/cosmo_parser_compound.py
+++ b/data/bao/compound/cosmo_parser_compound.py
@@ -1,16 +1,16 @@
 
-"""Parse the *compound* BAO dataset and attach metadata.
+r"""Parse the *compound* BAO dataset and attach metadata.
 
 This parser is intentionally lightweight and makes no assumptions about the
-cosmological model.  It simply reads the YAML table located in ``data_dir``
-and returns a :class:`pandas.DataFrame` with the expected columns.  A matching
+cosmological model. It simply reads the YAML table located in ``data_dir`` and
+returns a :class:`pandas.DataFrame` with the expected columns. A matching
 ``metadata_*.yml`` file supplies the human readable dataset name and
-documentation strings.  The compound dataset does **not** ship with a
+documentation strings. The compound dataset does **not** ship with a
 covariance matrix; uncertainties are therefore treated as uncorrelated and the
 engine falls back to a diagonal covariance during the :math:`\chi^2`
-evaluation.  When a fiducial sound horizon ``rs_fiducial_Mpc`` is provided the
-values are converted to true ``*_over_rs`` observables so the engine remains
-agnostic of any fiducial scaling.
+evaluation. A ``rs_fiducial_Mpc`` column may appear in some entries but is
+retained only for reference—no unit conversion is performed so that published
+values are used directly without risking double scaling.
 """
 
 import os
@@ -61,21 +61,11 @@ def parse_bao_v1(data_dir, **kwargs):
             );
             return None
 
-        # Ensure numeric columns are typed correctly.  ``rs_fiducial_Mpc`` may
+        # Ensure numeric columns are typed correctly. ``rs_fiducial_Mpc`` may
         # be absent or contain ``null`` which converts to ``NaN``.
         for col in ['redshift', 'value', 'error', 'rs_fiducial_Mpc']:
             if col in df.columns:
                 df[col] = pd.to_numeric(df[col], errors='coerce')
-
-        # Some literature quotes distances multiplied by ``r_s^fid / r_s``. If
-        # a fiducial sound horizon is specified we divide the measurement and
-        # its uncertainty by that value to recover the dimensionless
-        # ``*_over_rs`` form expected by the engine.  Entries without a fiducial
-        # value are assumed to already be in the correct units.
-        if 'rs_fiducial_Mpc' in df.columns:
-            mask = df['rs_fiducial_Mpc'].notna()
-            df.loc[mask, 'value'] /= df.loc[mask, 'rs_fiducial_Mpc']
-            df.loc[mask, 'error'] /= df.loc[mask, 'rs_fiducial_Mpc']
 
         df.dropna(subset=required_cols, inplace=True)
         if df.empty:

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -41,4 +41,4 @@ inverse covariance is stored on the returned DataFrame.
 ### BOSS DR12 BAO Consensus (Alam et al. 2017)
 *Source:* "The clustering of galaxies in the completed SDSS-III Baryon Oscillation Spectroscopic Survey" (Alam et al. 2017).
 *Location:* `data/bao/bossdr12/`.
-*Parser:* `cosmo_parser_bossdr12.py` reads consensus $D_V/r_s$ and $F_{AP}$ values, converts them to $D_M/r_s$ and $D_H/r_s$, and propagates the published covariance matrix.
+*Parser:* `cosmo_parser_bossdr12.py` reads consensus $D_V/r_s$ and $F_{AP}$ values, converts them to $D_M/r_s$ and $D_H/r_s$ using $D_V^3 = D_M^2 D_H z$, and propagates the published covariance matrix.


### PR DESCRIPTION
## Summary
- prevent escape sequence warnings via new AGENTS guideline
- keep compound BAO measurements unscaled and raw string docstring
- incorporate redshift factor into BOSS DR12 parser and update docs

## Testing
- `python -m unittest discover`
- `pre-commit run --files AGENTS.md CHANGELOG.md README.md data/bao/bossdr12/cosmo_parser_bossdr12.py data/bao/compound/cosmo_parser_compound.py docs/data_overview.md` *(fails: `.pre-commit-config.yaml` is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_688f4dfaf968832fba34d6e449fe0604