### PR TITLE
Use full covariance for BOSS DR12 BAO dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.3.3
+- 2025-08-03: Ensured BOSS DR12 parser uses published covariance by keeping only independent $D_M/r_s$ and $D_H/r_s$ observables; updated documentation and bumped version (AI assistant)
+
 ## Version 3.3.2
 - 2025-08-03: Corrected BOSS DR12 BAO conversion to include redshift scaling, fixed compound parser scaling bug and added escape-sequence guideline; bumped version (AI assistant)
 

--- a/data/bao/bossdr12/cosmo_parser_bossdr12.py
+++ b/data/bao/bossdr12/cosmo_parser_bossdr12.py
@@ -1,25 +1,41 @@
 r"""Parse BOSS DR12 consensus BAO measurements.
 
-The public BOSS DR12 release tabulates the spherically averaged distance
-``D_V/rs`` and the Alcock--Paczyński parameter ``F_AP`` for three redshift
-bins. This parser converts those quantities into ``D_M/rs``, ``D_H/rs`` and
-``D_V/rs`` so they can be consumed by the engine's generic BAO routines.
-The conversion explicitly accounts for the relation :math:`D_V^3 = D_M^2 D_H z`
-and ``F_AP = D_M / D_H``. The accompanying covariance matrix is propagated
-through the variable transformation and the inverse covariance is attached to
-the resulting :class:`pandas.DataFrame`.
+The public BOSS DR12 release tabulates transverse distances
+``D_M(r_s^{\rm fid}/r_s)`` and Hubble parameters
+``H(z)(r_s/r_s^{\rm fid})`` for three redshift bins. This parser converts
+those quantities into the dimensionless observables ``D_M/r_s`` and
+``D_H/r_s`` (with ``D_H = c / H``) so they can be consumed by the
+engine's generic BAO routines. The published covariance matrix is
+propagated through this variable transformation and its inverse is
+attached to the returned :class:`pandas.DataFrame`.
+
+``D_V`` is a deterministic combination of ``D_M`` and ``D_H`` and would
+render the covariance matrix singular if included explicitly. The parser
+therefore omits ``D_V`` rows entirely while still allowing the engine to
+reconstruct ``D_V`` from ``D_M`` and ``D_H`` during evaluation.
 """
 
-import os
 import logging
+import os
+
 import numpy as np
 import pandas as pd
 
 from copernican_lib.data_loaders import register_bao_parser
 from copernican_lib.utils import load_metadata_from_dir
 
+
+# Directory containing the raw BOSS DR12 files and accompanying metadata.
 DATA_DIR = os.path.dirname(__file__)
 META = load_metadata_from_dir(DATA_DIR)
+
+
+# Reusable constants from the public release.  The sound horizon of the
+# fiducial cosmology is required to convert tabulated numbers to the
+# dimensionless form used internally by the suite.
+RS_FIDUCIAL_MPC = 147.78
+C_LIGHT = 299_792.458  # km/s
+
 
 DATASET_NAME = META.get("dataset_name", "BOSS DR12 BAO Consensus")
 DESCRIPTION = META.get(
@@ -30,11 +46,30 @@ DESCRIPTION = META.get(
 
 @register_bao_parser(DATASET_NAME, DESCRIPTION, data_dir=DATA_DIR)
 def parse_boss_dr12(data_dir, **kwargs):
-    """Return BAO observables and covariance from the BOSS DR12 release."""
+    """Return BAO observables and covariance from the BOSS DR12 release.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory that holds the published BOSS DR12 tables and
+        covariance matrices. This function assumes that
+        ``BAO_consensus_results_dM_Hz.txt`` and
+        ``BAO_consensus_covtot_dM_Hz.txt`` live inside that directory.
+
+    Returns
+    -------
+    pandas.DataFrame | None
+        DataFrame with ``DM_over_rs`` and ``DH_over_rs`` rows. The inverse
+        covariance matrix is attached to ``df.attrs['covariance_matrix_inv']``.
+        ``None`` is returned when any of the input files cannot be loaded
+        or when the covariance matrix fails to invert.
+    """
+
     logger = logging.getLogger()
 
-    results_path = os.path.join(data_dir, "BAO_consensus_results_dV_FAP.txt")
-    cov_path = os.path.join(data_dir, "BAO_consensus_covtot_dV_FAP.txt")
+    results_path = os.path.join(data_dir, "BAO_consensus_results_dM_Hz.txt")
+    cov_path = os.path.join(data_dir, "BAO_consensus_covtot_dM_Hz.txt")
+
     try:
         table = pd.read_csv(
             results_path,
@@ -43,28 +78,29 @@ def parse_boss_dr12(data_dir, **kwargs):
             header=None,
             names=["z", "label", "value"],
         )
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - file errors are logged
         logger.error(f"Failed reading BOSS DR12 results file: {exc}")
         return None
 
-    # Extract ``D_V/rs`` and ``F_AP`` pairs while preserving redshift order.
-    redshifts = []
-    dv_vals = []
-    fap_vals = []
+    # Extract ``dM`` and ``Hz`` pairs while preserving the redshift order.
+    redshifts: list[float] = []
+    dm_vals: list[float] = []
+    hz_vals: list[float] = []
     for _, row in table.iterrows():
-        if isinstance(row["label"], str) and row["label"].startswith("dV/rs"):
+        label = row["label"]
+        if isinstance(label, str) and label.startswith("dM"):
             redshifts.append(float(row["z"]))
-            dv_vals.append(float(row["value"]))
-        elif isinstance(row["label"], str) and row["label"].startswith("F_AP"):
-            fap_vals.append(float(row["value"]))
+            dm_vals.append(float(row["value"]))
+        elif isinstance(label, str) and label.startswith("Hz"):
+            hz_vals.append(float(row["value"]))
 
-    if not (len(redshifts) == len(dv_vals) == len(fap_vals)):
+    if not (len(redshifts) == len(dm_vals) == len(hz_vals)):
         logger.error("BOSS DR12 results file is malformed.")
         return None
 
     try:
         cov_x = np.loadtxt(cov_path)
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover
         logger.error(f"Failed reading BOSS DR12 covariance: {exc}")
         return None
 
@@ -72,58 +108,53 @@ def parse_boss_dr12(data_dir, **kwargs):
         logger.error("Unexpected BOSS DR12 covariance matrix size.")
         return None
 
-    # Vector ordering in the files: [DV1, FAP1, DV2, FAP2, DV3, FAP3]
+    # Vector ordering in the files: [dM1, Hz1, dM2, Hz2, dM3, Hz3]
     x_vec = np.empty(6)
-    x_vec[0::2] = dv_vals
-    x_vec[1::2] = fap_vals
+    x_vec[0::2] = dm_vals
+    x_vec[1::2] = hz_vals
 
     n_z = len(redshifts)
-    y_vec = np.empty(n_z * 3)
-    jac = np.zeros((n_z * 3, 6))
+    y_vec = np.empty(n_z * 2)
+    jac = np.zeros((n_z * 2, 6))
 
+    # Convert the published values into DM/rs and DH/rs and build the
+    # Jacobian for covariance propagation. The transformation is linear
+    # in ``dM`` and nonlinear in ``Hz`` owing to ``D_H = c / H``.
     for i in range(n_z):
-        dv = x_vec[2 * i]
-        fap = x_vec[2 * i + 1]
-        z = redshifts[i]
-        z_factor = z ** (1.0 / 3.0)
+        dM_file = x_vec[2 * i]
+        Hz_file = x_vec[2 * i + 1]
 
-        # Recover the transverse and radial distances.  The relationships
-        # follow from :math:`D_V^3 = D_M^2 D_H z` and ``F_AP = D_M / D_H``.
-        dm = dv * fap ** (1.0 / 3.0) / z_factor
-        dh = dv * fap ** (-2.0 / 3.0) / z_factor
-        y_vec[3 * i : 3 * i + 3] = [dm, dh, dv]
+        dm_over_rs = dM_file / RS_FIDUCIAL_MPC
+        dh_over_rs = C_LIGHT / (Hz_file * RS_FIDUCIAL_MPC)
 
-        # Jacobian for covariance propagation. Each block maps the original
-        # ``[DV, F_AP]`` pair to ``[DM, DH, DV]`` at the same redshift.
-        jac[3 * i, 2 * i] = fap ** (1.0 / 3.0) / z_factor
-        jac[3 * i, 2 * i + 1] = (1.0 / 3.0) * dv * fap ** (-2.0 / 3.0) / z_factor
-        jac[3 * i + 1, 2 * i] = fap ** (-2.0 / 3.0) / z_factor
-        jac[3 * i + 1, 2 * i + 1] = (-2.0 / 3.0) * dv * fap ** (-5.0 / 3.0) / z_factor
-        jac[3 * i + 2, 2 * i] = 1.0
-        jac[3 * i + 2, 2 * i + 1] = 0.0
+        y_vec[2 * i : 2 * i + 2] = [dm_over_rs, dh_over_rs]
 
-    # Propagate covariance and attempt to invert
+        jac[2 * i, 2 * i] = 1.0 / RS_FIDUCIAL_MPC
+        jac[2 * i + 1, 2 * i + 1] = -C_LIGHT / (Hz_file ** 2 * RS_FIDUCIAL_MPC)
+
+    # Propagate covariance and attempt to invert it. The transformation
+    # yields a well-conditioned 6x6 matrix because only the independent
+    # ``D_M`` and ``D_H`` measurements are kept.
     cov_y = jac @ cov_x @ jac.T
     diag = np.sqrt(np.diag(cov_y))
     try:
         cond = np.linalg.cond(cov_y)
         cov_inv = np.linalg.inv(cov_y) if np.isfinite(cond) and cond < 1e12 else None
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover
         logger.warning(f"BOSS DR12 covariance inversion failed: {exc}")
         cov_inv = None
 
     records = []
     for i, z in enumerate(redshifts):
-        dm = y_vec[3 * i]
-        dh = y_vec[3 * i + 1]
-        dv = y_vec[3 * i + 2]
+        dm = y_vec[2 * i]
+        dh = y_vec[2 * i + 1]
         records.append(
             {
                 "name": f"BOSS DR12 z={z} (DM/rs)",
                 "redshift": z,
                 "observable_type": "DM_over_rs",
                 "value": dm,
-                "error": diag[3 * i],
+                "error": diag[2 * i],
             }
         )
         records.append(
@@ -132,21 +163,13 @@ def parse_boss_dr12(data_dir, **kwargs):
                 "redshift": z,
                 "observable_type": "DH_over_rs",
                 "value": dh,
-                "error": diag[3 * i + 1],
-            }
-        )
-        records.append(
-            {
-                "name": f"BOSS DR12 z={z} (DV/rs)",
-                "redshift": z,
-                "observable_type": "DV_over_rs",
-                "value": dv,
-                "error": diag[3 * i + 2],
+                "error": diag[2 * i + 1],
             }
         )
 
     df = pd.DataFrame.from_records(records)
-    df.sort_values('redshift', inplace=True, ignore_index=True)
+    df.sort_values("redshift", inplace=True, ignore_index=True)
+
     df.attrs["covariance_matrix_inv"] = cov_inv
     df.attrs["diag_errors_for_plot"] = diag
     df.attrs["dataset_long_name"] = META.get("dataset_name", DATASET_NAME)
@@ -155,3 +178,4 @@ def parse_boss_dr12(data_dir, **kwargs):
     df.attrs["notes"] = META.get("notes", "")
     df.attrs["description"] = META.get("description", "")
     return df
+

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -41,4 +41,4 @@ inverse covariance is stored on the returned DataFrame.
 ### BOSS DR12 BAO Consensus (Alam et al. 2017)
 *Source:* "The clustering of galaxies in the completed SDSS-III Baryon Oscillation Spectroscopic Survey" (Alam et al. 2017).
 *Location:* `data/bao/bossdr12/`.
-*Parser:* `cosmo_parser_bossdr12.py` reads consensus $D_V/r_s$ and $F_{AP}$ values, converts them to $D_M/r_s$ and $D_H/r_s$ using $D_V^3 = D_M^2 D_H z$, and propagates the published covariance matrix.
+*Parser:* `cosmo_parser_bossdr12.py` converts the published $D_M(r_s^{fid}/r_s)$ and $H(z)(r_s/r_s^{fid})$ measurements into $D_M/r_s$ and $D_H/r_s$ while propagating their full covariance. The derived $D_V$ values are omitted to keep the covariance matrix invertible.


### PR DESCRIPTION
## Summary
- Parse BOSS DR12 consensus BAO data using the published covariance matrix by converting dM and H(z) entries to DM/rs and DH/rs
- Drop derived DV measurements to avoid a singular covariance matrix
- Document parser changes and note the update in the changelog

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_688f5b2d35b4832fb934c2242b07ecfa