### PR TITLE
test: add BOSS DR12 parser coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.3.4
+- 2025-08-03: Added regression test for BOSS DR12 BAO parser validating covariance handling and error paths (AI assistant)
+
 ## Version 3.3.3
 - 2025-08-03: Integrated full BOSS DR12 BAO covariance by combining dM/Hz and D_V/F_AP inputs; updated documentation and version (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.3.3
+**Version:** 3.3.4
 **Last Updated:** 2025-08-03
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.

--- a/copernican.py
+++ b/copernican.py
@@ -57,7 +57,7 @@ data_loaders = None
 # outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
 # unified exponent syntax across model YAML files and drops all
 # legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.3.3"
+COPERNICAN_VERSION = "3.3.4"
 CURRENT_LOG_FILE = None
 
 

--- a/tests/test_bossdr12_parser.py
+++ b/tests/test_bossdr12_parser.py
@@ -1,0 +1,60 @@
+"""Validate the BOSS DR12 BAO parser.
+
+This test confirms that the parser combines the two covariance matrices into a
+single 9x9 inverse covariance matrix and produces one row per observable at each
+of the three redshift bins. It also ensures that missing covariance files are
+reported via a ``None`` return value.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+import importlib.util
+from pathlib import Path
+
+
+class BossDR12ParserTestCase(unittest.TestCase):
+    """Exercise the ``parse_boss_dr12`` routine under normal and failure modes."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Dynamically import the parser directly from the data directory. This
+        # avoids mutating ``sys.path`` and keeps the tests self-contained.
+        base = Path(__file__).resolve().parents[1]
+        cls.data_dir = base / "data" / "bao" / "bossdr12"
+        spec = importlib.util.spec_from_file_location(
+            "cosmo_parser_bossdr12", cls.data_dir / "cosmo_parser_bossdr12.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        # Keep a reference to the imported module so its functions remain
+        # unbound and callable without additional ``self`` arguments.
+        cls.parser = module
+
+    def test_dataframe_shape_and_covariance(self):
+        """Parser should return nine observables with a 9x9 inverse covariance."""
+        df = self.parser.parse_boss_dr12(str(self.data_dir))
+        self.assertIsNotNone(df)
+        self.assertEqual(len(df), 9)
+        cov_inv = df.attrs.get("covariance_matrix_inv")
+        self.assertIsNotNone(cov_inv)
+        self.assertEqual(cov_inv.shape, (9, 9))
+
+    def test_missing_covariance_files(self):
+        """Dropping a covariance file should trigger graceful error handling."""
+        # Remove the dM/Hz covariance and expect ``None``.
+        with tempfile.TemporaryDirectory() as tmp:
+            shutil.copytree(self.data_dir, tmp, dirs_exist_ok=True)
+            os.remove(os.path.join(tmp, "BAO_consensus_covtot_dM_Hz.txt"))
+            self.assertIsNone(self.parser.parse_boss_dr12(tmp))
+
+        # Repeat for the D_V/F_AP covariance matrix.
+        with tempfile.TemporaryDirectory() as tmp:
+            shutil.copytree(self.data_dir, tmp, dirs_exist_ok=True)
+            os.remove(os.path.join(tmp, "BAO_consensus_covtot_dV_FAP.txt"))
+            self.assertIsNone(self.parser.parse_boss_dr12(tmp))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add regression test for BOSS DR12 parser that validates covariance and error handling
- bump suite version to 3.3.4 and document new test in the changelog

## Testing
- `python -m unittest tests/test_bossdr12_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_688f75f9cacc832f871e09aefbdcb23f