### PR TITLE
docs: note missing joint covariance for BOSS DR12 BAO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.3.5
+- 2025-08-03: Documented absence of joint covariance for BOSS DR12 data and parser's block-diagonal approach in docs and README (AI assistant)
+
 ## Version 3.3.4
 - 2025-08-03: Added regression test for BOSS DR12 BAO parser validating covariance handling and error paths (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -176,9 +176,12 @@ the same CMB calculation regardless of their own fitting scheme.
    selected, its parser and files are loaded automatically from
    `data/<type>/<source>/`. The CMB loader now understands TT, TE and EE
    spectra with full covariance so additional datasets can be dropped in with
-   minimal effort. The BOSS DR12 BAO parser combines the consensus dM, Hz,
-   $D_V$ and $F_{AP}$ measurements with their covariance matrices to yield
-   $D_M/r_s$, $D_H/r_s$ and $D_V/r_s$.
+  minimal effort. The BOSS DR12 BAO parser combines the consensus dM, Hz,
+  $D_V$ and $F_{AP}$ measurements with their covariance matrices to yield
+  $D_M/r_s$, $D_H/r_s$ and $D_V/r_s$. The public [SDSS DR12 archive](https://data.sdss.org/sas/dr12/boss/) does not provide a
+  joint covariance matrix for these observables, so `cosmo_parser_bossdr12.py`
+  follows a block-diagonal approach that assumes the $dM/Hz$ and $D_V/F_{AP}$
+  sets are uncorrelated.
 - Engines are selected interactively from the `engines/` directory. Parsers are
   discovered automatically when their source folders are imported.
 - After each run you may choose to evaluate another model or exit. Cache files

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -41,5 +41,4 @@ inverse covariance is stored on the returned DataFrame.
 ### BOSS DR12 BAO Consensus (Alam et al. 2017)
 *Source:* "The clustering of galaxies in the completed SDSS-III Baryon Oscillation Spectroscopic Survey" (Alam et al. 2017).
 *Location:* `data/bao/bossdr12/`.
-*Parser:* `cosmo_parser_bossdr12.py` combines the published $dM(rs_{\rm fid}/r_s)$, $Hz(r_s/rs_{\rm fid})$, $D_V/r_s$ and $F_{AP}$ measurements.
-These four inputs are converted to $D_M/r_s$, $D_H/r_s$ and $D_V/r_s$ while propagating their covariance matrices into a single $9\times9$ covariance.
+*Parser:* `cosmo_parser_bossdr12.py` combines the published $dM(rs_{\rm fid}/r_s)$, $Hz(r_s/rs_{\rm fid})$, $D_V/r_s$ and $F_{AP}$ measurements. The public [SDSS DR12 archive](https://data.sdss.org/sas/dr12/boss/) provides separate covariance matrices for the $dM/Hz$ and $D_V/F_{AP}$ sets but no joint covariance. Following the parser's block-diagonal rationale, these are assembled into a $9\times9$ matrix assuming the two inputs are uncorrelated and then converted to $D_M/r_s$, $D_H/r_s$ and $D_V/r_s$.


### PR DESCRIPTION
## Summary
- clarify that the SDSS BOSS DR12 BAO release ships separate covariance matrices without cross-covariance
- reference parser's block-diagonal combination of the dM/Hz and D_V/F_AP covariances
- mirror the covariance note in README and changelog

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_688f77635ef8832f97d75b96d9d8880c