### PR TITLE
Use updated author metadata key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.3.7
+- 2025-08-04: Updated metadata key references to use `author` and refreshed documentation; bumped version (AI assistant)
+
 ## Version 3.3.6
 - 2025-08-04: Added BibTeX metadata fields and updated citations across public datasets; refreshed documentation and version numbers (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.3.6
+**Version:** 3.3.7
 **Last Updated:** 2025-08-04
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -42,9 +42,10 @@ Each generated plot now includes a footer noting the comparison details,
 Copernican Suite version and a timestamp. Footer text is positioned
 dynamically so the canvas height grows when needed and never overlaps the
 plots.
-Dataset names, descriptions and citations are read from `metadata_*.yml` files stored
-next to each dataset. The program never hard-codes these values; instead the metadata
-is attached to the parsed DataFrame and used for plot footers and CSV headers.
+Dataset names, descriptions, author lists and citations are read from
+`metadata_*.yml` files stored next to each dataset. The program never
+hard-codes these values; instead the metadata is attached to the parsed
+DataFrame and used for plot footers and CSV headers.
 During configuration each loader prints a short summary including whether the
 dataset's covariance matrix was inverted successfully or if diagonal errors are
 being used.

--- a/copernican.py
+++ b/copernican.py
@@ -57,7 +57,7 @@ data_loaders = None
 # outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
 # unified exponent syntax across model YAML files and drops all
 # legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.3.6"
+COPERNICAN_VERSION = "3.3.7"
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -72,14 +72,21 @@ def get_binned_average(
 
 
 def compose_footer(base_line: str, data_attrs: dict) -> list[str]:
-    """Return footer lines with dataset information."""
+    """Return footer lines with dataset information.
+
+    The footer annotates each plot with the dataset name, optional notes,
+    full author list and a formatted citation.
+    """
 
     long_name = data_attrs.get(
         "dataset_long_name", data_attrs.get("dataset_name_attr", "")
     )
+    # Pull the full author list from the ``author`` field so plot footers
+    # can display the complete citation details.
+    authors = data_attrs.get("author", "")
     notes = data_attrs.get("notes", "")
     citation = data_attrs.get("citation", "")
-    second_line = f"{_wrap_math(long_name)}: {notes} {citation}".strip()
+    second_line = f"{_wrap_math(long_name)}: {notes} {authors} {citation}".strip()
     # Allow more characters per line so lengthy citations do not wrap
     # excessively. Each wrapped line will be drawn separately with a
     # slightly smaller font size by the caller.


### PR DESCRIPTION
## Summary
- include author list in plot footers using `author` metadata key
- document author metadata and bump Copernican Suite version to 3.3.7

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_6890179f55fc832f91e89fce8e28e756