### PR TITLE
Centralize dataset metadata loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ package and will exit cleanly even when Matplotlib has not yet been imported.
 ```
 models/           - YAML model definitions with embedded theory text and equations.
 engines/          - Computational backends (SciPy CPU by default)
-data/             - Observation files under ``data/<type>/<source>/``. Each dataset directory includes a `metadata_*.yml` file with `dataset_name`, `description`, `citation`, the full `author` list and BibTeX keys such as `title`, `volume`, `journal` and `DOI`.
+data/             - Observation files under ``data/<type>/<source>/``. Each dataset directory includes a `metadata_*.yml` file with `dataset_name`, `description`, `citation`, the full `author` list and BibTeX keys such as `title`, `volume`, `journal` and `DOI`. Metadata is loaded exclusively by `copernican_lib/data_loaders.py` after each parser runs.
   cmb/planck2018lite/ - Planck 2018 lite TT/TE/EE spectra and covariance
 output/           - Generated plots and CSV tables (created automatically)
 AGENTS.md         - Development specification and contributor rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.4.0
+- 2025-08-04: Centralised dataset metadata loading in `data_loaders.py`, removed metadata handling from parsers and updated documentation (AI assistant)
+
 ## Version 3.3.8
 - 2025-08-04: Replaced dataset name attributes with `dataset_name_sanitized`, preserved original `dataset_name`, and refreshed documentation (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ dynamically so the canvas height grows when needed and never overlaps the
 plots.
 Dataset names, descriptions, author lists and citations are read from
 `metadata_*.yml` files stored next to each dataset. The program never
-hard-codes these values; instead the metadata is attached to the parsed
-DataFrame and used for plot footers and CSV headers.
+hard-codes these values; `copernican_lib/data_loaders.py` reads the metadata
+after invoking each parser and attaches it to the returned DataFrame for plot
+footers and CSV headers. Individual parsers no longer access metadata files
+directly.
 During configuration each loader prints a short summary including whether the
 dataset's covariance matrix was inverted successfully or if diagonal errors are
 being used.

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -11,6 +11,7 @@ import os
 import logging
 import importlib
 from . import console_output as console
+from .utils import load_metadata_from_dir
 
 # --- Parser Registry ---
 # Each registry maps a short human readable key to a dictionary
@@ -25,10 +26,17 @@ SIREN_PARSERS: dict = {}
 
 
 # --- Decorators to register parsers ---
-def register_sne_parser(name, description="", data_dir=None):
-    """Decorator to register a SNe data parsing function bound to a data source."""
+def register_sne_parser(name=None, description="", data_dir=None):
+    """Decorator to register a SNe data parsing function bound to a data source.
+
+    The registration no longer requires the human readable dataset name or
+    description up front. When ``name`` is ``None`` the base name of
+    ``data_dir`` is used as a temporary key and replaced with the metadata
+    ``dataset_name`` during discovery.
+    """
     def decorator(func):
-        SNE_PARSERS[name] = {
+        key = name or os.path.basename(data_dir or func.__name__)
+        SNE_PARSERS[key] = {
             'function': func,
             'description': description,
             'data_dir': data_dir,
@@ -36,10 +44,16 @@ def register_sne_parser(name, description="", data_dir=None):
         return func
     return decorator
 
-def register_bao_parser(name, description="", data_dir=None):
-    """Decorator to register a BAO data parsing function bound to a data source."""
+def register_bao_parser(name=None, description="", data_dir=None):
+    """Decorator to register a BAO data parsing function bound to a data source.
+
+    When ``name`` is ``None`` the dataset directory name is used as a temporary
+    key and replaced with the metadata-supplied ``dataset_name`` during
+    discovery.
+    """
     def decorator(func):
-        BAO_PARSERS[name] = {
+        key = name or os.path.basename(data_dir or func.__name__)
+        BAO_PARSERS[key] = {
             'function': func,
             'description': description,
             'data_dir': data_dir,
@@ -47,10 +61,15 @@ def register_bao_parser(name, description="", data_dir=None):
         return func
     return decorator
 
-def register_cmb_parser(name, description="", data_dir=None):
-    """Decorator to register a CMB data parsing function bound to a data source."""
+def register_cmb_parser(name=None, description="", data_dir=None):
+    """Decorator to register a CMB data parsing function bound to a data source.
+
+    When ``name`` is omitted the dataset directory name acts as a temporary key
+    until discovery replaces it with the metadata ``dataset_name``.
+    """
     def decorator(func):
-        CMB_PARSERS[name] = {
+        key = name or os.path.basename(data_dir or func.__name__)
+        CMB_PARSERS[key] = {
             'function': func,
             'description': description,
             'data_dir': data_dir,
@@ -58,10 +77,14 @@ def register_cmb_parser(name, description="", data_dir=None):
         return func
     return decorator
 
-def register_gw_parser(name, description="", data_dir=None):
-    """Decorator to register a gravitational wave data parsing function bound to a data source."""
+def register_gw_parser(name=None, description="", data_dir=None):
+    """Decorator to register a gravitational wave parser bound to a data source.
+
+    Omitting ``name`` defers human-readable naming to metadata discovery.
+    """
     def decorator(func):
-        GW_PARSERS[name] = {
+        key = name or os.path.basename(data_dir or func.__name__)
+        GW_PARSERS[key] = {
             'function': func,
             'description': description,
             'data_dir': data_dir,
@@ -69,10 +92,15 @@ def register_gw_parser(name, description="", data_dir=None):
         return func
     return decorator
 
-def register_siren_parser(name, description="", data_dir=None):
-    """Decorator to register a standard siren data parsing function bound to a data source."""
+def register_siren_parser(name=None, description="", data_dir=None):
+    """Decorator to register a standard siren parser bound to a data source.
+
+    When ``name`` is ``None`` the dataset directory name serves as a temporary
+    key and is replaced with the metadata ``dataset_name`` during discovery.
+    """
     def decorator(func):
-        SIREN_PARSERS[name] = {
+        key = name or os.path.basename(data_dir or func.__name__)
+        SIREN_PARSERS[key] = {
             'function': func,
             'description': description,
             'data_dir': data_dir,
@@ -82,11 +110,21 @@ def register_siren_parser(name, description="", data_dir=None):
 
 # --- Dynamic Discovery of Parser Modules ---
 def _discover_parsers():
-    """Imports parser modules stored within ``data/<type>/<source>`` directories."""
+    """Import parser modules and populate registries with dataset metadata."""
     # Parser modules register themselves in the dictionaries above when
     # imported.  Automatically scanning the data directory keeps the core
-    # code agnostic to the exact set of available sources.
+    # code agnostic to the exact set of available sources.  Metadata is
+    # read here rather than inside the parser modules so that discovery and
+    # user prompts present human readable dataset names without forcing the
+    # parsers to access the metadata files themselves.
     base_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data')
+    registry_map = {
+        'sne': SNE_PARSERS,
+        'bao': BAO_PARSERS,
+        'cmb': CMB_PARSERS,
+        'gw': GW_PARSERS,
+        'sirens': SIREN_PARSERS,
+    }
     for dtype in ('sne', 'bao', 'cmb', 'gw', 'sirens'):
         type_dir = os.path.join(base_dir, dtype)
         if not os.path.isdir(type_dir):
@@ -99,6 +137,8 @@ def _discover_parsers():
             src_dir = os.path.join(type_dir, source)
             if not os.path.isdir(src_dir):
                 continue
+            meta = load_metadata_from_dir(src_dir)
+            placeholder_key = os.path.basename(src_dir)
             for fname in os.listdir(src_dir):
                 if fname.startswith('cosmo_parser_') and fname.endswith('.py'):
                     module_name = f"data.{dtype}.{source}.{fname[:-3]}"
@@ -109,6 +149,21 @@ def _discover_parsers():
                         spec.loader.exec_module(module)
                     except Exception as e:
                         logging.getLogger().error(f"Failed loading parser module {file_path}: {e}")
+                    registry = registry_map[dtype]
+                    if placeholder_key in registry:
+                        entry = registry.pop(placeholder_key)
+                        dataset_name = meta.get('dataset_name', placeholder_key)
+                        entry['description'] = meta.get('description', entry.get('description', ''))
+                        entry['data_dir'] = src_dir
+                        registry[dataset_name] = entry
+                    # If the parser registered with an explicit name, simply
+                    # update the description if metadata provides one.
+                    else:
+                        dataset_name = meta.get('dataset_name')
+                        if dataset_name and dataset_name in registry:
+                            registry[dataset_name]['description'] = meta.get(
+                                'description', registry[dataset_name].get('description', '')
+                            )
 
 # Discover parsers at import time so that functions like
 # ``load_sne_data`` can simply refer to the registries without
@@ -148,14 +203,15 @@ def _log_dataset_info(df, data_type, logger):
     """Log summary and covariance usage for ``df``."""
     # Centralised helper so that every loader reports consistent
     # information about the dataset and whether a covariance matrix was
-    # actually used.  The attributes are attached by the individual
-    # parser modules.
+    # actually used.  ``load_*_data`` attaches all metadata via
+    # :func:`load_metadata_from_dir` so the log entries rely solely on the
+    # DataFrame attributes.
     if df is None or df.empty:
         return
     # Prefer the human-readable dataset name but fall back to the sanitized
-    # identifier when only that field is available.  Parsers are expected to
-    # attach both ``dataset_name`` (original string) and
-    # ``dataset_name_sanitized`` (underscored variant).
+    # identifier when only that field is available.  Loaders attach both
+    # ``dataset_name`` (original string) and ``dataset_name_sanitized``
+    # (underscored variant).
     name = df.attrs.get("dataset_name", df.attrs.get("dataset_name_sanitized", ""))
     logger.info(f"Loaded {data_type} dataset '{name}' with {len(df)} rows.")
     if "covariance_matrix_inv" in df.attrs:
@@ -185,9 +241,13 @@ def load_sne_data(source_key=None, **kwargs):
         logger.info(f"Attempting to load SNe data from source '{source_key}'")
         data_df = parser_func(data_dir, **kwargs)
         if data_df is not None and not data_df.empty:
+            meta = load_metadata_from_dir(data_dir)
+            if meta:
+                data_df.attrs.update(meta)
             data_df.attrs['source_key'] = source_key
-            if 'dataset_name_sanitized' not in data_df.attrs:
-                data_df.attrs['dataset_name_sanitized'] = f"SNe_{source_key.replace(' ', '_')}"
+            dataset_name = data_df.attrs.get('dataset_name', source_key)
+            data_df.attrs['dataset_name'] = dataset_name
+            data_df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
             logger.info(f"Successfully loaded {len(data_df)} SNe data points.")
             _log_dataset_info(data_df, "SNe", logger)
         elif data_df is None:
@@ -219,9 +279,13 @@ def load_bao_data(source_key=None, **kwargs):
         logger.info(f"Attempting to load BAO data from source '{source_key}'")
         data_df = parser_func(data_dir, **kwargs)
         if data_df is not None and not data_df.empty:
+            meta = load_metadata_from_dir(data_dir)
+            if meta:
+                data_df.attrs.update(meta)
             data_df.attrs['source_key'] = source_key
-            if 'dataset_name_sanitized' not in data_df.attrs:
-                data_df.attrs['dataset_name_sanitized'] = f"BAO_{source_key.replace(' ', '_')}"
+            dataset_name = data_df.attrs.get('dataset_name', source_key)
+            data_df.attrs['dataset_name'] = dataset_name
+            data_df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
             logger.info(f"Successfully loaded {len(data_df)} BAO data points.")
             _log_dataset_info(data_df, "BAO", logger)
         elif data_df is None:
@@ -253,9 +317,13 @@ def load_cmb_data(source_key=None, **kwargs):
         logger.info(f"Attempting to load CMB data from source '{source_key}'")
         data_df = parser_func(data_dir, **kwargs)
         if data_df is not None and not data_df.empty:
+            meta = load_metadata_from_dir(data_dir)
+            if meta:
+                data_df.attrs.update(meta)
             data_df.attrs['source_key'] = source_key
-            if 'dataset_name_sanitized' not in data_df.attrs:
-                data_df.attrs['dataset_name_sanitized'] = f"CMB_{source_key.replace(' ', '_')}"
+            dataset_name = data_df.attrs.get('dataset_name', source_key)
+            data_df.attrs['dataset_name'] = dataset_name
+            data_df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
             logger.info(f"Successfully loaded {len(data_df)} CMB data points.")
             _log_dataset_info(data_df, "CMB", logger)
         elif data_df is None:
@@ -287,9 +355,13 @@ def load_gw_data(source_key=None, **kwargs):
         logger.info(f"Attempting to load GW data from source '{source_key}'")
         data_df = parser_func(data_dir, **kwargs)
         if data_df is not None and not data_df.empty:
+            meta = load_metadata_from_dir(data_dir)
+            if meta:
+                data_df.attrs.update(meta)
             data_df.attrs['source_key'] = source_key
-            if 'dataset_name_sanitized' not in data_df.attrs:
-                data_df.attrs['dataset_name_sanitized'] = f"GW_{source_key.replace(' ', '_')}"
+            dataset_name = data_df.attrs.get('dataset_name', source_key)
+            data_df.attrs['dataset_name'] = dataset_name
+            data_df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
             logger.info(f"Successfully loaded {len(data_df)} GW data points.")
             _log_dataset_info(data_df, "GW", logger)
         elif data_df is None:
@@ -321,9 +393,13 @@ def load_siren_data(source_key=None, **kwargs):
         logger.info(f"Attempting to load siren data from source '{source_key}'")
         data_df = parser_func(data_dir, **kwargs)
         if data_df is not None and not data_df.empty:
+            meta = load_metadata_from_dir(data_dir)
+            if meta:
+                data_df.attrs.update(meta)
             data_df.attrs['source_key'] = source_key
-            if 'dataset_name_sanitized' not in data_df.attrs:
-                data_df.attrs['dataset_name_sanitized'] = f"SIREN_{source_key.replace(' ', '_')}"
+            dataset_name = data_df.attrs.get('dataset_name', source_key)
+            data_df.attrs['dataset_name'] = dataset_name
+            data_df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
             logger.info(f"Successfully loaded {len(data_df)} standard siren data points.")
             _log_dataset_info(data_df, "SIREN", logger)
         elif data_df is None:

--- a/copernican_lib/utils.py
+++ b/copernican_lib/utils.py
@@ -70,6 +70,9 @@ def load_metadata_from_dir(data_dir: str) -> dict:
     The loader looks for a file starting with ``metadata`` and ending in
     ``.yml`` or ``.yaml``. JSON files were supported in earlier versions but
     have been removed to keep the format consistent across the project.
+    Some legacy metadata files contain unquoted values with embedded colons,
+    e.g. URLs. ``yaml.safe_load`` rejects such scalars so a simple
+    line-by-line fallback parser is used when the strict loader fails.
     """
     try:
         meta_files = [
@@ -79,8 +82,21 @@ def load_metadata_from_dir(data_dir: str) -> dict:
             and f.lower().endswith((".yml", ".yaml"))
         ]
         if meta_files:
-            with open(os.path.join(data_dir, sorted(meta_files)[0]), "r") as fh:
-                return yaml.safe_load(fh)
+            path = os.path.join(data_dir, sorted(meta_files)[0])
+            try:
+                with open(path, "r") as fh:
+                    return yaml.safe_load(fh)
+            except Exception:
+                # Fallback: parse ``key: value`` pairs manually so that
+                # unquoted URLs or other colon-containing values do not break
+                # metadata loading.
+                meta = {}
+                with open(path, "r") as fh:
+                    for line in fh:
+                        if ":" in line:
+                            key, val = line.strip().split(":", 1)
+                            meta[key.strip()] = val.strip()
+                return meta
     except Exception:
         pass
     return {}

--- a/data/bao/bossdr12/cosmo_parser_bossdr12.py
+++ b/data/bao/bossdr12/cosmo_parser_bossdr12.py
@@ -23,7 +23,6 @@ import numpy as np
 import pandas as pd
 
 from copernican_lib.data_loaders import register_bao_parser
-from copernican_lib.utils import load_metadata_from_dir
 
 # Speed of light in km/s used to convert ``H(z)`` into ``D_H``.
 C_LIGHT = 299792.458
@@ -35,16 +34,9 @@ C_LIGHT = 299792.458
 RS_FIDUCIAL_MPC = 147.78
 
 DATA_DIR = os.path.dirname(__file__)
-META = load_metadata_from_dir(DATA_DIR)
-
-DATASET_NAME = META.get("dataset_name", "BOSS DR12 BAO Consensus")
-DESCRIPTION = META.get(
-    "description",
-    "BOSS DR12 consensus BAO distances with full covariance from dM/Hz and D_V/F_AP measurements.",
-)
 
 
-@register_bao_parser(DATASET_NAME, DESCRIPTION, data_dir=DATA_DIR)
+@register_bao_parser(data_dir=DATA_DIR)
 def parse_boss_dr12(data_dir, **kwargs):
     """Return BAO observables and covariance from the BOSS DR12 release."""
 
@@ -246,10 +238,7 @@ def parse_boss_dr12(data_dir, **kwargs):
     df.sort_values("redshift", inplace=True, ignore_index=True)
     df.attrs["covariance_matrix_inv"] = cov_inv
     df.attrs["diag_errors_for_plot"] = diag
-    df.attrs["dataset_name"] = META.get("dataset_name", DATASET_NAME)
-    df.attrs["dataset_name_sanitized"] = df.attrs["dataset_name"].replace(" ", "_")
-    df.attrs["citation"] = META.get("citation", "")
-    df.attrs["notes"] = META.get("notes", "")
-    df.attrs["description"] = META.get("description", "")
+    # Metadata such as dataset name and citation is attached by
+    # ``load_bao_data`` after this function returns.
     return df
 

--- a/data/bao/compound/cosmo_parser_compound.py
+++ b/data/bao/compound/cosmo_parser_compound.py
@@ -1,16 +1,17 @@
 
-r"""Parse the *compound* BAO dataset and attach metadata.
+r"""Parse the *compound* BAO dataset.
 
 This parser is intentionally lightweight and makes no assumptions about the
 cosmological model. It simply reads the YAML table located in ``data_dir`` and
 returns a :class:`pandas.DataFrame` with the expected columns. A matching
 ``metadata_*.yml`` file supplies the human readable dataset name and
-documentation strings. The compound dataset does **not** ship with a
-covariance matrix; uncertainties are therefore treated as uncorrelated and the
-engine falls back to a diagonal covariance during the :math:`\chi^2`
-evaluation. A ``rs_fiducial_Mpc`` column may appear in some entries but is
-retained only for reference—no unit conversion is performed so that published
-values are used directly without risking double scaling.
+documentation strings which are attached by
+``copernican_lib.data_loaders.load_bao_data``. The compound dataset does
+**not** ship with a covariance matrix; uncertainties are therefore treated as
+uncorrelated and the engine falls back to a diagonal covariance during the
+:math:`\chi^2` evaluation. A ``rs_fiducial_Mpc`` column may appear in some
+entries but is retained only for reference—no unit conversion is performed so
+that published values are used directly without risking double scaling.
 """
 
 import os
@@ -19,25 +20,13 @@ import yaml
 import logging
 
 from copernican_lib.data_loaders import register_bao_parser
-from copernican_lib.utils import load_metadata_from_dir
 
 DATA_DIR = os.path.dirname(__file__)
-META = load_metadata_from_dir(DATA_DIR)
-
-DATASET_NAME = META.get("dataset_name", "BAO dataset")
-DESCRIPTION = META.get(
-    "description",
-    "Compilation of baryon acoustic oscillation measurements.",
-)
 
 
-@register_bao_parser(
-    DATASET_NAME,
-    DESCRIPTION,
-    data_dir=DATA_DIR,
-)
+@register_bao_parser(data_dir=DATA_DIR)
 def parse_bao_v1(data_dir, **kwargs):
-    """Parse a BAO dataset and attach metadata."""
+    """Parse a BAO dataset defined in a small YAML table."""
     logger = logging.getLogger()
     data_files = [
         f
@@ -71,15 +60,9 @@ def parse_bao_v1(data_dir, **kwargs):
         if df.empty:
             logger.error(f"No valid BAO data points after parsing {filepath}."); return None
 
-        meta = META
-
-        dataset_name = meta.get('dataset_name', data_json.get('name', f"BAO_{os.path.basename(filepath)}"))
-        df.attrs['citation'] = meta.get('citation', data_json.get('citation', 'N/A'))
-        df.attrs['notes'] = meta.get('notes', data_json.get('notes', 'N/A'))
-        df.attrs['description'] = meta.get('description', '')
-        df.attrs['dataset_name'] = dataset_name
-        df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
-
+        # Metadata such as dataset name, citation and notes is loaded by
+        # ``load_bao_data`` and attached to the DataFrame after this function
+        # returns.
         return df
     except Exception as e:
         logger.error(

--- a/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
+++ b/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
@@ -10,23 +10,11 @@ import numpy as np
 import pandas as pd
 
 from copernican_lib.data_loaders import register_cmb_parser
-from copernican_lib.utils import load_metadata_from_dir
 
 DATA_DIR = os.path.dirname(__file__)
-META = load_metadata_from_dir(DATA_DIR)
-
-DATASET_NAME = META.get("dataset_name", "Planck 2018 Lite TT/TE/EE").replace("\\", "")
-DESCRIPTION = META.get(
-    "description",
-    "Planck 2018 lite TT/TE/EE spectra.",
-)
 
 
-@register_cmb_parser(
-    DATASET_NAME,
-    DESCRIPTION,
-    data_dir=DATA_DIR,
-)
+@register_cmb_parser(data_dir=DATA_DIR)
 def parse_planck2018lite(data_dir, **kwargs):
     """Parse Planck 2018 lite power spectrum and covariance."""
 
@@ -139,13 +127,9 @@ def parse_planck2018lite(data_dir, **kwargs):
 
         df.attrs["covariance_matrix_inv"] = cov_inv
         df.attrs["diag_errors_for_plot"] = diag_errors
-        dataset_name = META.get("dataset_name", "CMB_Planck2018lite")
-        df.attrs["dataset_name"] = dataset_name
-        df.attrs["dataset_name_sanitized"] = dataset_name.replace(" ", "_")
-        df.attrs["citation"] = META.get("citation", "")
-        df.attrs["notes"] = META.get("notes", "")
-        df.attrs["description"] = META.get("description", "")
         df.attrs["is_cmb"] = True
+        # Metadata including dataset name and citation is attached by
+        # ``load_cmb_data`` after this function returns.
         # Map the order of CAMB parameters used by the engine
         df.attrs["param_names"] = [
             "H0",

--- a/data/gw/placeholder/cosmo_parser_gw_placeholder.py
+++ b/data/gw/placeholder/cosmo_parser_gw_placeholder.py
@@ -3,18 +3,11 @@
 import logging
 import os
 from copernican_lib.data_loaders import register_gw_parser
-from copernican_lib.utils import load_metadata_from_dir
 
 DATA_DIR = os.path.dirname(__file__)
-META = load_metadata_from_dir(DATA_DIR)
 
-DATASET_NAME = META.get("dataset_name", "GW Placeholder")
-DESCRIPTION = META.get(
-    "description",
-    "Placeholder GW parser.",
-)
 
-@register_gw_parser(DATASET_NAME, DESCRIPTION, data_dir=DATA_DIR)
+@register_gw_parser(data_dir=DATA_DIR)
 def parse_gw_placeholder(data_dir, **kwargs):
     """Stub parser that logs a message and returns None."""
     # Gravitational wave support is under development. This stub allows the rest

--- a/data/sirens/placeholder/cosmo_parser_sirens_placeholder.py
+++ b/data/sirens/placeholder/cosmo_parser_sirens_placeholder.py
@@ -3,18 +3,11 @@
 import logging
 import os
 from copernican_lib.data_loaders import register_siren_parser
-from copernican_lib.utils import load_metadata_from_dir
 
 DATA_DIR = os.path.dirname(__file__)
-META = load_metadata_from_dir(DATA_DIR)
 
-DATASET_NAME = META.get("dataset_name", "Standard Siren Placeholder")
-DESCRIPTION = META.get(
-    "description",
-    "Placeholder standard siren parser.",
-)
 
-@register_siren_parser(DATASET_NAME, DESCRIPTION, data_dir=DATA_DIR)
+@register_siren_parser(data_dir=DATA_DIR)
 def parse_siren_placeholder(data_dir, **kwargs):
     """Stub parser that logs a message and returns None."""
     # Placeholder to keep the API consistent while actual siren datasets are

--- a/data/sne/jla2014/cosmo_parser_jla2014.py
+++ b/data/sne/jla2014/cosmo_parser_jla2014.py
@@ -13,16 +13,8 @@ import logging
 from astropy.io import fits
 
 from copernican_lib.data_loaders import register_sne_parser
-from copernican_lib.utils import load_metadata_from_dir
 
 DATA_DIR = os.path.dirname(__file__)
-META = load_metadata_from_dir(DATA_DIR)
-
-DATASET_NAME = META.get("dataset_name", "JLA 2014").replace("\\", "")
-DESCRIPTION = META.get(
-    "description",
-    "Joint SDSS-II and SNLS supernova sample (Betoule et al. 2014).",
-)
 
 # SALT2 nuisance parameters used to convert light-curve fits into
 # distance moduli.  The Betoule et al. analysis reports best-fit
@@ -34,11 +26,7 @@ DEFAULT_SALT2_ALPHA_FIXED = 0.141
 DEFAULT_SALT2_BETA_FIXED = 3.101
 
 
-@register_sne_parser(
-    DATASET_NAME,
-    DESCRIPTION,
-    data_dir=DATA_DIR,
-)
+@register_sne_parser(data_dir=DATA_DIR)
 def parse_jla2014(
     data_dir,
     salt2_m_abs_fixed=DEFAULT_SALT2_M_ABS_FIXED,
@@ -172,12 +160,6 @@ def parse_jla2014(
     parsed.attrs["salt2_m_abs_fixed"] = salt2_m_abs_fixed
     parsed.attrs["salt2_alpha_fixed"] = salt2_alpha_fixed
     parsed.attrs["salt2_beta_fixed"] = salt2_beta_fixed
-    long_name = META.get("dataset_name", "JLA2014").replace("\\", "")
-    parsed.attrs["dataset_name"] = long_name
-    parsed.attrs["dataset_name_sanitized"] = long_name.replace(
-        " ", "_"
-    )
-    parsed.attrs["citation"] = META.get("citation", "")
-    parsed.attrs["notes"] = META.get("notes", "")
-    parsed.attrs["description"] = META.get("description", "")
+    # Metadata such as dataset name and citation is attached by
+    # ``load_sne_data`` after this function returns.
     return parsed

--- a/data/sne/pantheon/cosmo_parser_pantheon.py
+++ b/data/sne/pantheon/cosmo_parser_pantheon.py
@@ -6,23 +6,11 @@ import numpy as np
 import logging
 
 from copernican_lib.data_loaders import register_sne_parser
-from copernican_lib.utils import load_metadata_from_dir
 
 DATA_DIR = os.path.dirname(__file__)
-META = load_metadata_from_dir(DATA_DIR)
-
-DATASET_NAME = META.get("dataset_name", "Pantheon+ dataset").replace("\\", "")
-DESCRIPTION = META.get(
-    "description",
-    "Supernova distances with full covariance matrix.",
-)
 
 
-@register_sne_parser(
-    DATASET_NAME,
-    DESCRIPTION,
-    data_dir=DATA_DIR,
-)
+@register_sne_parser(data_dir=DATA_DIR)
 def parse_pantheon_plus(data_dir, **kwargs):
     """Parse Pantheon+ data and its covariance matrix."""
     logger = logging.getLogger()
@@ -127,12 +115,9 @@ def parse_pantheon_plus(data_dir, **kwargs):
             )
             output_df.attrs["covariance_matrix_inv"] = None
             output_df.attrs["diag_errors_for_plot"] = output_df["e_mu_obs"].values
-        long_name = META.get("dataset_name", "PantheonPlus2022").replace("\\", "")
-        output_df.attrs["dataset_name"] = long_name
-        output_df.attrs["dataset_name_sanitized"] = long_name.replace(" ", "_")
-        output_df.attrs["citation"] = META.get("citation", "")
-        output_df.attrs["notes"] = META.get("notes", "")
-        output_df.attrs["description"] = META.get("description", "")
+        # Metadata such as dataset name and citation is attached later by the
+        # loader. Only the numerical data and covariance information are
+        # handled here.
         return output_df
     except Exception as e:
         logger.error(f"Error processing Pantheon+ data: {e}", exc_info=True)

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -35,9 +35,10 @@ from the model YAML.
 
 All data parsers return a ``pandas.DataFrame`` with common columns and
 metadata so that engines remain agnostic to the origin of the data.
-Metadata is read from ``metadata_*.yml`` files located next to the
-dataset tables and attached via the ``DataFrame.attrs`` dictionary.  For
-supernovae datasets the table contains at minimum ``Name``, ``zcmb``,
+`copernican_lib/data_loaders.py` reads ``metadata_*.yml`` files located next to
+the dataset tables and attaches the fields via the ``DataFrame.attrs``
+dictionary after the parser returns. For supernovae datasets the table contains
+at minimum ``Name``, ``zcmb``,
 ``mu_obs`` and ``e_mu_obs``. Attributes such as ``covariance_matrix_inv``
 and ``diag_errors_for_plot`` are also attached. BAO and CMB loaders
 follow the same pattern. New datasets can therefore be added simply by

--- a/docs/bao_compound_dataset_format.md
+++ b/docs/bao_compound_dataset_format.md
@@ -2,7 +2,7 @@
 
 This document describes the YAML format used for the **compound** BAO dataset shipped with the Copernican Suite. The folder lives under `data/bao/compound/` and mirrors the structure expected for real BAO sources. JSON files were supported in early versions but have now been removed so that all datasets use a single YAML representation.
 
-Each dataset is stored in its own directory and contains a single YAML file with a `data_points` array. The parser also looks for an optional `metadata_*.yml` file which mirrors the structure used for real datasets, including BibTeX fields. The compound dataset lets developers exercise the BAO pipeline without downloading large public releases. A covariance matrix is intentionally omitted; uncertainties are treated as uncorrelated.
+Each dataset is stored in its own directory and contains a single YAML file with a `data_points` array. An optional `metadata_*.yml` file mirrors the structure used for real datasets, including BibTeX fields. The data loader reads this metadata after parsing so the parser itself remains trivial. The compound dataset lets developers exercise the BAO pipeline without downloading large public releases. A covariance matrix is intentionally omitted; uncertainties are treated as uncorrelated.
 
 Example `compound.yml`:
 ```yaml
@@ -38,4 +38,4 @@ pages: N/A
 notes: Observable types: DV_over_rs (D_V(z)/r_s), DM_over_rs (D_M(z)/r_s), DH_over_rs (D_H(z)/r_s = c/(H(z) r_s)). All r_s values are the model's sound horizon at the drag epoch unless a fiducial r_s is specified. No covariance matrix is available; uncertainties are treated as uncorrelated.
 ```
 
-All observable types use the naming convention `DV_over_rs`, `DM_over_rs` or `DH_over_rs` to indicate $D_V$, $D_M$ or $D_H$ divided by the sound horizon. The parser converts the YAML to a Pandas `DataFrame` and attaches the metadata to the `.attrs` attribute. In addition to the original `dataset_name`, a sanitized version `dataset_name_sanitized` replaces spaces with underscores for safe filenames. The same `metadata_*.yml` structure with `dataset_name`, `description`, `citation`, the `author` list and other BibTeX fields is used for **all** datasets so plot footers can display consistent source information.
+All observable types use the naming convention `DV_over_rs`, `DM_over_rs` or `DH_over_rs` to indicate $D_V$, $D_M$ or $D_H$ divided by the sound horizon. The parser converts the YAML to a Pandas `DataFrame` and the data loader attaches the metadata to the `.attrs` attribute. In addition to the original `dataset_name`, a sanitized version `dataset_name_sanitized` replaces spaces with underscores for safe filenames. The same `metadata_*.yml` structure with `dataset_name`, `description`, `citation`, the `author` list and other BibTeX fields is used for **all** datasets so plot footers can display consistent source information.

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -17,11 +17,13 @@ Each subdirectory contains one or more dataset sources. A Python file named `cos
 Every dataset folder also provides a `metadata_*.yml` describing the
 source. Fields such as `dataset_name`, `description`, `citation`, the full
 `author` list and accompanying BibTeX information (for example `title`,
-`volume`, `journal` and `DOI`) are loaded dynamically so no parser
-hard-codes them. Parsed DataFrames expose the same information on their
-`.attrs` property and include `dataset_name_sanitized`, where spaces are
-replaced by underscores for safe filenames. See `dataset_metadata.md` for a
-full description of these fields. The reference files remain read-only.
+`volume`, `journal` and `DOI`) are read by
+`copernican_lib/data_loaders.py` after the parser returns so individual
+parsers remain metadata-agnostic. Parsed DataFrames expose the same
+information on their `.attrs` property and include `dataset_name_sanitized`,
+where spaces are replaced by underscores for safe filenames. See
+`dataset_metadata.md` for a full description of these fields. The reference
+files remain read-only.
 
 ## Supernovae Datasets
 

--- a/docs/dataset_metadata.md
+++ b/docs/dataset_metadata.md
@@ -24,9 +24,10 @@ source. All fields are optional except for `dataset_name` and
 - `pages` -- Page range or article number.
 - `notes` -- Additional free-form comments.
 
-The metadata file is loaded automatically by
-`copernican_lib.utils.load_metadata_from_dir` and attached to the parsed
-`DataFrame` through the ``.attrs`` dictionary. Parsers store the original
-`dataset_name` along with a sanitized variant, `dataset_name_sanitized`,
-where spaces are replaced by underscores for safe filenames. Custom fields
-are preserved and can be used by new engines or analysis scripts.
+The metadata file is loaded automatically by the data loaders via
+`copernican_lib.utils.load_metadata_from_dir` after the parser returns and
+attached to the parsed `DataFrame` through the ``.attrs`` dictionary.
+Loaders store the original `dataset_name` along with a sanitized variant,
+`dataset_name_sanitized`, where spaces are replaced by underscores for safe
+filenames. Custom fields are preserved and can be used by new engines or
+analysis scripts.


### PR DESCRIPTION
## Summary
- centralize dataset metadata loading in `data_loaders` and simplify parser registration
- add robust YAML fallback for metadata files with unquoted colons
- document that loaders attach metadata and update all dataset parser modules

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68906ebe2ed4832f8a86b4ba8e55388f