### PR TITLE
Clarify naming conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,8 @@ To keep the project maintainable all contributors, human or AI, must follow thes
 7. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in any file.**
 8. **Re-read the "Development laws and protocols for human and AI contributors" section in `README.md` at the start of every development session.**
 9. **Document every module, function and class with clear "what" and "why" explanations.** Comments and docstrings should describe not only the behaviour but also the rationale behind it.
-10. **Use raw strings or escape backslashes explicitly to avoid invalid escape sequence warnings in docstrings or string literals.**
+10. **Use concise, descriptive function and identifier names that accurately convey their purpose without unnecessary length.**
+11. **Use raw strings or escape backslashes explicitly to avoid invalid escape sequence warnings in docstrings or string literals.**
 
 Failure to follow these guidelines will compromise the Copernican Suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.4.1
+- 2025-08-04: Added rule requiring concise, descriptive function and identifier names and synchronized documentation (AI assistant)
+
 ## Version 3.4.0
 - 2025-08-04: Centralised dataset metadata loading in `data_loaders.py`, removed metadata handling from parsers and updated documentation (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.3.7
+**Version:** 3.4.1
 **Last Updated:** 2025-08-04
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -396,6 +396,8 @@ See `CHANGELOG.md` for complete version history.
 > 7. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in any file.**
 > 8. **Re-read the "Development laws and protocols for human and AI contributors" section in `README.md` at the start of every development session.**
 > 9. **Document every module, function and class with clear "what" and "why" explanations.** Comments and docstrings should describe not only the behaviour but also the rationale behind it.
+> 10. **Use concise, descriptive function and identifier names that accurately convey their purpose without unnecessary length.**
+> 11. **Use raw strings or escape backslashes explicitly to avoid invalid escape sequence warnings in docstrings or string literals.**
 >
 > Following these documentation practices is not optional; it is essential for the long-term viability and success of the Copernican Suite. Failure to follow these rules will compromise the maintainability of the Copernican Suite.
 

--- a/copernican.py
+++ b/copernican.py
@@ -57,7 +57,7 @@ data_loaders = None
 # outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
 # unified exponent syntax across model YAML files and drops all
 # legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.3.7"
+COPERNICAN_VERSION = "3.4.1"
 CURRENT_LOG_FILE = None
 
 


### PR DESCRIPTION
## Summary
- Emphasize concise, descriptive function and identifier names in development guidelines and mirror them in README
- Synchronize development protocol lists and bump project version to 3.4.1
- Record naming-convention rule in changelog

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_689074171c0c832fbf39c383148f6691