### PR TITLE
Fix dataset footer bold formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.4.4
+- 2025-08-04: Replaced unsupported ``\textbf`` footer styling with ``\mathbf`` and preserved spaces to prevent plot save failures (AI assistant)
+
 ## Version 3.4.3
 - 2025-08-04: Dropped HTML tags from plot footers, centralised footer generation and kept dataset names spaced; bumped version (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.4.3
+**Version:** 3.4.4
 **Last Updated:** 2025-08-04
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -42,7 +42,8 @@ Each generated plot now includes a centered footer. The first line shows the
 model comparison, suite version and a timestamp. The second line lists the
 observational dataset and processing notes, and the third line provides the
 citation. The first and third lines are bold, and the dataset name on the
-second line retains its original spacing while appearing in bold.
+second line retains its original spacing while appearing in bold via
+MathText's ``\mathbf`` command.
 Metadata values are read from `metadata_*.yml` files stored next to each
 dataset. The program never hard-codes these values; `copernican_lib/data_loaders.py`
 reads the metadata after invoking each parser and attaches it to the returned

--- a/copernican.py
+++ b/copernican.py
@@ -57,7 +57,7 @@ data_loaders = None
 # outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
 # unified exponent syntax across model YAML files and drops all
 # legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.4.3"
+COPERNICAN_VERSION = "3.4.4"
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -105,15 +105,19 @@ def compose_footer(base_line: str, data_attrs: dict) -> list[tuple[str, bool]]:
         .replace("{", "\\{")
         .replace("}", "\\}")
         .replace("_", "\\_")
+        .replace(" ", "\\ ")  # Preserve spaces for MathText rendering
     )
     description = data_attrs.get("description", "")
     notes = data_attrs.get("notes", "")
     citation = data_attrs.get("citation", "")
 
+    # ``mathtext`` does not support ``\textbf`` so ``\mathbf`` is used instead
+    # to emphasise the dataset name while keeping the rest of the line in the
+    # default font. Spaces are escaped above to preserve their appearance.
     second_line = (
         "Observational dataset and processing: "
-        f"$\\textbf{{{safe_name}}}$: {description} {notes}"
-    ).strip()
+        f"$\\mathbf{{{safe_name}}}$: {description} {notes}"
+        ).strip()
 
     wrapped: list[tuple[str, bool]] = [(base_line, True)]
     if second_line:


### PR DESCRIPTION
## Summary
- prevent `ParseSyntaxException` during plot saving by replacing unsupported `\textbf` with MathText's `\mathbf`
- document `\mathbf` usage for dataset names and bump version to 3.4.4

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6890a5aadd6c832fad8e52470f454131