### PR TITLE
Expand Unicode sub/superscript coverage in latex_utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.5.0
+- 2025-02-14: Expanded subscript and superscript tables to cover full Latin and Greek alphabets, digits and common operators; updated docs and bumped version (AI assistant)
+
 ## Version 3.4.4
 - 2025-08-04: Replaced unsupported ``\textbf`` footer styling with ``\mathbf`` and preserved spaces to prevent plot save failures (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.4.4
-**Last Updated:** 2025-08-04
+**Version:** 3.5.0
+**Last Updated:** 2025-02-14
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.
@@ -224,6 +224,8 @@ See `cosmo_model_template.yml` for a detailed template.
    parameter names in math mode.
 11. Console and log outputs display parameter names with Greek letters,
     subscripts and superscripts when possible for easier reading.
+    The conversion tables cover every Latin and Greek letter, digits and
+    common operators.
 
 **Common mistakes**
 * Missing `*` between variables and parentheses results in a `'Symbol' object is not callable` error.

--- a/copernican.py
+++ b/copernican.py
@@ -57,7 +57,7 @@ data_loaders = None
 # outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
 # unified exponent syntax across model YAML files and drops all
 # legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.4.4"
+COPERNICAN_VERSION = "3.5.0"
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/latex_utils.py
+++ b/copernican_lib/latex_utils.py
@@ -91,7 +91,18 @@ def wrap_math(text: str) -> str:
 # added without modifying this module.
 _UNICODE_SYMBOLS = _MAPPINGS.get("unicode_symbols", {})
 
-_SUB_MAP = {
+"""Tables of subscript and superscript characters used by ``latex_to_unicode``."""
+
+# Only a subset of characters have dedicated Unicode glyphs.  The base tables
+# below list those known substitutions.  During map generation we iterate over
+# the full set of required characters—Latin and Greek letters, digits and basic
+# math operators—falling back to the original character whenever no specialised
+# glyph exists.  Ordering follows the user expectation: Latin uppercases, Latin
+# lowercases, Greek uppercases, Greek lowercases, digits, parentheses,
+# brackets/braces and common operators.
+
+_SUBSCRIPT_BASE = {
+    # Digits
     "0": "₀",
     "1": "₁",
     "2": "₂",
@@ -102,15 +113,18 @@ _SUB_MAP = {
     "7": "₇",
     "8": "₈",
     "9": "₉",
+    # Basic operators and grouping
     "+": "₊",
     "-": "₋",
     "=": "₌",
     "(": "₍",
     ")": "₎",
+    # Letters with dedicated subscript forms
     "a": "ₐ",
     "e": "ₑ",
     "h": "ₕ",
     "i": "ᵢ",
+    "j": "ⱼ",
     "k": "ₖ",
     "l": "ₗ",
     "m": "ₘ",
@@ -123,6 +137,7 @@ _SUB_MAP = {
     "u": "ᵤ",
     "v": "ᵥ",
     "x": "ₓ",
+    # Greek letters with subscript variants
     "β": "ᵦ",
     "γ": "ᵧ",
     "ρ": "ᵨ",
@@ -130,7 +145,8 @@ _SUB_MAP = {
     "χ": "ᵪ",
 }
 
-_SUP_MAP = {
+_SUPERSCRIPT_BASE = {
+    # Digits
     "0": "⁰",
     "1": "¹",
     "2": "²",
@@ -141,14 +157,126 @@ _SUP_MAP = {
     "7": "⁷",
     "8": "⁸",
     "9": "⁹",
+    # Basic operators and grouping
     "+": "⁺",
     "-": "⁻",
     "=": "⁼",
     "(": "⁽",
     ")": "⁾",
-    "i": "ⁱ",
+    "*": "⁎",
+    "/": "⁄",
+    # Latin lowercase letters
+    "a": "ᵃ",
+    "b": "ᵇ",
+    "c": "ᶜ",
+    "d": "ᵈ",
+    "e": "ᵉ",
+    "f": "ᶠ",
+    "g": "ᵍ",
+    "h": "ʰ",
+    "i": "ᶦ",
+    "j": "ʲ",
+    "k": "ᵏ",
+    "l": "ˡ",
+    "m": "ᵐ",
     "n": "ⁿ",
+    "o": "ᵒ",
+    "p": "ᵖ",
+    "r": "ʳ",
+    "s": "ˢ",
+    "t": "ᵗ",
+    "u": "ᵘ",
+    "v": "ᵛ",
+    "w": "ʷ",
+    "x": "ˣ",
+    "y": "ʸ",
+    "z": "ᶻ",
+    # Latin uppercase letters
+    "A": "ᴬ",
+    "B": "ᴮ",
+    "C": "ᶜ",
+    "D": "ᴰ",
+    "E": "ᴱ",
+    "F": "ᶠ",
+    "G": "ᴳ",
+    "H": "ᴴ",
+    "I": "ᴵ",
+    "J": "ᴶ",
+    "K": "ᴷ",
+    "L": "ᴸ",
+    "M": "ᴹ",
+    "N": "ᴺ",
+    "O": "ᴼ",
+    "P": "ᴾ",
+    "R": "ᴿ",
+    "T": "ᵀ",
+    "U": "ᵁ",
+    "V": "ⱽ",
+    "W": "ᵂ",
+    # Greek letters with superscript variants
+    "α": "ᵅ",
+    "β": "ᵝ",
+    "γ": "ᵞ",
+    "δ": "ᵟ",
+    "ε": "ᵋ",
+    "θ": "ᶿ",
+    "ι": "ᶥ",
+    "φ": "ᵠ",
+    "χ": "ᵡ",
+    "ρ": "ᵨ",
 }
+
+
+def _build_script_maps() -> tuple[Dict[str, str], Dict[str, str]]:
+    """Generate full sub/superscript lookup tables.
+
+    Characters without specialised Unicode variants map to themselves.  The
+    insertion order matches the alphabetical specification required by the
+    documentation: Latin uppercases, Latin lowercases, Greek uppercases, Greek
+    lowercases, digits, parentheses, brackets, braces and operators.
+    """
+
+    sub_map: Dict[str, str] = {}
+    sup_map: Dict[str, str] = {}
+
+    latin_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    latin_lower = "abcdefghijklmnopqrstuvwxyz"
+    greek_upper = "ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ"
+    greek_lower = "αβγδεζηθικλμνξοπρστυφχψω"
+    digits = "0123456789"
+
+    for ch in latin_upper:
+        sub_map[ch] = _SUBSCRIPT_BASE.get(ch.lower(), ch)
+        sup_map[ch] = _SUPERSCRIPT_BASE.get(ch, _SUPERSCRIPT_BASE.get(ch.lower(), ch))
+    for ch in latin_lower:
+        sub_map[ch] = _SUBSCRIPT_BASE.get(ch, ch)
+        sup_map[ch] = _SUPERSCRIPT_BASE.get(ch, ch)
+    for ch in greek_upper:
+        lower = ch.lower()
+        sub_map[ch] = _SUBSCRIPT_BASE.get(lower, _SUBSCRIPT_BASE.get(ch, ch))
+        sup_map[ch] = _SUPERSCRIPT_BASE.get(ch, _SUPERSCRIPT_BASE.get(lower, ch))
+    for ch in greek_lower:
+        sub_map[ch] = _SUBSCRIPT_BASE.get(ch, ch)
+        sup_map[ch] = _SUPERSCRIPT_BASE.get(ch, ch)
+    for ch in digits:
+        sub_map[ch] = _SUBSCRIPT_BASE.get(ch, ch)
+        sup_map[ch] = _SUPERSCRIPT_BASE.get(ch, ch)
+    for ch in "()":
+        sub_map[ch] = _SUBSCRIPT_BASE.get(ch, ch)
+        sup_map[ch] = _SUPERSCRIPT_BASE.get(ch, ch)
+    for ch in "[]":
+        sub_map[ch] = _SUBSCRIPT_BASE.get(ch, ch)
+        sup_map[ch] = _SUPERSCRIPT_BASE.get(ch, ch)
+    for ch in "{}":
+        sub_map[ch] = _SUBSCRIPT_BASE.get(ch, ch)
+        sup_map[ch] = _SUPERSCRIPT_BASE.get(ch, ch)
+    for ch in "+-*/=":
+        sub_map[ch] = _SUBSCRIPT_BASE.get(ch, ch)
+        sup_map[ch] = _SUPERSCRIPT_BASE.get(ch, ch)
+    return sub_map, sup_map
+
+
+_SUB_MAP, _SUP_MAP = _build_script_maps()
 
 
 def latex_to_unicode(text: str) -> str:

--- a/docs/latex_syntax.md
+++ b/docs/latex_syntax.md
@@ -26,3 +26,7 @@ The parser strips common spacing and sizing commands (`\left`, `\right`, `\!`, `
 - `unicode_symbols` – conversions used by `latex_to_unicode` for log output.
 
 All Greek letters—upper and lower case—and variants such as `\varphi` are included in these tables in alphabetical order.
+
+### Subscripts and Superscripts
+
+`latex_utils.py` now ships with exhaustive lookup tables covering every Latin and Greek letter in both cases, digits and common math operators. Characters without dedicated Unicode glyphs fall back to their original form.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -143,6 +143,8 @@ class PlotterUtilTestCase(unittest.TestCase):
         self.assertEqual(latex_utils.latex_to_unicode(r"\Omega_{gamma}"), "Ωᵧ")
         self.assertEqual(latex_utils.latex_to_unicode("H_0"), "H₀")
         self.assertEqual(latex_utils.latex_to_unicode(r"z_{\rm rec}"), "zᵣₑc")
+        self.assertEqual(latex_utils.latex_to_unicode("x_{(1+2)}"), "x₍₁₊₂₎")
+        self.assertEqual(latex_utils.latex_to_unicode("y^{*}"), "y⁎")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- programmatically generate exhaustive subscript and superscript tables spanning Latin and Greek alphabets, digits, and basic math symbols
- document full script coverage in README and LaTeX syntax guide
- bump version to 3.5.0 and extend tests for new conversions

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6890deccc808832fa0d7997b4d9603e1