### PR TITLE
Document codebase and expand suite documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.5.1
+- 2025-08-08: Expanded comments across codebase, restructured plot footer documentation and enlarged technical docs (AI assistant)
+
 ## Version 3.5.0
 - 2025-08-07: Added comprehensive development plan summarizing project goals (AI assistant)
 - 2025-08-05: Expanded subscript and superscript tables to cover full Latin and Greek alphabets, digits and common operators; updated docs and bumped version (AI assistant)

--- a/PLAN.md
+++ b/PLAN.md
@@ -23,7 +23,7 @@ Copernican Suite has grown from a single script into a modular, cross-platform c
 - For now, macOS builds are left unsigned. When desired, an Apple Developer ID certificate will be used to sign and notarize each build. A qualified electronic signature (QES) is insufficient for Gatekeeper; signing must be repeated for every newly produced binary.
 
 ## Version Management
-- The runtime version will ultimately be derived from package metadata using `importlib.metadata`. Hard-coded version strings (e.g. `COPERNICAN_VERSION = "3.5.0"`) will be replaced with a helper function that returns the installed package version and falls back to `"0+unknown"` when metadata is unavailable.
+- The runtime version will ultimately be derived from package metadata using `importlib.metadata`. Hard-coded version strings (e.g. `COPERNICAN_VERSION = "3.5.1"`) will be replaced with a helper function that returns the installed package version and falls back to `"0+unknown"` when metadata is unavailable.
 - `setuptools_scm` reads Git tags to embed accurate version numbers during packaging. When a commit on `main` is tagged (e.g. `v3.6.0`), future builds will report that version automatically.
 - Version bumps follow semantic rules: increment **MAJOR** for breaking changes, **MINOR** for backward-compatible features and **PATCH** for fixes. Documentation-only commits may omit a version change.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.5.0
-**Last Updated:** 2025-02-14
+**Version:** 3.5.1
+**Last Updated:** 2025-08-08
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.
@@ -19,12 +19,13 @@ Additional design notes can be found under the `docs/` directory.
 7. [Dataset Metadata Fields](docs/dataset_metadata.md)
 8. [LaTeX Syntax Guide](docs/latex_syntax.md)
 9. [Using the Suite](#using-the-suite)
-10. [Creating New Models](#creating-new-models)
-11. [Developer Guide](#developer-guide)
-12. [AI-driven and human development laws and protocols](#6-ai-driven-and-human-development-laws-and-protocols)
-13. [License](#license)
-14. [Versioning Policy](#versioning-policy)
-15. [API Overview](docs/api_overview.md)
+10. [Plot Footers and Metadata](#plot-footers-and-metadata)
+11. [Creating New Models](#creating-new-models)
+12. [Developer Guide](#developer-guide)
+13. [AI-driven and human development laws and protocols](#6-ai-driven-and-human-development-laws-and-protocols)
+14. [License](#license)
+15. [Versioning Policy](#versioning-policy)
+16. [API Overview](docs/api_overview.md)
 
 ---
 
@@ -38,23 +39,6 @@ software.
 Users select models, datasets, and computational engines at runtime through a
 simple command line interface. Results are saved as plots and CSV files in the
 `./output/` directory.
-Each generated plot now includes a centered footer. The first line shows the
-model comparison, suite version and a timestamp. The second line lists the
-observational dataset and processing notes, and the third line provides the
-citation. The first and third lines are bold, and the dataset name on the
-second line retains its original spacing while appearing in bold via
-MathText's ``\mathbf`` command.
-Metadata values are read from `metadata_*.yml` files stored next to each
-dataset. The program never hard-codes these values; `copernican_lib/data_loaders.py`
-reads the metadata after invoking each parser and attaches it to the returned
-DataFrame for plot footers and CSV headers. Individual parsers no longer
-access metadata files directly.
-During configuration each loader prints a short summary including whether the
-dataset's covariance matrix was inverted successfully or if diagonal errors are
-being used.
-When generating file names the suite sanitizes dataset names, replacing spaces and
-characters like `/` with hyphens so output paths remain valid on all platforms.
-
 Under the hood the program follows a clear pipeline:
 1. **Dependency Check** – `copernican.py` scans for required packages and
    prints an install command tailored to your OS listing only the missing packages.
@@ -193,6 +177,26 @@ the same CMB calculation regardless of their own fitting scheme.
 - When a run finishes the suite prints the abstract text from each model along
   with a summary of the best-fit parameters and individual chi-squared values for
   SNe, BAO and CMB.
+
+## Plot Footers and Metadata
+Each generated plot includes a centered footer that documents the run.
+The first line shows the model comparison, Copernican Suite version and a
+timestamp. The second line lists the observational dataset and processing
+notes, and the third line provides the citation. The first and third lines are
+bold, while the dataset name on the second line retains its original spacing
+via MathText's ``\mathbf`` command.
+
+Metadata values are read from ``metadata_*.yml`` files stored next to each
+dataset. ``copernican_lib/data_loaders.py`` attaches this metadata to the
+DataFrame returned by each parser so both plot footers and CSV headers reflect
+the official dataset description and citation. Individual parsers never access
+metadata files directly.
+
+During configuration each loader prints a summary indicating whether the
+dataset's covariance matrix was inverted successfully or if diagonal errors are
+being used. When generating file names the suite sanitizes dataset names,
+replacing spaces and characters like ``/`` with hyphens so output paths remain
+portable across operating systems.
 
 ## Creating New Models
 All model details, including theory text and equations, must be stored in a

--- a/copernican.py
+++ b/copernican.py
@@ -57,7 +57,7 @@ data_loaders = None
 # outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
 # unified exponent syntax across model YAML files and drops all
 # legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.5.0"
+COPERNICAN_VERSION = "3.5.1"
 CURRENT_LOG_FILE = None
 
 
@@ -446,6 +446,7 @@ def main_workflow():
 
     # Load the baseline LCDM model from YAML and validate it
     def _load_lcdm_model():
+        """Load and validate the reference ΛCDM model from its YAML file."""
         models_dir = os.path.join(SCRIPT_DIR, "models")
         yaml_path = os.path.join(models_dir, "cosmo_model_lcdm.yml")
         cache_dir = os.path.join(models_dir, "cache")
@@ -747,6 +748,7 @@ def main_workflow():
         )
 
         def _print_fit(label, sne_res, bao_res, cmb_res, plugin):
+            """Pretty-print χ² statistics and fitted parameters for a model."""
             console.write(f"--- {label} Fit Report ---\n")
             if sne_res:
                 from copernican_lib import latex_utils

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -35,6 +35,7 @@ def register_sne_parser(name=None, description="", data_dir=None):
     ``dataset_name`` during discovery.
     """
     def decorator(func):
+        """Store ``func`` in the SNe parser registry under a temporary key."""
         key = name or os.path.basename(data_dir or func.__name__)
         SNE_PARSERS[key] = {
             'function': func,
@@ -52,6 +53,7 @@ def register_bao_parser(name=None, description="", data_dir=None):
     discovery.
     """
     def decorator(func):
+        """Store ``func`` in the BAO parser registry under a temporary key."""
         key = name or os.path.basename(data_dir or func.__name__)
         BAO_PARSERS[key] = {
             'function': func,
@@ -68,6 +70,7 @@ def register_cmb_parser(name=None, description="", data_dir=None):
     until discovery replaces it with the metadata ``dataset_name``.
     """
     def decorator(func):
+        """Store ``func`` in the CMB parser registry under a temporary key."""
         key = name or os.path.basename(data_dir or func.__name__)
         CMB_PARSERS[key] = {
             'function': func,
@@ -83,6 +86,7 @@ def register_gw_parser(name=None, description="", data_dir=None):
     Omitting ``name`` defers human-readable naming to metadata discovery.
     """
     def decorator(func):
+        """Store ``func`` in the GW parser registry under a temporary key."""
         key = name or os.path.basename(data_dir or func.__name__)
         GW_PARSERS[key] = {
             'function': func,
@@ -99,6 +103,7 @@ def register_siren_parser(name=None, description="", data_dir=None):
     key and is replaced with the metadata ``dataset_name`` during discovery.
     """
     def decorator(func):
+        """Store ``func`` in the standard siren parser registry."""
         key = name or os.path.basename(data_dir or func.__name__)
         SIREN_PARSERS[key] = {
             'function': func,

--- a/copernican_lib/latex_utils.py
+++ b/copernican_lib/latex_utils.py
@@ -287,6 +287,7 @@ def latex_to_unicode(text: str) -> str:
         cleaned = re.sub(re.escape(pat), repl, cleaned)
 
     def _sub_repl(match: re.Match[str]) -> str:
+        """Translate a ``_{} `` group into Unicode subscripts."""
         inner = match.group(1)
         inner = re.sub(r"\\rm\s*", "", inner)
         inner = inner.replace(" ", "")
@@ -296,6 +297,7 @@ def latex_to_unicode(text: str) -> str:
         return "".join(_SUB_MAP.get(ch, ch) for ch in inner)
 
     def _sup_repl(match: re.Match[str]) -> str:
+        """Translate a ``^{} `` group into Unicode superscripts."""
         inner = match.group(1)
         inner = inner.replace(" ", "")
         return "".join(_SUP_MAP.get(ch, ch) for ch in inner)

--- a/copernican_lib/logger.py
+++ b/copernican_lib/logger.py
@@ -18,10 +18,12 @@ class _PathFilter(logging.Filter):
     """Filter that strips absolute paths above the project root."""
 
     def __init__(self, base_dir: str):
+        """Store repository root for later path stripping."""
         super().__init__()
         self.base_dir = os.path.abspath(base_dir)
 
     def filter(self, record: logging.LogRecord) -> bool:
+        """Remove leading ``base_dir`` segments from log messages."""
         if isinstance(record.msg, str):
             record.msg = record.msg.replace(self.base_dir + os.sep, "").replace(
                 self.base_dir, "."
@@ -33,6 +35,7 @@ class _ConsoleFilter(logging.Filter):
     """Filter to exclude captured console messages from the StreamHandler."""
 
     def filter(self, record: logging.LogRecord) -> bool:
+        """Skip records already printed via patched ``print``/``input``."""
         # When ``console_capture`` is True the message originated from
         # ``print`` or ``input``. Those messages are already displayed on the
         # console via the original call, so the stream handler should ignore
@@ -51,10 +54,12 @@ def _patch_builtins(base_dir: str) -> None:
     orig_input = builtins.input
 
     def _shorten(msg: str) -> str:
+        """Replace absolute paths in ``msg`` with project-relative forms."""
         base = os.path.abspath(base_dir)
         return msg.replace(base + os.sep, "").replace(base, ".")
 
     def print_patch(*args, **kwargs):
+        """Proxy ``print`` that mirrors output to the log file."""
         orig_print(*args, **kwargs)
         if kwargs.get("file", sys.stdout) is sys.stdout:
             sep = kwargs.get("sep", " ")
@@ -68,6 +73,7 @@ def _patch_builtins(base_dir: str) -> None:
             )
 
     def input_patch(prompt: str = ""):
+        """Proxy ``input`` that logs the prompt and response."""
         response = orig_input(prompt)
         logger.info(
             _shorten(f"{prompt}{response}"),

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -1,8 +1,9 @@
-# """Model coder that turns validated YAML into callable Python functions."""
+"""Translate sanitized model YAML into executable NumPy-aware callables.
 
-# Every cosmological model is stored as YAML.  This module reads the sanitized
-# YAML and uses SymPy to translate mathematical expressions into efficient
-# NumPy-friendly functions.
+Every cosmological model is stored as YAML. This module parses that file,
+converts equations to SymPy expressions and then compiles them into fast
+NumPy functions suitable for evaluation within the engines.
+"""
 
 import yaml
 from pathlib import Path
@@ -26,6 +27,7 @@ class QuadPrinter(NumPyPrinter):
     """NumPy printer that expands ``Integral`` nodes into ``scipy`` quad calls."""
 
     def _print_Integral(self, expr):
+        """Translate SymPy ``Integral`` nodes into ``quad`` expressions."""
         # Currently support single-variable integrals of the form (var, a, b).
         var, a, b = expr.limits[0]
         integrand = expr.function
@@ -200,11 +202,13 @@ def generate_callables(cache_path):
                     zrec = params[zr_i]
 
                     def sound_speed(zv):
+                        """Return baryon-photon sound speed in km/s at redshift ``zv``."""
                         return 299792.458 / np.sqrt(3 * (1 + 3 * Ob_val / (4 * Og_val) / (1 + zv)))
 
                     h0_val = hz_fn(0.0, *params)
 
                     def hz_with_radiation(zv):
+                        """Return H(z) including a simple radiation density term."""
                         base = hz_fn(zv, *params)
                         rad_sq = (h0_val ** 2) * Og_val * (1 + zv) ** 4
                         return np.sqrt(base ** 2 + rad_sq)
@@ -265,6 +269,7 @@ def generate_callables(cache_path):
         and 'get_luminosity_distance_Mpc' in funcs
     ):
         def _mu(zv, *params):
+            """Compute distance modulus from luminosity distance in Mpc."""
             dl = funcs['get_luminosity_distance_Mpc'](zv, *params)
             with np.errstate(divide='ignore', invalid='ignore'):
                 mu = 5 * np.log10(dl) + 25.0

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -38,9 +38,28 @@ metadata so that engines remain agnostic to the origin of the data.
 `copernican_lib/data_loaders.py` reads ``metadata_*.yml`` files located next to
 the dataset tables and attaches the fields via the ``DataFrame.attrs``
 dictionary after the parser returns. For supernovae datasets the table contains
-at minimum ``Name``, ``zcmb``,
-``mu_obs`` and ``e_mu_obs``. Attributes such as ``covariance_matrix_inv``
-and ``diag_errors_for_plot`` are also attached. BAO and CMB loaders
-follow the same pattern. New datasets can therefore be added simply by
-placing them under ``data/<type>/<source>/`` and providing a compatible
-YAML parser.
+at minimum ``Name``, ``zcmb``, ``mu_obs`` and ``e_mu_obs``. Attributes such as
+``covariance_matrix_inv`` and ``diag_errors_for_plot`` are also attached. BAO and
+CMB loaders follow the same pattern. New datasets can therefore be added simply
+by placing them under ``data/<type>/<source>/`` and providing a compatible YAML
+parser.
+
+## Extending the API
+
+Third-party tools may import these modules directly. A typical scripting
+session looks like this:
+
+```python
+from copernican_lib import model_parser, model_coder, engine_interface, data_loaders
+import engines.cosmo_engine_comb as engine
+
+cache = model_parser.parse_model('models/cosmo_model_lcdm.yml', 'models/cache')
+funcs, parsed = model_coder.generate_callables(cache)
+plugin = engine_interface.build_plugin(parsed, funcs)
+sne = data_loaders.load_sne_data('JLA 2014')
+result = engine.fit_sne_parameters(sne, plugin)
+```
+
+Because the API is intentionally thin, advanced users can orchestrate custom
+pipelines or integrate the suite into larger optimisation frameworks without
+relying on the command-line wrapper.

--- a/docs/bao_compound_dataset_format.md
+++ b/docs/bao_compound_dataset_format.md
@@ -38,4 +38,16 @@ pages: N/A
 notes: Observable types: DV_over_rs (D_V(z)/r_s), DM_over_rs (D_M(z)/r_s), DH_over_rs (D_H(z)/r_s = c/(H(z) r_s)). All r_s values are the model's sound horizon at the drag epoch unless a fiducial r_s is specified. No covariance matrix is available; uncertainties are treated as uncorrelated.
 ```
 
+## Usage
+
+The compound dataset is primarily intended for automated tests and examples. It
+demonstrates how BAO observables are encoded without requiring gigabyte-scale
+survey releases. When developing a new parser, model the output DataFrame on the
+structure produced by this example: one row per measurement with columns for the
+observable, its uncertainty and any fiducial sound horizon.
+
+When a real dataset supplies a covariance matrix the parser should attach the
+inverse matrix to `df.attrs['covariance_matrix_inv']`. For uncorrelated data, as
+shown here, omitting the matrix is sufficient and the engine will fall back to
+diagonal errors.
 All observable types use the naming convention `DV_over_rs`, `DM_over_rs` or `DH_over_rs` to indicate $D_V$, $D_M$ or $D_H$ divided by the sound horizon. The parser converts the YAML to a Pandas `DataFrame` and the data loader attaches the metadata to the `.attrs` attribute. In addition to the original `dataset_name`, a sanitized version `dataset_name_sanitized` replaces spaces with underscores for safe filenames. The same `metadata_*.yml` structure with `dataset_name`, `description`, `notes` and `citation` is used for **all** datasets so plot footers render the dataset name in bold, followed by its description, notes and a separate citation line.

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -13,6 +13,7 @@ data/
 
 Note: The `gw` and `sirens` parsers are stubs that return `None`. Real data support is under development.
 Each subdirectory contains one or more dataset sources. A Python file named `cosmo_parser_*.py` lives inside each source folder and registers a parser function via decorators from `copernican_lib.data_loaders`.
+Folders named `placeholder` are ignored during automatic discovery so work-in-progress datasets do not appear in interactive menus. When a dataset becomes usable simply rename the folder and supply a valid parser and metadata file.
 
 Every dataset folder also provides a `metadata_*.yml` describing the
 source. Fields such as `dataset_name`, `description`, `citation`, the full
@@ -46,3 +47,23 @@ inverse covariance is stored on the returned DataFrame.
 *Source:* "The clustering of galaxies in the completed SDSS-III Baryon Oscillation Spectroscopic Survey" (Alam et al. 2017).
 *Location:* `data/bao/bossdr12/`.
 *Parser:* `cosmo_parser_bossdr12.py` combines the published $dM(rs_{\rm fid}/r_s)$, $Hz(r_s/rs_{\rm fid})$, $D_V/r_s$ and $F_{AP}$ measurements. The public [SDSS DR12 archive](https://data.sdss.org/sas/dr12/boss/) provides separate covariance matrices for the $dM/Hz$ and $D_V/F_{AP}$ sets but no joint covariance. Following the parser's block-diagonal rationale, these are assembled into a $9\times9$ matrix assuming the two inputs are uncorrelated and then converted to $D_M/r_s$, $D_H/r_s$ and $D_V/r_s$.
+
+## CMB Datasets
+
+### Planck 2018 Lite TT/TE/EE
+*Source:* Planck 2018 legacy release.
+*Location:* `data/cmb/planck2018lite/`.
+*Parser:* `cosmo_parser_cmb_planck2018lite.py` loads the temperature and
+polarisation spectra, the compressed covariance matrix and the beam window
+functions. The parser attaches these arrays to `df.attrs` so engines can compute
+likelihoods without invoking external tools like CAMB.
+
+## Adding New Datasets
+
+To add a new dataset create a `data/<type>/<source>/` directory, place your raw
+tables inside and implement `cosmo_parser_<source>.py`. The parser should return
+a `pandas.DataFrame` with observations and attach any auxiliary arrays to
+`df.attrs`. Document the dataset in `metadata_<source>.yml` with a
+`dataset_name`, a plain-language `description` and the full `citation`. Once the
+folder no longer carries the `placeholder` name it will appear automatically in
+the interactive menus.

--- a/docs/dataset_metadata.md
+++ b/docs/dataset_metadata.md
@@ -34,3 +34,12 @@ filenames. Plot footers render the dataset name in bold followed by
 `: description notes` on the second line and the citation on a third
 line. Custom fields are preserved and can be used by new engines or
 analysis scripts.
+
+### Best Practices
+
+- Keep descriptions short yet informative; the second footer line wraps at
+  190 characters, so overly long notes may span several lines.
+- Use the full author list to ensure proper attribution in publications that
+  derive from the suite's outputs.
+- Unknown fields are preserved by the loader, making it safe to add
+  experiment-specific keys for downstream tools.

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -29,3 +29,18 @@ Greek letters and subscripts in console logs.
 Console messages are emitted through `copernican_lib/console_output.py` so that
 all output passes through a single function. The logger patches `print` and
 `input` to capture these messages verbatim.
+
+Engines follow a strict interface. `engine_interface.validate_plugin` ensures
+that any model plugin supplies the callable hooks required by a backend. This
+allows alternative engines—GPU-accelerated solvers, for example—to be swapped in
+without touching the high-level orchestration in `copernican.py`.
+
+To keep multiprocessing predictable, the suite sets the start method to
+``spawn`` and validates model YAML only in the main process. Worker processes
+operate on sanitised cached models which avoids repeated schema checks and
+keeps startup costs low.
+
+Caching is deliberately explicit. Parsed models are written to
+`models/cache/` and cleared only when the user exits the program. This approach
+allows repeated runs with different datasets without re-parsing YAML files,
+while still letting contributors inspect the generated intermediate files.

--- a/docs/latex_syntax.md
+++ b/docs/latex_syntax.md
@@ -30,3 +30,13 @@ All Greek letters—upper and lower case—and variants such as `\varphi` are in
 ### Subscripts and Superscripts
 
 `latex_utils.py` now ships with exhaustive lookup tables covering every Latin and Greek letter in both cases, digits and common math operators. Characters without dedicated Unicode glyphs fall back to their original form.
+
+## Tips for Writing Equations
+
+- Always enclose multi-character subscripts or superscripts in braces, e.g.
+  `H_{\rm 0}` or `x^{(1+z)}`. This ensures the parser interprets the entire
+  group correctly.
+- Use raw strings in YAML where possible to avoid accidental escape sequences.
+- Avoid vendor-specific macros; if a symbol is missing from
+  `latex_mappings.yml`, consider extending the mapping rather than embedding
+  raw Unicode characters in the YAML file.

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -453,6 +453,7 @@ def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin)
         logger.info("Running SNe pre-fit to obtain better starting values...")
 
         def _chi2_sne_only(p):
+            """Return χ² for a parameter vector using SNe-only data."""
             return chi_squared_sne(p, model_plugin.distance_modulus_model, sne_data_df)
 
         pre_res, _, pre_best, pre_params = minimize_with_progress(
@@ -475,6 +476,7 @@ def fit_combined_parameters(sne_data_df, bao_data_df, cmb_data_df, model_plugin)
     options = {'maxiter': 2000}
 
     def combined_chi2(p):
+        """Return combined χ² across SNe, BAO and CMB datasets."""
         return chi_squared_combined(
             p,
             model_plugin,

--- a/tests/test_bossdr12_parser.py
+++ b/tests/test_bossdr12_parser.py
@@ -19,6 +19,7 @@ class BossDR12ParserTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        """Import the parser module once for use across all test methods."""
         # Dynamically import the parser directly from the data directory. This
         # avoids mutating ``sys.path`` and keeps the tests self-contained.
         base = Path(__file__).resolve().parents[1]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,6 +17,7 @@ class FunctionalTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        """Prepare a validated ΛCDM plugin used by several test cases."""
         # Prepare a validated ΛCDM plugin used by several test cases.
         base = Path(__file__).resolve().parents[1]
         models_dir = base / 'models'
@@ -28,9 +29,11 @@ class FunctionalTestCase(unittest.TestCase):
         engine_interface.validate_plugin(cls.plugin)
 
     def test_plugin_validation(self):
+        """Ensure the constructed plugin exposes the expected API."""
         self.assertTrue(hasattr(self.plugin, 'distance_modulus_model'))
 
     def test_engine_routines(self):
+        """Run a smoke test across the main engine routines."""
         sne_df = data_loaders.load_sne_data('JLA 2014')
         self.assertIsNotNone(sne_df)
         sne_df = sne_df.head(3)
@@ -67,6 +70,7 @@ class FunctionalTestCase(unittest.TestCase):
         self.assertEqual(len(spec["TT"]), len(cmb_df))
 
     def test_combined_fit(self):
+        """Check that the combined fit pipeline returns finite χ² values."""
         sne_df = data_loaders.load_sne_data('JLA 2014').head(2)
         if sne_df.attrs.get('covariance_matrix_inv') is not None:
             sne_df.attrs['covariance_matrix_inv'] = sne_df.attrs['covariance_matrix_inv'][:2, :2]
@@ -82,6 +86,7 @@ class FunctionalTestCase(unittest.TestCase):
         self.assertTrue(np.isfinite(result['chi2_total']))
 
     def test_chi_squared_cmb_planck2018lite(self):
+        """Verify that the Planck 2018 lite dataset yields finite χ²."""
         cmb_df = data_loaders.load_cmb_data('Planck 2018 Lite TT/TE/EE')
         params = self.plugin.INITIAL_GUESSES
         chi2 = engine.chi_squared_cmb(params, cmb_df, self.plugin)
@@ -121,6 +126,7 @@ class PlotterUtilTestCase(unittest.TestCase):
     """Test helper utilities in ``plotter``."""
 
     def test_wrap_math_removes_size_macros(self):
+        """Ensure size macros are stripped when wrapping math expressions."""
         import sys
         import importlib
         from types import SimpleNamespace


### PR DESCRIPTION
## Summary
- Move plot footer details into dedicated README section and update version to 3.5.1
- Add missing docstrings and explanatory comments across core modules and engines
- Broaden technical docs with API examples, dataset guidance and LaTeX tips

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_689643e0bc98832fb407a11293531cae