### PR TITLE
Add cross-platform PyInstaller specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+## Version 3.5.3
+- 2025-08-09: Added PyInstaller build specifications for Windows, macOS and Linux, bundled project sources and documented macOS signing (AI assistant)
+
 ## Version 3.5.2
 - 2025-08-09: Added cross-platform CI workflow using GitHub Actions (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.5.2
+**Version:** 3.5.3
 **Last Updated:** 2025-08-09
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -26,6 +26,7 @@ Additional design notes can be found under the `docs/` directory.
 14. [License](#license)
 15. [Versioning Policy](#versioning-policy)
 16. [API Overview](docs/api_overview.md)
+17. [Packaging Guide](docs/packaging.md)
 
 ---
 
@@ -111,6 +112,10 @@ Installing the suite with `pip` creates a `copernican_suite.egg-info` directory.
 This folder contains package metadata such as the version number, dependency
 list and entry points used by Python's packaging tools. It is generated
 automatically and does not need to be tracked in version control.
+
+Standalone executables can be created with the PyInstaller spec files included
+at the repository root. See [docs/packaging.md](docs/packaging.md) for platform
+specific build commands and macOS signing instructions.
 
 
 ## Directory Layout

--- a/copernican_linux.spec
+++ b/copernican_linux.spec
@@ -1,0 +1,35 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller specification for building a self-contained Linux binary of the
+Copernican Suite. Project sources are bundled so the resulting executable can
+run on systems without Python pre-installed.
+"""
+
+block_cipher = None
+
+a = Analysis(
+    ['copernican.py'],
+    pathex=['.'],
+    datas=[
+        ('copernican_lib', 'copernican_lib'),
+        ('engines', 'engines'),
+        ('models', 'models'),
+        ('data', 'data'),
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='copernican',
+    console=True,
+)

--- a/copernican_macos.spec
+++ b/copernican_macos.spec
@@ -1,0 +1,45 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller specification for building a universal2 macOS application bundle of
+the Copernican Suite. All project sources are included so the generated
+``Copernican.app`` runs without external dependencies. The bundle may be signed
+and notarised once an Apple Developer ID is available.
+"""
+
+block_cipher = None
+
+a = Analysis(
+    ['copernican.py'],
+    pathex=['.'],
+    datas=[
+        ('copernican_lib', 'copernican_lib'),
+        ('engines', 'engines'),
+        ('models', 'models'),
+        ('data', 'data'),
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    target_arch='universal2',
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='Copernican',
+    console=False,
+    target_arch='universal2',
+)
+
+app = BUNDLE(
+    exe,
+    name='Copernican.app',
+    icon=None,
+    bundle_identifier='org.copernican.suite',
+)

--- a/copernican_win.spec
+++ b/copernican_win.spec
@@ -1,0 +1,36 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller specification for building a standalone Windows executable of the
+Copernican Suite. The project source directories are bundled so the resulting
+``copernican.exe`` can run without requiring a separate checkout of the
+repository.
+"""
+
+block_cipher = None
+
+a = Analysis(
+    ['copernican.py'],
+    pathex=['.'],
+    datas=[
+        ('copernican_lib', 'copernican_lib'),
+        ('engines', 'engines'),
+        ('models', 'models'),
+        ('data', 'data'),
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='copernican',
+    console=True,
+)

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,36 @@
+# Packaging Guide
+
+This guide describes how to build standalone executables for the Copernican Suite
+using PyInstaller. Each provided spec file bundles the project source code so
+the resulting binary can run without an existing checkout of the repository or a
+pre-installed copy of Python.
+
+## Windows `.exe`
+1. Install PyInstaller: `pip install pyinstaller`.
+2. Run `pyinstaller copernican_win.spec`.
+3. The `dist/copernican.exe` file contains the suite and all bundled sources.
+
+## macOS universal2 `.app`
+1. Install PyInstaller on a macOS system.
+2. Run `pyinstaller copernican_macos.spec`.
+3. The `dist/Copernican.app` bundle supports both Intel and Apple Silicon.
+
+### Signing and notarizing
+Once you have an Apple Developer ID, the bundle can be signed and notarized:
+
+```bash
+codesign --deep --force --options runtime \
+  --sign "Developer ID Application: YOUR NAME (TEAMID)" dist/Copernican.app
+hdiutil create -fs HFS+ -volname Copernican -srcfolder dist/Copernican.app dist/copernican.dmg
+xcrun notarytool submit dist/copernican.dmg --apple-id YOUR_ID@example.com \
+  --team-id TEAMID --password YOUR_APP_SPECIFIC_PASSWORD --wait
+xcrun stapler staple dist/Copernican.app
+```
+
+These steps sign the application, submit it to Apple for notarization and staple
+the approval ticket so the app runs without security prompts.
+
+## Linux self-contained binary
+1. Install PyInstaller: `pip install pyinstaller`.
+2. Run `pyinstaller copernican_linux.spec`.
+3. The `dist/copernican` file is a one-file binary containing the full project source.


### PR DESCRIPTION
## Summary
- add PyInstaller specifications for Windows, macOS (universal2) and Linux, bundling project sources
- document packaging workflow with signing and notarization steps for macOS
- surface packaging guide in README and changelog

## Testing
- `python -m py_compile copernican_win.spec copernican_macos.spec copernican_linux.spec`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_6896fb157df4832f8ffabe7f3568591c