### PR TITLE
centralise version retrieval with setuptools_scm fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,5 +154,7 @@ Failure to follow these guidelines will compromise the Copernican Suite.
 The project follows Semantic Versioning (`MAJOR.MINOR.PATCH`). Increment the
 `MAJOR` number for breaking changes, the `MINOR` for new backward-compatible
 features and the `PATCH` for bug fixes. Package versions are derived from Git
-tags using `setuptools_scm`. Contributors must update the version whenever
-a pull request introduces a change covered by these rules.
+tags using `setuptools_scm`. Runtime code should obtain the current version
+via ``copernican_lib.version.get_version`` rather than hard-coded strings.
+Contributors must update the version whenever a pull request introduces a
+change covered by these rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Add one line for each substantive commit or pull request directly under the late
 ```
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
+### Version Bump Rules
+- **MAJOR**: incompatible API changes.
+- **MINOR**: backward-compatible feature additions.
+- **PATCH**: backward-compatible bug fixes and documentation updates.
+
+## Version 3.6.0
+- 2025-08-09: Centralised version handling via `copernican_lib.version`, routed modules through the helper, configured `setuptools_scm` fallback and documented SemVer bump rules (AI assistant)
+
 ## Version 3.5.3
 - 2025-08-09: Added PyInstaller build specifications for Windows, macOS and Linux, bundled project sources and documented macOS signing (AI assistant)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -23,7 +23,7 @@ Copernican Suite has grown from a single script into a modular, cross-platform c
 - For now, macOS builds are left unsigned. When desired, an Apple Developer ID certificate will be used to sign and notarize each build. A qualified electronic signature (QES) is insufficient for Gatekeeper; signing must be repeated for every newly produced binary.
 
 ## Version Management
-- The runtime version will ultimately be derived from package metadata using `importlib.metadata`. Hard-coded version strings (e.g. `COPERNICAN_VERSION = "3.5.1"`) will be replaced with a helper function that returns the installed package version and falls back to `"0+unknown"` when metadata is unavailable.
+- The runtime version is derived from package metadata using `importlib.metadata` through a helper that falls back to `"0+unknown"` when metadata is unavailable.
 - `setuptools_scm` reads Git tags to embed accurate version numbers during packaging. When a commit on `main` is tagged (e.g. `v3.6.0`), future builds will report that version automatically.
 - Version bumps follow semantic rules: increment **MAJOR** for breaking changes, **MINOR** for backward-compatible features and **PATCH** for fixes. Documentation-only commits may omit a version change.
 

--- a/copernican.py
+++ b/copernican.py
@@ -6,7 +6,6 @@ Copernican Suite - Main Orchestrator.
 
 import importlib.util
 import importlib
-from importlib.metadata import version as package_version, PackageNotFoundError
 import ast
 import os
 import sys
@@ -18,6 +17,7 @@ import argparse
 from pathlib import Path
 
 from copernican_lib import console_output as console
+from copernican_lib.version import get_version
 
 # Verify interpreter version early so users see clear feedback
 MIN_PYTHON = (3, 12)
@@ -53,11 +53,10 @@ log_mod = None
 logger = None
 data_loaders = None
 
-# Use a fixed version string to avoid confusion when the package metadata is
-# outdated. Automatic releases are not yet enabled. Version 3.1.0 adds
-# unified exponent syntax across model YAML files and drops all
-# legacy JSON dataset support in favour of YAML-only inputs.
-COPERNICAN_VERSION = "3.5.1"
+# Retrieve the runtime version from installed package metadata. When the
+# distribution is not installed, ``get_version`` supplies ``"0+unknown"`` so
+# logs and plot footers still carry a version-like identifier.
+COPERNICAN_VERSION = get_version()
 CURRENT_LOG_FILE = None
 
 

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -14,7 +14,10 @@ from . import latex_utils
 
 from .utils import generate_filename, ensure_dir_exists, get_timestamp
 from .logger import get_logger
-from copernican import COPERNICAN_VERSION
+from .version import get_version
+
+# Query package metadata once so every plot records the same version string.
+COPERNICAN_VERSION = get_version()
 
 
 def _wrap_math(text: str) -> str:

--- a/copernican_lib/version.py
+++ b/copernican_lib/version.py
@@ -1,0 +1,32 @@
+"""Version helpers for the Copernican Suite.
+
+This module centralises retrieval of the project's version string so that
+all components report a consistent value. It queries ``importlib.metadata``
+for the installed package version and falls back to ``"0+unknown"`` when the
+metadata is missing (for example when running from an unpackaged source
+checkout). The helper avoids scattering hard-coded version numbers across the
+codebase and keeps logging and plot footers in sync with tagged releases.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+PACKAGE_NAME = "copernican-suite"
+
+
+def get_version() -> str:
+    """Return the installed package version or a fallback.
+
+    The function asks :mod:`importlib.metadata` for the version of the
+    ``copernican-suite`` distribution. When that information cannot be found,
+    a fallback string of ``"0+unknown"`` is returned so that users still see a
+    version-like identifier in logs and plot footers.
+    """
+
+    try:
+        return version(PACKAGE_NAME)
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+__all__ = ["get_version"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,4 @@ py-modules = ["copernican"]
 
 [tool.setuptools_scm]
 version_scheme = "no-guess-dev"
+fallback_version = "0+unknown"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,6 @@
 """Basic functional tests for the Copernican Suite."""
 
 import unittest
-import importlib
 from pathlib import Path
 import numpy as np
 import camb
@@ -127,12 +126,7 @@ class PlotterUtilTestCase(unittest.TestCase):
 
     def test_wrap_math_removes_size_macros(self):
         """Ensure size macros are stripped when wrapping math expressions."""
-        import sys
-        import importlib
-        from types import SimpleNamespace
-
-        sys.modules['copernican'] = SimpleNamespace(COPERNICAN_VERSION='test')
-        plotter = importlib.import_module('copernican_lib.plotter')
+        from copernican_lib import plotter
 
         expr = r"\mu(z) = 5\log_{10}\bigl[d_L(z)/\mathrm{Mpc}\bigr] + 25"
         expected = r"$\mu(z) = 5\log_{10}[d_L(z)/{Mpc}] + 25$"


### PR DESCRIPTION
## Summary
- add `copernican_lib.version.get_version` to read package metadata and fall back to `0+unknown`
- call the new helper from `copernican.py` and plotting utilities instead of hard-coded strings
- configure `setuptools_scm` fallback and document semantic version bump rules in the changelog

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_6896fe4818c0832f923641e105791a9e