### PR TITLE
Delegate run-tests to unittest discovery and expand test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: pre-commit run --all-files # fail fast on style issues
 
       - name: Execute unit tests
-        run: python -m unittest discover # run suite and fail on test errors
+        run: python copernican.py --run-tests # run suite via CLI and fail on test errors
 
       - name: Build executables
         run: pyinstaller --onefile copernican.py # produce standalone binary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,9 @@ ensures the expected functions are present and callable. Starting with
 version 1.11.4 the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify that
 the reference LCDM model and data parsers operate correctly. The `--run-tests`
-flag now uses Python's built-in discovery to gather all tests from the `tests`
-package and will exit cleanly even when Matplotlib has not yet been imported.
+flag delegates to `python -m unittest discover`, gathering all tests from the
+`tests` package and exiting cleanly even when Matplotlib has not yet been
+imported.
 
 ## 2. Directory Layout
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Add one line for each substantive commit or pull request directly under the late
 - **MINOR**: backward-compatible feature additions.
 - **PATCH**: backward-compatible bug fixes and documentation updates.
 
+## Version 3.6.1
+- 2025-08-09: Delegated `--run-tests` to `python -m unittest discover`, expanded regression and interface tests, and updated CI to run the full suite on every push (AI assistant)
+
 ## Version 3.6.0
 - 2025-08-09: Centralised version handling via `copernican_lib.version`, routed modules through the helper, configured `setuptools_scm` fallback and documented SemVer bump rules (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Under the hood the program follows a clear pipeline:
 2. Follow the interactive prompts to choose a model, preferred data sources and
    computation engine.
 3. Execute `python3 copernican.py --run-tests` or run `python -m unittest discover`
-   to verify the reference model and parsers. The `--run-tests` flag now leverages
-   unittest discovery to gather all modules under `tests/`.
+   to verify the reference model and parsers. The `--run-tests` flag delegates to
+   `python -m unittest discover` to gather all modules under `tests/`.
 4. Plots and CSV results will appear in the `output/` folder when the run
    completes.
 

--- a/copernican.py
+++ b/copernican.py
@@ -14,6 +14,7 @@ import shutil
 import time
 import datetime
 import argparse
+import subprocess
 from pathlib import Path
 
 from copernican_lib import console_output as console
@@ -102,20 +103,21 @@ def _get_cpu_info() -> tuple[str, str]:
 
 
 def run_startup_tests():
-    """Discover and execute functional tests within the ``tests`` package."""
-    # This routine is invoked when the ``--run-tests`` flag is supplied.
-    # It uses Python's built-in unittest discovery to execute all test modules
-    # under the ``tests`` folder. The boolean return value determines whether
-    # the suite ran successfully.
-    import unittest
+    """Execute the project's unit tests via ``python -m unittest discover``.
 
+    The main entry point delegates to Python's standard discovery mechanism
+    so that ``copernican.py --run-tests`` behaves identically to invoking
+    ``python -m unittest discover`` from the command line. A ``True`` return
+    value indicates that all tests passed.
+    """
     try:
-        suite = unittest.defaultTestLoader.discover("tests")
+        result = subprocess.run(
+            [sys.executable, "-m", "unittest", "discover"], check=False
+        )
     except Exception as exc:
-        console.write(f"Error discovering startup tests: {exc}")
+        console.write(f"Error running startup tests: {exc}")
         return False
-    result = unittest.TextTestRunner(verbosity=1).run(suite)
-    return result.wasSuccessful()
+    return result.returncode == 0
 
 
 def parse_args():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,28 @@
+"""Tests for command-line helpers in ``copernican.py``."""
+
+import importlib
+import sys
+import unittest
+from unittest import mock
+
+with mock.patch("sys.version_info", (3, 12, 0)):
+    copernican = importlib.import_module("copernican")
+
+
+class RunTestsFlagTestCase(unittest.TestCase):
+    """Verify that ``--run-tests`` delegates to ``python -m unittest discover``."""
+
+    @mock.patch("subprocess.run")
+    def test_run_startup_tests_invokes_unittest_discover(self, run_mock):
+        """Ensure the helper spawns the expected discovery command."""
+        run_mock.return_value.returncode = 0
+        result = copernican.run_startup_tests()
+        self.assertTrue(result)
+        run_mock.assert_called_once()
+        cmd = run_mock.call_args[0][0]
+        self.assertEqual(cmd[:3], [sys.executable, "-m", "unittest"])
+        self.assertEqual(cmd[3], "discover")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -1,0 +1,41 @@
+"""Tests for ``copernican_lib.data_loaders`` registration helpers."""
+
+import os
+import tempfile
+import unittest
+
+import pandas as pd
+import yaml
+
+from copernican_lib import data_loaders
+
+
+class DataLoaderRegistryTestCase(unittest.TestCase):
+    """Exercise parser registration and metadata handling."""
+
+    def test_register_and_load_sne_parser(self):
+        """A temporary SNe parser should load data and metadata."""
+        prev = data_loaders.SNE_PARSERS.copy()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                meta = {"dataset_name": "Dummy SNe", "description": "test set"}
+                with open(os.path.join(tmp, "metadata_dummy.yml"), "w", encoding="utf-8") as fh:
+                    yaml.safe_dump(meta, fh)
+
+                @data_loaders.register_sne_parser(name="Dummy SNe", data_dir=tmp)
+                def _parser(_dir, **_kwargs):
+                    return pd.DataFrame({
+                        "zcmb": [0.1],
+                        "mu_obs": [1.0],
+                        "e_mu_obs": [0.1],
+                    })
+
+                df = data_loaders.load_sne_data("Dummy SNe")
+                self.assertEqual(df.attrs["dataset_name"], "Dummy SNe")
+                self.assertEqual(len(df), 1)
+        finally:
+            data_loaders.SNE_PARSERS = prev
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine_interface.py
+++ b/tests/test_engine_interface.py
@@ -1,0 +1,53 @@
+"""Tests for ``copernican_lib.engine_interface`` helpers."""
+
+import unittest
+from types import SimpleNamespace
+
+from copernican_lib import engine_interface
+
+
+def _dummy_func(*_args, **_kwargs):
+    """Return a placeholder numerical value."""
+    return 0.0
+
+
+class EngineInterfaceTestCase(unittest.TestCase):
+    """Validate plugin construction and associated helpers."""
+
+    def setUp(self):
+        """Build a minimal plugin for reuse across tests."""
+        self.model_data = {
+            "model_name": "Dummy",
+            "description": "desc",
+            "abstract": "abs",
+            "parameters": [
+                {"python_var": "h0", "latex_name": "H_0", "bounds": [60, 80]}
+            ],
+            "equations": {"sne": ["$$E=mc^2$$"], "bao": []},
+            "cmb": {"param_map": {"H0": "H_0", "ombh2": 0.022}},
+        }
+        funcs = {name: _dummy_func for name in engine_interface.REQUIRED_FUNCTIONS}
+        self.plugin = engine_interface.build_plugin(self.model_data, funcs)
+
+    def test_plugin_validation(self):
+        """Plugin built from minimal data should validate."""
+        self.assertTrue(engine_interface.validate_plugin(self.plugin))
+
+    def test_missing_attribute_fails_validation(self):
+        """A plugin lacking required attributes is rejected."""
+        bad = SimpleNamespace()
+        self.assertFalse(engine_interface.validate_plugin(bad))
+
+    def test_get_camb_params_expression(self):
+        """LaTeX expressions in ``cmb.param_map`` evaluate correctly."""
+        camb = self.plugin.get_camb_params([70.0])
+        self.assertEqual(camb["H0"], 70.0)
+        self.assertAlmostEqual(camb["ombh2"], 0.022)
+
+    def test_equation_sanitization(self):
+        """Equations are sanitized into Matplotlib-friendly form."""
+        self.assertEqual(self.plugin.MODEL_EQUATIONS_LATEX_SN[0], "$E=mc^2$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Delegate `--run-tests` flag to `python -m unittest discover`
- Add tests covering CLI delegation, engine interface helpers, and data loader registration
- Run full test suite via CLI in CI workflow

## Testing
- `python -m pre_commit run --all-files` *(fails: .pre-commit-config.yaml is not a file)*
- `python -m unittest discover`
- `python copernican.py --run-tests` *(fails: Copernican Suite requires Python 3.12 or later)*

------
https://chatgpt.com/codex/tasks/task_e_689700a6e738832fb28e64c8adbd42ef