### PR TITLE
chore: add style hooks and license reminders

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,8 @@ To keep the project maintainable all contributors, human or AI, must follow thes
 9. **Document every module, function and class with clear "what" and "why" explanations.** Comments and docstrings should describe not only the behaviour but also the rationale behind it.
 10. **Use concise, descriptive function and identifier names that accurately convey their purpose without unnecessary length.**
 11. **Use raw strings or escape backslashes explicitly to avoid invalid escape sequence warnings in docstrings or string literals.**
+12. **Run `pre-commit` on all modified files before committing to enforce Black, Isort, Ruff and Flake8 checks.**
+13. **Do not redistribute the Copernican Suite in full or assert patent claims; the license forbids these actions.**
 
 Failure to follow these guidelines will compromise the Copernican Suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Add one line for each substantive commit or pull request directly under the late
 - **MINOR**: backward-compatible feature additions.
 - **PATCH**: backward-compatible bug fixes and documentation updates.
 
+## Version 3.6.2
+- 2025-08-09: Configured pre-commit with Black, Isort, Ruff and Flake8 and added licensing reminders to contributor docs (AI assistant)
+
 ## Version 3.6.1
 - 2025-08-09: Delegated `--run-tests` to `python -m unittest discover`, expanded regression and interface tests, and updated CI to run the full suite on every push (AI assistant)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,10 @@
 Thank you for considering a contribution. Before opening a pull request, please
 read `AGENTS.md` for the full development specification. The quick checklist is:
 
-1. Run the test suite with `python -m unittest discover` or `copernican.py --run-tests`.
-2. Document your changes in `CHANGELOG.md` using the `- YYYY-MM-DD: summary (author)` format.
-3. Update documentation where needed, including `README.md` and `AGENTS.md`.
-4. Ensure your code is well commented and follows the project's style.
+1. Run `pre-commit run --files <changed files>` to apply Black, Isort, Ruff and Flake8 checks.
+2. Run the test suite with `python -m unittest discover` or `copernican.py --run-tests`.
+3. Document your changes in `CHANGELOG.md` using the `- YYYY-MM-DD: summary (author)` format.
+4. Update documentation where needed, including `README.md` and `AGENTS.md`.
+5. Ensure your code is well commented and follows the project's style.
 
-Pull requests that do not meet these requirements may be rejected.
+Pull requests that do not meet these requirements may be rejected. Contributions must comply with the Copernican Suite License, which forbids redistributing the suite in full and prohibits patent claims.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.5.3
+**Version:** 3.6.2
 **Last Updated:** 2025-08-09
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
@@ -328,10 +328,19 @@ See `CHANGELOG.md` for the complete project history.
 The short file `CONTRIBUTING.md` summarises the basic workflow for submitting
 patches and links back to these guidelines.
 
+The Copernican Suite License forbids redistributing the full suite and prohibits patent filings or assertions. All contributions must adhere to these restrictions.
+
 To start developing, install the suite in editable mode:
 
 ```bash
 pip install -e .
+```
+
+Install and run the pre-commit hooks to apply Black, Isort, Ruff and Flake8 checks:
+
+```bash
+pre-commit install
+pre-commit run --files <changed files>
 ```
 
 Run the tests with either command:
@@ -360,7 +369,7 @@ not modify them unless explicitly instructed.
 
 
 ## License
-The Copernican Suite is distributed under the terms of the [Copernican Suite License (CSL)](LICENSE.md).
+The Copernican Suite is distributed under the terms of the [Copernican Suite License (CSL)](LICENSE.md). The license forbids redistributing the software in full and disallows patent filings or assertions.
 
 ## Versioning Policy
 The project now follows [Semantic Versioning](https://semver.org/). Versions are
@@ -412,6 +421,8 @@ See `CHANGELOG.md` for complete version history.
 > 9. **Document every module, function and class with clear "what" and "why" explanations.** Comments and docstrings should describe not only the behaviour but also the rationale behind it.
 > 10. **Use concise, descriptive function and identifier names that accurately convey their purpose without unnecessary length.**
 > 11. **Use raw strings or escape backslashes explicitly to avoid invalid escape sequence warnings in docstrings or string literals.**
+> 12. **Run `pre-commit` on all modified files before committing to enforce Black, Isort, Ruff and Flake8 checks.**
+> 13. **Do not redistribute the Copernican Suite in full or assert patent claims; the license forbids these actions.**
 >
 > Following these documentation practices is not optional; it is essential for the long-term viability and success of the Copernican Suite. Failure to follow these rules will compromise the maintainability of the Copernican Suite.
 


### PR DESCRIPTION
## Summary
- configure pre-commit with Black, Isort, Ruff and Flake8
- document new pre-commit requirement and licensing limits across contributor docs
- record change in changelog

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md AGENTS.md CONTRIBUTING.md CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68971089e03c832fa8028ca965b20a2b