### PR TITLE
Constrain logger lines to 79 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Add one line for each substantive commit or pull request directly under the late
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
 ## Unreleased
+- 2025-08-09: Wrapped long lines in `logger.py` for 79-column compliance (AI assistant)
 - 2025-08-09: Wrapped long lines in `latex_utils.py` for 79-column compliance (AI assistant)
 - 2025-08-09: Wrapped overly long lines in `copernican.py` to satisfy style guide (AI assistant)
 

--- a/copernican_lib/logger.py
+++ b/copernican_lib/logger.py
@@ -6,12 +6,12 @@ standard log messages. ``print`` and ``input`` are patched so their text is
 captured to the log file without being echoed twice on the console.
 """
 
+import builtins
 import logging
 import os
 import sys
-import builtins
-import datetime
-from .utils import get_timestamp, ensure_dir_exists
+
+from .utils import ensure_dir_exists, get_timestamp
 
 
 class _PathFilter(logging.Filter):
@@ -25,9 +25,9 @@ class _PathFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         """Remove leading ``base_dir`` segments from log messages."""
         if isinstance(record.msg, str):
-            record.msg = record.msg.replace(self.base_dir + os.sep, "").replace(
-                self.base_dir, "."
-            )
+            # Replace absolute base paths with project-relative forms
+            clean = record.msg.replace(self.base_dir + os.sep, "")
+            record.msg = clean.replace(self.base_dir, ".")
         return True
 
 
@@ -96,11 +96,14 @@ def setup_logging(log_dir: str = ".", base_dir: str | None = None) -> str:
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
 
-    log_filename = os.path.join(log_dir, f"copernican-run_{get_timestamp()}.txt")
+    # Name log file using an execution timestamp
+    run_tag = f"copernican-run_{get_timestamp()}.txt"
+    log_filename = os.path.join(log_dir, run_tag)
 
     fh = logging.FileHandler(log_filename)
     fh.setLevel(logging.INFO)
-    fh.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    fh.setFormatter(formatter)
     if base_dir:
         fh.addFilter(_PathFilter(base_dir))
     logger.addHandler(fh)


### PR DESCRIPTION
## Summary
- wrap path sanitisation and filename setup in `logger.py` to keep lines under 79 chars
- note formatting change in changelog

## Testing
- `pre-commit run --files copernican_lib/logger.py CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68973b45fda0832f90e58e574b29c2c7