### PR TITLE
Wrap long lines in data loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Add one line for each substantive commit or pull request directly under the late
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
 ## Unreleased
+- 2025-08-09: Wrapped long lines in `copernican_lib/data_loaders.py` for 79-column compliance (AI assistant)
 - 2025-08-09: Wrapped long lines in `logger.py` for 79-column compliance (AI assistant)
 - 2025-08-09: Wrapped long lines in `latex_utils.py` for 79-column compliance (AI assistant)
 - 2025-08-09: Wrapped overly long lines in `copernican.py` to satisfy style guide (AI assistant)

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -2,16 +2,17 @@
 """
 Modular data loading for various cosmological datasets (SNe, BAO, etc.).
 """
+import importlib
+import logging
+import os
+
+from . import console_output as console
+from .utils import load_metadata_from_dir
+
 # Each parser is registered via a decorator so that ``copernican.py`` can list
 # available data sources dynamically. The loaders below simply call the
 # registered functions after prompting the user.
-import pandas as pd
-import numpy as np
-import os
-import logging
-import importlib
-from . import console_output as console
-from .utils import load_metadata_from_dir
+
 
 # --- Parser Registry ---
 # Each registry maps a short human readable key to a dictionary
@@ -27,74 +28,90 @@ SIREN_PARSERS: dict = {}
 
 # --- Decorators to register parsers ---
 def register_sne_parser(name=None, description="", data_dir=None):
-    """Decorator to register a SNe data parsing function bound to a data source.
+    """Decorator to register a SNe data parsing function bound to a data
+    source.
 
     The registration no longer requires the human readable dataset name or
     description up front. When ``name`` is ``None`` the base name of
     ``data_dir`` is used as a temporary key and replaced with the metadata
     ``dataset_name`` during discovery.
     """
+
     def decorator(func):
         """Store ``func`` in the SNe parser registry under a temporary key."""
         key = name or os.path.basename(data_dir or func.__name__)
         SNE_PARSERS[key] = {
-            'function': func,
-            'description': description,
-            'data_dir': data_dir,
+            "function": func,
+            "description": description,
+            "data_dir": data_dir,
         }
         return func
+
     return decorator
 
+
 def register_bao_parser(name=None, description="", data_dir=None):
-    """Decorator to register a BAO data parsing function bound to a data source.
+    """Decorator to register a BAO data parsing function bound to a data
+    source.
 
     When ``name`` is ``None`` the dataset directory name is used as a temporary
     key and replaced with the metadata-supplied ``dataset_name`` during
     discovery.
     """
+
     def decorator(func):
         """Store ``func`` in the BAO parser registry under a temporary key."""
         key = name or os.path.basename(data_dir or func.__name__)
         BAO_PARSERS[key] = {
-            'function': func,
-            'description': description,
-            'data_dir': data_dir,
+            "function": func,
+            "description": description,
+            "data_dir": data_dir,
         }
         return func
+
     return decorator
 
+
 def register_cmb_parser(name=None, description="", data_dir=None):
-    """Decorator to register a CMB data parsing function bound to a data source.
+    """Decorator to register a CMB data parsing function bound to a data
+    source.
 
     When ``name`` is omitted the dataset directory name acts as a temporary key
     until discovery replaces it with the metadata ``dataset_name``.
     """
+
     def decorator(func):
         """Store ``func`` in the CMB parser registry under a temporary key."""
         key = name or os.path.basename(data_dir or func.__name__)
         CMB_PARSERS[key] = {
-            'function': func,
-            'description': description,
-            'data_dir': data_dir,
+            "function": func,
+            "description": description,
+            "data_dir": data_dir,
         }
         return func
+
     return decorator
 
+
 def register_gw_parser(name=None, description="", data_dir=None):
-    """Decorator to register a gravitational wave parser bound to a data source.
+    """Decorator to register a gravitational wave parser bound to a data
+    source.
 
     Omitting ``name`` defers human-readable naming to metadata discovery.
     """
+
     def decorator(func):
         """Store ``func`` in the GW parser registry under a temporary key."""
         key = name or os.path.basename(data_dir or func.__name__)
         GW_PARSERS[key] = {
-            'function': func,
-            'description': description,
-            'data_dir': data_dir,
+            "function": func,
+            "description": description,
+            "data_dir": data_dir,
         }
         return func
+
     return decorator
+
 
 def register_siren_parser(name=None, description="", data_dir=None):
     """Decorator to register a standard siren parser bound to a data source.
@@ -102,16 +119,19 @@ def register_siren_parser(name=None, description="", data_dir=None):
     When ``name`` is ``None`` the dataset directory name serves as a temporary
     key and is replaced with the metadata ``dataset_name`` during discovery.
     """
+
     def decorator(func):
         """Store ``func`` in the standard siren parser registry."""
         key = name or os.path.basename(data_dir or func.__name__)
         SIREN_PARSERS[key] = {
-            'function': func,
-            'description': description,
-            'data_dir': data_dir,
+            "function": func,
+            "description": description,
+            "data_dir": data_dir,
         }
         return func
+
     return decorator
+
 
 # --- Dynamic Discovery of Parser Modules ---
 def _discover_parsers():
@@ -122,22 +142,22 @@ def _discover_parsers():
     # read here rather than inside the parser modules so that discovery and
     # user prompts present human readable dataset names without forcing the
     # parsers to access the metadata files themselves.
-    base_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data')
+    base_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
     registry_map = {
-        'sne': SNE_PARSERS,
-        'bao': BAO_PARSERS,
-        'cmb': CMB_PARSERS,
-        'gw': GW_PARSERS,
-        'sirens': SIREN_PARSERS,
+        "sne": SNE_PARSERS,
+        "bao": BAO_PARSERS,
+        "cmb": CMB_PARSERS,
+        "gw": GW_PARSERS,
+        "sirens": SIREN_PARSERS,
     }
-    for dtype in ('sne', 'bao', 'cmb', 'gw', 'sirens'):
+    for dtype in ("sne", "bao", "cmb", "gw", "sirens"):
         type_dir = os.path.join(base_dir, dtype)
         if not os.path.isdir(type_dir):
             continue
         for source in os.listdir(type_dir):
             # Skip placeholder folders so unfinished datasets do not appear in
             # the interactive menus.
-            if source.lower() == 'placeholder':
+            if source.lower() == "placeholder":
                 continue
             src_dir = os.path.join(type_dir, source)
             if not os.path.isdir(src_dir):
@@ -145,35 +165,49 @@ def _discover_parsers():
             meta = load_metadata_from_dir(src_dir)
             placeholder_key = os.path.basename(src_dir)
             for fname in os.listdir(src_dir):
-                if fname.startswith('cosmo_parser_') and fname.endswith('.py'):
+                if fname.startswith("cosmo_parser_") and fname.endswith(".py"):
                     module_name = f"data.{dtype}.{source}.{fname[:-3]}"
                     file_path = os.path.join(src_dir, fname)
-                    spec = importlib.util.spec_from_file_location(module_name, file_path)
+                    spec = importlib.util.spec_from_file_location(
+                        module_name,
+                        file_path,
+                    )
                     module = importlib.util.module_from_spec(spec)
                     try:
                         spec.loader.exec_module(module)
                     except Exception as e:
-                        logging.getLogger().error(f"Failed loading parser module {file_path}: {e}")
+                        logging.getLogger().error(
+                            f"Failed loading parser module {file_path}: {e}",
+                        )
                     registry = registry_map[dtype]
                     if placeholder_key in registry:
                         entry = registry.pop(placeholder_key)
-                        dataset_name = meta.get('dataset_name', placeholder_key)
-                        entry['description'] = meta.get('description', entry.get('description', ''))
-                        entry['data_dir'] = src_dir
+                        dataset_name = meta.get(
+                            "dataset_name",
+                            placeholder_key,
+                        )
+                        entry["description"] = meta.get(
+                            "description",
+                            entry.get("description", ""),
+                        )
+                        entry["data_dir"] = src_dir
                         registry[dataset_name] = entry
                     # If the parser registered with an explicit name, simply
                     # update the description if metadata provides one.
                     else:
-                        dataset_name = meta.get('dataset_name')
+                        dataset_name = meta.get("dataset_name")
                         if dataset_name and dataset_name in registry:
-                            registry[dataset_name]['description'] = meta.get(
-                                'description', registry[dataset_name].get('description', '')
+                            registry[dataset_name]["description"] = meta.get(
+                                "description",
+                                registry[dataset_name].get("description", ""),
                             )
+
 
 # Discover parsers at import time so that functions like
 # ``load_sne_data`` can simply refer to the registries without
 # additional setup.
 _discover_parsers()
+
 
 # --- Helper to list and select parsers ---
 def _select_source(parser_registry, data_type_name):
@@ -186,14 +220,18 @@ def _select_source(parser_registry, data_type_name):
     logger.info(f"\nAvailable {data_type_name} data sources:")
     options = list(parser_registry.keys())
     for i, key in enumerate(options):
-        desc = parser_registry[key]['description']
-        console.write(f"  {i+1}. {key} ({desc})" if desc else f"  {i+1}. {key}")
+        desc = parser_registry[key]["description"]
+        console.write(
+            f"  {i+1}. {key} ({desc})" if desc else f"  {i+1}. {key}",
+        )
 
-    console.write("Write the number of your preferred choice or 'c' to cancel:")
+    console.write(
+        "Write the number of your preferred choice or 'c' to cancel:",
+    )
     while True:
         try:
             choice = console.ask("> ").strip()
-            if choice.lower() == 'c':
+            if choice.lower() == "c":
                 return None
             choice_idx = int(choice) - 1
             if 0 <= choice_idx < len(options):
@@ -202,6 +240,7 @@ def _select_source(parser_registry, data_type_name):
                 console.write("Invalid selection. Please try again.")
         except ValueError:
             console.write("Invalid input. Please enter a number or 'c'.")
+
 
 # --- Verbose dataset info helper ---
 def _log_dataset_info(df, data_type, logger):
@@ -217,13 +256,24 @@ def _log_dataset_info(df, data_type, logger):
     # identifier when only that field is available.  Loaders attach both
     # ``dataset_name`` (original string) and ``dataset_name_sanitized``
     # (underscored variant).
-    name = df.attrs.get("dataset_name", df.attrs.get("dataset_name_sanitized", ""))
-    logger.info(f"Loaded {data_type} dataset '{name}' with {len(df)} rows.")
+    name = df.attrs.get(
+        "dataset_name",
+        df.attrs.get("dataset_name_sanitized", ""),
+    )
+    logger.info(
+        f"Loaded {data_type} dataset '{name}' with {len(df)} rows.",
+    )
     if "covariance_matrix_inv" in df.attrs:
         if df.attrs["covariance_matrix_inv"] is not None:
-            logger.info(f"{data_type} covariance matrix inverted successfully.")
+            logger.info(
+                f"{data_type} covariance matrix inverted successfully.",
+            )
         else:
-            logger.info(f"{data_type} parser provided no usable covariance matrix; using diagonal errors only.")
+            logger.info(
+                f"{data_type} parser provided no usable covariance matrix; "
+                "using diagonal errors only.",
+            )
+
 
 # --- Main Loading Functions ---
 def load_sne_data(source_key=None, **kwargs):
@@ -240,8 +290,8 @@ def load_sne_data(source_key=None, **kwargs):
         return None
 
     entry = SNE_PARSERS[source_key]
-    parser_func = entry['function']
-    data_dir = entry['data_dir']
+    parser_func = entry["function"]
+    data_dir = entry["data_dir"]
     try:
         logger.info(f"Attempting to load SNe data from source '{source_key}'")
         data_df = parser_func(data_dir, **kwargs)
@@ -249,20 +299,33 @@ def load_sne_data(source_key=None, **kwargs):
             meta = load_metadata_from_dir(data_dir)
             if meta:
                 data_df.attrs.update(meta)
-            data_df.attrs['source_key'] = source_key
-            dataset_name = data_df.attrs.get('dataset_name', source_key)
-            data_df.attrs['dataset_name'] = dataset_name
-            data_df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
-            logger.info(f"Successfully loaded {len(data_df)} SNe data points.")
+            data_df.attrs["source_key"] = source_key
+            dataset_name = data_df.attrs.get("dataset_name", source_key)
+            data_df.attrs["dataset_name"] = dataset_name
+            data_df.attrs["dataset_name_sanitized"] = dataset_name.replace(
+                " ",
+                "_",
+            )
+            logger.info(
+                f"Successfully loaded {len(data_df)} SNe data points.",
+            )
             _log_dataset_info(data_df, "SNe", logger)
         elif data_df is None:
-             logger.error(f"SNe parser '{source_key}' returned None.")
+            logger.error(
+                f"SNe parser '{source_key}' returned None.",
+            )
         else:
-             logger.error(f"SNe parser '{source_key}' returned an empty DataFrame.")
+            logger.error(
+                f"SNe parser '{source_key}' returned an empty DataFrame.",
+            )
         return data_df
     except Exception as e:
-        logger.critical(f"CRITICAL Error during SNe data parsing ({source_key}): {e}", exc_info=True)
+        logger.critical(
+            f"CRITICAL Error during SNe data parsing ({source_key}): {e}",
+            exc_info=True,
+        )
         return None
+
 
 def load_bao_data(source_key=None, **kwargs):
     """Loads BAO data for the chosen source."""
@@ -278,8 +341,8 @@ def load_bao_data(source_key=None, **kwargs):
         return None
 
     entry = BAO_PARSERS[source_key]
-    parser_func = entry['function']
-    data_dir = entry['data_dir']
+    parser_func = entry["function"]
+    data_dir = entry["data_dir"]
     try:
         logger.info(f"Attempting to load BAO data from source '{source_key}'")
         data_df = parser_func(data_dir, **kwargs)
@@ -287,20 +350,33 @@ def load_bao_data(source_key=None, **kwargs):
             meta = load_metadata_from_dir(data_dir)
             if meta:
                 data_df.attrs.update(meta)
-            data_df.attrs['source_key'] = source_key
-            dataset_name = data_df.attrs.get('dataset_name', source_key)
-            data_df.attrs['dataset_name'] = dataset_name
-            data_df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
-            logger.info(f"Successfully loaded {len(data_df)} BAO data points.")
+            data_df.attrs["source_key"] = source_key
+            dataset_name = data_df.attrs.get("dataset_name", source_key)
+            data_df.attrs["dataset_name"] = dataset_name
+            data_df.attrs["dataset_name_sanitized"] = dataset_name.replace(
+                " ",
+                "_",
+            )
+            logger.info(
+                f"Successfully loaded {len(data_df)} BAO data points.",
+            )
             _log_dataset_info(data_df, "BAO", logger)
         elif data_df is None:
-            logger.error(f"BAO parser '{source_key}' returned None.")
+            logger.error(
+                f"BAO parser '{source_key}' returned None.",
+            )
         else:
-            logger.error(f"BAO parser '{source_key}' returned an empty DataFrame.")
+            logger.error(
+                f"BAO parser '{source_key}' returned an empty DataFrame.",
+            )
         return data_df
     except Exception as e:
-        logger.critical(f"CRITICAL Error during BAO data parsing ({source_key}): {e}", exc_info=True)
+        logger.critical(
+            f"CRITICAL Error during BAO data parsing ({source_key}): {e}",
+            exc_info=True,
+        )
         return None
+
 
 def load_cmb_data(source_key=None, **kwargs):
     """Loads CMB data for the chosen source."""
@@ -316,8 +392,8 @@ def load_cmb_data(source_key=None, **kwargs):
         return None
 
     entry = CMB_PARSERS[source_key]
-    parser_func = entry['function']
-    data_dir = entry['data_dir']
+    parser_func = entry["function"]
+    data_dir = entry["data_dir"]
     try:
         logger.info(f"Attempting to load CMB data from source '{source_key}'")
         data_df = parser_func(data_dir, **kwargs)
@@ -325,20 +401,33 @@ def load_cmb_data(source_key=None, **kwargs):
             meta = load_metadata_from_dir(data_dir)
             if meta:
                 data_df.attrs.update(meta)
-            data_df.attrs['source_key'] = source_key
-            dataset_name = data_df.attrs.get('dataset_name', source_key)
-            data_df.attrs['dataset_name'] = dataset_name
-            data_df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
-            logger.info(f"Successfully loaded {len(data_df)} CMB data points.")
+            data_df.attrs["source_key"] = source_key
+            dataset_name = data_df.attrs.get("dataset_name", source_key)
+            data_df.attrs["dataset_name"] = dataset_name
+            data_df.attrs["dataset_name_sanitized"] = dataset_name.replace(
+                " ",
+                "_",
+            )
+            logger.info(
+                f"Successfully loaded {len(data_df)} CMB data points.",
+            )
             _log_dataset_info(data_df, "CMB", logger)
         elif data_df is None:
-            logger.error(f"CMB parser '{source_key}' returned None.")
+            logger.error(
+                f"CMB parser '{source_key}' returned None.",
+            )
         else:
-            logger.error(f"CMB parser '{source_key}' returned an empty DataFrame.")
+            logger.error(
+                f"CMB parser '{source_key}' returned an empty DataFrame.",
+            )
         return data_df
     except Exception as e:
-        logger.critical(f"CRITICAL Error during CMB data parsing ({source_key}): {e}", exc_info=True)
+        logger.critical(
+            f"CRITICAL Error during CMB data parsing ({source_key}): {e}",
+            exc_info=True,
+        )
         return None
+
 
 def load_gw_data(source_key=None, **kwargs):
     """Loads gravitational wave data for the chosen source."""
@@ -350,33 +439,54 @@ def load_gw_data(source_key=None, **kwargs):
             return None
 
     if source_key not in GW_PARSERS:
-        logger.error(f"No gravitational wave parser registered for source '{source_key}'")
+        # fmt: off
+        msg = (
+            "No gravitational wave parser registered for source "
+            f"'{source_key}'"
+        )
+        # fmt: on
+        logger.error(msg)
         return None
 
     entry = GW_PARSERS[source_key]
-    parser_func = entry['function']
-    data_dir = entry['data_dir']
+    parser_func = entry["function"]
+    data_dir = entry["data_dir"]
     try:
-        logger.info(f"Attempting to load GW data from source '{source_key}'")
+        logger.info(
+            f"Attempting to load GW data from source '{source_key}'",
+        )
         data_df = parser_func(data_dir, **kwargs)
         if data_df is not None and not data_df.empty:
             meta = load_metadata_from_dir(data_dir)
             if meta:
                 data_df.attrs.update(meta)
-            data_df.attrs['source_key'] = source_key
-            dataset_name = data_df.attrs.get('dataset_name', source_key)
-            data_df.attrs['dataset_name'] = dataset_name
-            data_df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
-            logger.info(f"Successfully loaded {len(data_df)} GW data points.")
+            data_df.attrs["source_key"] = source_key
+            dataset_name = data_df.attrs.get("dataset_name", source_key)
+            data_df.attrs["dataset_name"] = dataset_name
+            data_df.attrs["dataset_name_sanitized"] = dataset_name.replace(
+                " ",
+                "_",
+            )
+            logger.info(
+                f"Successfully loaded {len(data_df)} GW data points.",
+            )
             _log_dataset_info(data_df, "GW", logger)
         elif data_df is None:
-            logger.error(f"GW parser '{source_key}' returned None.")
+            logger.error(
+                f"GW parser '{source_key}' returned None.",
+            )
         else:
-            logger.error(f"GW parser '{source_key}' returned an empty DataFrame.")
+            logger.error(
+                f"GW parser '{source_key}' returned an empty DataFrame.",
+            )
         return data_df
     except Exception as e:
-        logger.critical(f"CRITICAL Error during GW data parsing ({source_key}): {e}", exc_info=True)
+        logger.critical(
+            f"CRITICAL Error during GW data parsing ({source_key}): {e}",
+            exc_info=True,
+        )
         return None
+
 
 def load_siren_data(source_key=None, **kwargs):
     """Loads standard siren data for the chosen source."""
@@ -388,30 +498,54 @@ def load_siren_data(source_key=None, **kwargs):
             return None
 
     if source_key not in SIREN_PARSERS:
-        logger.error(f"No standard siren parser registered for source '{source_key}'")
+        logger.error(
+            f"No standard siren parser registered for source '{source_key}'",
+        )
         return None
 
     entry = SIREN_PARSERS[source_key]
-    parser_func = entry['function']
-    data_dir = entry['data_dir']
+    parser_func = entry["function"]
+    data_dir = entry["data_dir"]
     try:
-        logger.info(f"Attempting to load siren data from source '{source_key}'")
+        logger.info(
+            f"Attempting to load siren data from source '{source_key}'",
+        )
         data_df = parser_func(data_dir, **kwargs)
         if data_df is not None and not data_df.empty:
             meta = load_metadata_from_dir(data_dir)
             if meta:
                 data_df.attrs.update(meta)
-            data_df.attrs['source_key'] = source_key
-            dataset_name = data_df.attrs.get('dataset_name', source_key)
-            data_df.attrs['dataset_name'] = dataset_name
-            data_df.attrs['dataset_name_sanitized'] = dataset_name.replace(' ', '_')
-            logger.info(f"Successfully loaded {len(data_df)} standard siren data points.")
+            data_df.attrs["source_key"] = source_key
+            dataset_name = data_df.attrs.get("dataset_name", source_key)
+            data_df.attrs["dataset_name"] = dataset_name
+            data_df.attrs["dataset_name_sanitized"] = dataset_name.replace(
+                " ",
+                "_",
+            )
+            # fmt: off
+            msg = (
+                f"Successfully loaded {len(data_df)} standard siren "
+                f"data points."
+            )
+            # fmt: on
+            logger.info(msg)
             _log_dataset_info(data_df, "SIREN", logger)
         elif data_df is None:
-            logger.error(f"Standard siren parser '{source_key}' returned None.")
+            logger.error(
+                f"Standard siren parser '{source_key}' returned None.",
+            )
         else:
-            logger.error(f"Standard siren parser '{source_key}' returned an empty DataFrame.")
+            logger.error(
+                f"Standard siren parser '{source_key}' returned an empty "
+                f"DataFrame.",
+            )
         return data_df
     except Exception as e:
-        logger.critical(f"CRITICAL Error during standard siren data parsing ({source_key}): {e}", exc_info=True)
+        # fmt: off
+        err_msg = (
+            "CRITICAL Error during standard siren data parsing "
+            f"({source_key}): {e}"
+        )
+        # fmt: on
+        logger.critical(err_msg, exc_info=True)
         return None


### PR DESCRIPTION
## Summary
- wrap overly long strings and comments in `data_loaders` for 79-column compliance
- document change in changelog

## Testing
- `pre-commit run --files copernican_lib/data_loaders.py CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68973dc41ff8832fbc2e323987dcd80d