### PR TITLE
Trim __init__ comment for line length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Add one line for each substantive commit or pull request directly under the late
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
 ## Unreleased
+- 2025-08-09: Shortened long comment in `copernican_lib/__init__.py` (AI assistant)
 - 2025-08-09: Wrapped long lines in `copernican_lib/data_loaders.py` for 79-column compliance (AI assistant)
 - 2025-08-09: Wrapped long lines in `logger.py` for 79-column compliance (AI assistant)
 - 2025-08-09: Wrapped long lines in `latex_utils.py` for 79-column compliance (AI assistant)

--- a/copernican_lib/__init__.py
+++ b/copernican_lib/__init__.py
@@ -7,4 +7,4 @@ individual engines remain lightweight.
 """
 
 # Nothing else is defined here. Importing this package simply exposes the
-# submodules such as ``logger`` and ``plotter`` which the rest of the code uses.
+# submodules like ``logger`` and ``plotter`` used throughout the code.


### PR DESCRIPTION
## Summary
- Shorten package comment in `copernican_lib/__init__.py` for 79-character compliance
- Log the comment update in `CHANGELOG.md`

## Testing
- `pre-commit run --files copernican_lib/__init__.py CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_689742f7eebc832fa317df50143e99ab