### PR TITLE
Wrap error_handler comments to 79 columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Add one line for each substantive commit or pull request directly under the late
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
 ## Unreleased
+- 2025-08-09: Wrapped long lines in `copernican_lib/error_handler.py` for 79-column compliance (AI assistant)
 - 2025-08-09: Shortened long comment in `copernican_lib/__init__.py` (AI assistant)
 - 2025-08-09: Wrapped long lines in `copernican_lib/data_loaders.py` for 79-column compliance (AI assistant)
 - 2025-08-09: Wrapped long lines in `logger.py` for 79-column compliance (AI assistant)

--- a/copernican_lib/error_handler.py
+++ b/copernican_lib/error_handler.py
@@ -11,6 +11,6 @@ import logging
 def report_error(message: str) -> None:
     """Log ``message`` to the shared application logger."""
     # Parsers call this helper instead of accessing the root logger directly so
-    # that logging configuration stays centralised. Any error messages end up in
-    # the same log file as the main application output.
+    # that logging configuration stays centralised. Any error messages end up
+    # in the same log file as the main application output.
     logging.getLogger().error(message)


### PR DESCRIPTION
## Summary
- wrap error_handler comments to stay within 79 columns
- document change in changelog

## Testing
- `pre-commit run --files copernican_lib/error_handler.py CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_689744a20d48832f963124e58baed5b8