### PR TITLE
Wrap long lines in CSV writer for 79-char compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Add one line for each substantive commit or pull request directly under the late
 - **MINOR**: backward-compatible feature additions.
 - **PATCH**: backward-compatible bug fixes and documentation updates.
 
+## Version 3.6.4
+- 2025-08-09: Wrapped long lines in `copernican_lib/csv_writer.py` for
+  79-column compliance (AI assistant)
+
 ## Version 3.6.3
 - 2025-08-09: Wrapped long lines across `copernican_lib` modules and `copernican.py` for 79-column compliance (AI assistant)
 - 2025-08-09: Lowered minimum Python version to 3.11, pinned `camb` to 1.6.2, updated CI and documentation (AI assistant)

--- a/copernican_lib/csv_writer.py
+++ b/copernican_lib/csv_writer.py
@@ -3,12 +3,13 @@
 # Functions here convert the results of a run into comma-separated value files
 # so that they can be analysed with spreadsheets or other tools. Each helper
 # handles a specific data type such as SNe, BAO or CMB.
-from typing import Any
 import os
+from typing import Any
+
 import numpy as np
 
-from .utils import generate_filename, ensure_dir_exists
 from .logger import get_logger
+from .utils import ensure_dir_exists, generate_filename
 
 
 def save_sne_results_detailed_csv(
@@ -20,11 +21,16 @@ def save_sne_results_detailed_csv(
     csv_dir: str = ".",
     timestamp: str | None = None,
 ) -> None:
-    """Save a detailed, point-by-point breakdown of the SNe Ia fitting results."""
+    """Save a detailed, point-by-point breakdown of the SNe Ia fitting
+    results."""
     ensure_dir_exists(csv_dir)
     logger = get_logger()
 
-    cols_to_keep = [col for col in ["Name", "zcmb", "mu_obs", "e_mu_obs"] if col in sne_data_df.columns]
+    cols_to_keep = [
+        col
+        for col in ["Name", "zcmb", "mu_obs", "e_mu_obs"]
+        if col in sne_data_df.columns
+    ]
     df_out = sne_data_df[cols_to_keep].copy()
 
     z_data = df_out["zcmb"].values
@@ -39,9 +45,12 @@ def save_sne_results_detailed_csv(
         df_out["mu_model_lcdm"] = np.nan
         df_out["residual_lcdm"] = np.nan
 
-    alt_model_name = alt_model_plugin.MODEL_NAME.replace(" ", "_").replace(".", "")
+    alt_model_name = alt_model_plugin.MODEL_NAME.replace(" ", "_")
+    alt_model_name = alt_model_name.replace(".", "")
     if alt_model_fit_results and alt_model_fit_results.get("success"):
-        p_alt = list(alt_model_fit_results["fitted_cosmological_params"].values())
+        p_alt = list(
+            alt_model_fit_results["fitted_cosmological_params"].values(),
+        )
         mu_model_alt = alt_model_plugin.distance_modulus_model(z_data, *p_alt)
         df_out[f"mu_model_{alt_model_name}"] = mu_model_alt
         df_out[f"residual_{alt_model_name}"] = mu_data - mu_model_alt
@@ -59,7 +68,11 @@ def save_sne_results_detailed_csv(
         timestamp=timestamp,
     )
     try:
-        df_out.to_csv(os.path.join(csv_dir, filename), index=False, float_format="%.8g")
+        df_out.to_csv(
+            os.path.join(csv_dir, filename),
+            index=False,
+            float_format="%.8g",
+        )
         logger.info(f"SNe detailed results CSV saved to {filename}")
     except Exception as exc:
         logger.error(f"Error saving SNe detailed results CSV: {exc}")
@@ -82,14 +95,28 @@ def save_bao_results_csv(
 
     df_out = bao_data_df.copy()
 
-    if lcdm_results and lcdm_results.get("pred_df") is not None and not lcdm_results["pred_df"].empty:
+    if (
+        lcdm_results
+        and lcdm_results.get("pred_df") is not None
+        and not lcdm_results["pred_df"].empty
+    ):
         df_out["pred_lcdm"] = lcdm_results["pred_df"]["model_prediction"]
-        df_out["chi2_contrib_lcdm"] = ((df_out["value"] - df_out["pred_lcdm"]) / df_out["error"]) ** 2
+        df_out["chi2_contrib_lcdm"] = (
+            (df_out["value"] - df_out["pred_lcdm"]) / df_out["error"]
+        ) ** 2
 
     alt_model_name_safe = alt_model_name.replace(" ", "_").replace(".", "")
-    if alt_model_results and alt_model_results.get("pred_df") is not None and not alt_model_results["pred_df"].empty:
-        df_out[f"pred_{alt_model_name_safe}"] = alt_model_results["pred_df"]["model_prediction"]
-        df_out[f"chi2_contrib_{alt_model_name_safe}"] = ((df_out["value"] - df_out[f"pred_{alt_model_name_safe}"]) / df_out["error"]) ** 2
+    if (
+        alt_model_results
+        and alt_model_results.get("pred_df") is not None
+        and not alt_model_results["pred_df"].empty
+    ):
+        df_out[f"pred_{alt_model_name_safe}"] = alt_model_results["pred_df"][
+            "model_prediction"
+        ]
+        diff = df_out["value"] - df_out[f"pred_{alt_model_name_safe}"]
+        ratio = diff / df_out["error"]
+        df_out[f"chi2_contrib_{alt_model_name_safe}"] = ratio**2
 
     dataset_name = bao_data_df.attrs.get("dataset_name_sanitized", "BAO_data")
     model_comparison_name = f"LCDM-vs-{alt_model_name}"
@@ -101,7 +128,11 @@ def save_bao_results_csv(
         timestamp=timestamp,
     )
     try:
-        df_out.to_csv(os.path.join(csv_dir, filename), index=False, float_format="%.6g")
+        df_out.to_csv(
+            os.path.join(csv_dir, filename),
+            index=False,
+            float_format="%.6g",
+        )
         logger.info(f"BAO detailed results CSV saved to {filename}")
     except Exception as exc:
         logger.error(f"Error saving BAO detailed results CSV: {exc}")
@@ -136,47 +167,72 @@ def save_cmb_results_csv(
                 df_out["residual_lcdm_tt"] = df_out["Dl_obs"] - th_lcdm["TT"]
             if "TE" in th_lcdm and "Dl_te_obs" in df_out.columns:
                 df_out["Dl_lcdm_te"] = th_lcdm["TE"]
-                df_out["residual_lcdm_te"] = df_out["Dl_te_obs"] - th_lcdm["TE"]
+                te_diff = df_out["Dl_te_obs"] - th_lcdm["TE"]
+                df_out["residual_lcdm_te"] = te_diff
             if "EE" in th_lcdm and "Dl_ee_obs" in df_out.columns:
                 df_out["Dl_lcdm_ee"] = th_lcdm["EE"]
-                df_out["residual_lcdm_ee"] = df_out["Dl_ee_obs"] - th_lcdm["EE"]
+                ee_diff = df_out["Dl_ee_obs"] - th_lcdm["EE"]
+                df_out["residual_lcdm_ee"] = ee_diff
         else:
             df_out["Dl_lcdm"] = th_lcdm
             df_out["residual_lcdm"] = df_out["Dl_obs"] - th_lcdm
     else:
-        df_out[[
-            col
-            for col in ["Dl_lcdm", "residual_lcdm", "Dl_lcdm_tt", "residual_lcdm_tt",
-                        "Dl_lcdm_te", "residual_lcdm_te", "Dl_lcdm_ee", "residual_lcdm_ee"]
-            if col not in df_out.columns
-        ]] = np.nan
+        df_out[
+            [
+                col
+                for col in [
+                    "Dl_lcdm",
+                    "residual_lcdm",
+                    "Dl_lcdm_tt",
+                    "residual_lcdm_tt",
+                    "Dl_lcdm_te",
+                    "residual_lcdm_te",
+                    "Dl_lcdm_ee",
+                    "residual_lcdm_ee",
+                ]
+                if col not in df_out.columns
+            ]
+        ] = np.nan
 
     alt_name_safe = alt_model_name.replace(" ", "_").replace(".", "")
-    if alt_model_results and alt_model_results.get("theory_spectrum") is not None:
+    has_theory = False
+    if alt_model_results:
+        has_theory = alt_model_results.get("theory_spectrum") is not None
+    if has_theory:
         th_alt = alt_model_results["theory_spectrum"]
         if isinstance(th_alt, dict):
             if "TT" in th_alt:
                 df_out[f"Dl_{alt_name_safe}_tt"] = th_alt["TT"]
-                df_out[f"residual_{alt_name_safe}_tt"] = df_out["Dl_obs"] - th_alt["TT"]
+                tt_diff = df_out["Dl_obs"] - th_alt["TT"]
+                df_out[f"residual_{alt_name_safe}_tt"] = tt_diff
             if "TE" in th_alt and "Dl_te_obs" in df_out.columns:
                 df_out[f"Dl_{alt_name_safe}_te"] = th_alt["TE"]
-                df_out[f"residual_{alt_name_safe}_te"] = df_out["Dl_te_obs"] - th_alt["TE"]
+                te_diff = df_out["Dl_te_obs"] - th_alt["TE"]
+                df_out[f"residual_{alt_name_safe}_te"] = te_diff
             if "EE" in th_alt and "Dl_ee_obs" in df_out.columns:
                 df_out[f"Dl_{alt_name_safe}_ee"] = th_alt["EE"]
-                df_out[f"residual_{alt_name_safe}_ee"] = df_out["Dl_ee_obs"] - th_alt["EE"]
+                ee_diff = df_out["Dl_ee_obs"] - th_alt["EE"]
+                df_out[f"residual_{alt_name_safe}_ee"] = ee_diff
         else:
             df_out[f"Dl_{alt_name_safe}"] = th_alt
             df_out[f"residual_{alt_name_safe}"] = df_out["Dl_obs"] - th_alt
     else:
-        df_out[[
-            col
-            for col in [
-                f"Dl_{alt_name_safe}", f"residual_{alt_name_safe}",
-                f"Dl_{alt_name_safe}_tt", f"residual_{alt_name_safe}_tt",
-                f"Dl_{alt_name_safe}_te", f"residual_{alt_name_safe}_te",
-                f"Dl_{alt_name_safe}_ee", f"residual_{alt_name_safe}_ee",
-            ] if col not in df_out.columns
-        ]] = np.nan
+        df_out[
+            [
+                col
+                for col in [
+                    f"Dl_{alt_name_safe}",
+                    f"residual_{alt_name_safe}",
+                    f"Dl_{alt_name_safe}_tt",
+                    f"residual_{alt_name_safe}_tt",
+                    f"Dl_{alt_name_safe}_te",
+                    f"residual_{alt_name_safe}_te",
+                    f"Dl_{alt_name_safe}_ee",
+                    f"residual_{alt_name_safe}_ee",
+                ]
+                if col not in df_out.columns
+            ]
+        ] = np.nan
 
     dataset_name = cmb_data_df.attrs.get("dataset_name_sanitized", "CMB_data")
     model_comparison_name = f"LCDM-vs-{alt_name_safe}"
@@ -188,7 +244,11 @@ def save_cmb_results_csv(
         timestamp=timestamp,
     )
     try:
-        df_out.to_csv(os.path.join(csv_dir, filename), index=False, float_format="%.6g")
+        df_out.to_csv(
+            os.path.join(csv_dir, filename),
+            index=False,
+            float_format="%.6g",
+        )
         logger.info(f"CMB detailed results CSV saved to {filename}")
     except Exception as exc:
         logger.error(f"Error saving CMB detailed results CSV: {exc}")


### PR DESCRIPTION
## Summary
- wrap long lines in `csv_writer` to meet 79-character limit
- log the line-wrapping in the changelog

## Testing
- `pre-commit run --files CHANGELOG.md copernican_lib/csv_writer.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6897541a5888832fa3431399e23f2366