### PR TITLE
Wrap long line in model_parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Add one line for each substantive commit or pull request directly under the late
 - **MINOR**: backward-compatible feature additions.
 - **PATCH**: backward-compatible bug fixes and documentation updates.
 
+## Version 3.6.5
+- 2025-08-09: Wrapped long line in `copernican_lib/model_parser.py` to
+  enforce 79-character limit (AI assistant)
+
 ## Version 3.6.4
 - 2025-08-09: Wrapped long lines in `copernican_lib/csv_writer.py` for
   79-column compliance (AI assistant)

--- a/copernican_lib/model_parser.py
+++ b/copernican_lib/model_parser.py
@@ -4,13 +4,13 @@
 # a sanitized copy to ``models/cache/``. The sanitized file is used by child
 # processes so that validation only happens once in the main process.
 
-import yaml
-import re
-from jsonschema import validate, ValidationError
-from pathlib import Path
 import multiprocessing as _mp
-from . import error_handler
-from . import latex_utils
+from pathlib import Path
+
+import yaml
+from jsonschema import ValidationError, validate
+
+from . import error_handler, latex_utils
 
 
 def _sanitise_name_to_var(name: str) -> str:
@@ -32,6 +32,7 @@ def _ensure_delim(expr: str | None) -> str | None:
     cleaned = f"$${cleaned}$$"
     return cleaned
 
+
 MODEL_SCHEMA = {
     "type": "object",
     "required": ["model_name", "version", "parameters", "equations"],
@@ -50,12 +51,12 @@ MODEL_SCHEMA = {
                         "type": "array",
                         "minItems": 2,
                         "maxItems": 2,
-                        "items": {"type": "number"}
+                        "items": {"type": "number"},
                     },
                     "unit": {"type": "string"},
-                    "latex_name": {"type": "string"}
-                }
-            }
+                    "latex_name": {"type": "string"},
+                },
+            },
         },
         "equations": {"type": "object"},
         "rs_expression": {"type": "string"},
@@ -66,8 +67,8 @@ MODEL_SCHEMA = {
         # Optional human-readable fields used by upcoming UI modules
         "abstract": {"type": "string"},
         "description": {"type": "string"},
-        "notes": {"type": "string"}
-    }
+        "notes": {"type": "string"},
+    },
 }
 
 
@@ -105,15 +106,16 @@ def parse_model(path, cache_dir):
         try:
             validate(instance=data, schema=MODEL_SCHEMA)
         except ValidationError as e:
-            error_handler.report_error(
-                f"Model YAML validation error: {e.message}"
-            )
-            raise ValueError(
-                f"Model YAML validation error: {e.message}"
-            ) from e
+            msg = f"Model YAML validation error: {e.message}"
+            error_handler.report_error(msg)
+            raise ValueError(msg) from e
 
     # Auto-generate missing python_var fields from LaTeX names
-    used_vars = {p.get("python_var") for p in data.get("parameters", []) if p.get("python_var")}
+    used_vars = {
+        param.get("python_var")
+        for param in data.get("parameters", [])
+        if param.get("python_var")
+    }
     for param in data.get("parameters", []):
         if "latex_name" not in param:
             raise ValueError("Missing required latex_name for parameter")
@@ -128,9 +130,9 @@ def parse_model(path, cache_dir):
             used_vars.add(candidate)
 
     # Ensure mathematical fields are wrapped with '$$' for downstream tools
-    data['Hz_expression'] = _ensure_delim(data.get('Hz_expression'))
-    data['rs_expression'] = _ensure_delim(data.get('rs_expression'))
-    eq_sections = data.get('equations', {})
+    data["Hz_expression"] = _ensure_delim(data.get("Hz_expression"))
+    data["rs_expression"] = _ensure_delim(data.get("rs_expression"))
+    eq_sections = data.get("equations", {})
     for key, arr in eq_sections.items():
         if isinstance(arr, list):
             eq_sections[key] = [_ensure_delim(e) for e in arr]


### PR DESCRIPTION
## Summary
- refactor validation error handling for clearer message reuse and line-length compliance
- split `used_vars` comprehension into multi-line form with descriptive variable names
- document 79-character limit fix in changelog

## Testing
- `pre-commit run --files copernican_lib/model_parser.py CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68976faa4d7c832f9856fd01a9cb0696