### PR TITLE
Wrap generate_filename definition for 79-char compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Add one line for each substantive commit or pull request directly under the late
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
 ## Unreleased
+- 2025-08-09: Wrapped `generate_filename` for 79-char limit (AI assistant)
 
 ### Version Bump Rules
 - **MAJOR**: incompatible API changes.

--- a/copernican_lib/utils.py
+++ b/copernican_lib/utils.py
@@ -9,11 +9,12 @@ been removed.
 # These helpers are intentionally tiny but keep repetitive tasks such as
 # timestamp generation and directory creation in one place.
 
+import logging
 import os
 import time
-import yaml
-import logging
+
 import numpy as np
+import yaml
 
 
 def get_timestamp():
@@ -21,7 +22,13 @@ def get_timestamp():
     return time.strftime("%Y%m%d_%H%M%S")
 
 
-def generate_filename(file_type, dataset_name, ext, model_name="", timestamp=None):
+def generate_filename(
+    file_type,
+    dataset_name,
+    ext,
+    model_name="",
+    timestamp=None,
+):
     """Generates a harmonized filename for all outputs.
 
     Parameters
@@ -38,17 +45,17 @@ def generate_filename(file_type, dataset_name, ext, model_name="", timestamp=Non
         Timestamp string applied to the filename. When ``None`` the current
         timestamp is generated.
     """
-    sanitized_type = file_type.replace('_', '-').lower()
-    sanitized_model = model_name.replace('_', '-').replace('.', '')
+    sanitized_type = file_type.replace("_", "-").lower()
+    sanitized_model = model_name.replace("_", "-").replace(".", "")
     # Remove whitespace, file extensions and unsafe path characters so the
     # resulting filename is portable across platforms.
     sanitized_dataset = (
-        dataset_name.replace('_', '-')
-        .replace(' ', '')
-        .replace('/', '-')
-        .replace('.yml', '')
-        .replace('.yaml', '')
-        .replace('.dat', '')
+        dataset_name.replace("_", "-")
+        .replace(" ", "")
+        .replace("/", "-")
+        .replace(".yml", "")
+        .replace(".yaml", "")
+        .replace(".dat", "")
     )
     base_name = (
         f"{sanitized_type}-{sanitized_model}-{sanitized_dataset}"
@@ -75,12 +82,14 @@ def load_metadata_from_dir(data_dir: str) -> dict:
     line-by-line fallback parser is used when the strict loader fails.
     """
     try:
+        # fmt: off
         meta_files = [
             f
             for f in os.listdir(data_dir)
             if f.startswith("metadata")
             and f.lower().endswith((".yml", ".yaml"))
         ]
+        # fmt: on
         if meta_files:
             path = os.path.join(data_dir, sorted(meta_files)[0])
             try:


### PR DESCRIPTION
## Summary
- wrap `generate_filename` parameters across lines to respect the 79-character limit
- record the change in the changelog

## Testing
- `pre-commit run --files copernican_lib/utils.py CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68977372e4c8832f8517ff161e08aae0