### PR TITLE
docs: record 79-char line wraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Add one line for each substantive commit or pull request directly under the late
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
 ## Unreleased
+- 2025-08-09: Wrapped long lines in `copernican_lib/csv_writer.py`,
+  `model_coder.py`, `model_parser.py`, `optim_utils.py` and `utils.py`
+  for 79-column compliance (AI assistant)
 - 2025-08-09: Wrapped `generate_filename` for 79-char limit (AI assistant)
 
 ### Version Bump Rules


### PR DESCRIPTION
## Summary
- document 79-character line wraps in csv_writer.py, model_coder.py, model_parser.py, optim_utils.py, and utils.py

## Testing
- `pre-commit run --files CHANGELOG.md`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68977601de6c832fa766c3cae6b03b49