### PR TITLE
Refactor model coder and align lint config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
+        args: [--profile, black]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.4
     hooks:
@@ -16,3 +17,4 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+        args: [--max-line-length=88]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Add one line for each substantive commit or pull request directly under the late
 ## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
 
 ## Unreleased
+- 2025-08-09: Refactored `model_coder` to replace lambda assignments,
+  aligned Flake8 line length with Black and shortened long lines for
+  lint compliance (AI assistant)
 - 2025-08-09: Wrapped long lines in `copernican_lib/csv_writer.py`,
   `model_coder.py`, `model_parser.py`, `optim_utils.py` and `utils.py`
   for 79-column compliance (AI assistant)

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -5,26 +5,27 @@ converts equations to SymPy expressions and then compiles them into fast
 NumPy functions suitable for evaluation within the engines.
 """
 
-import yaml
+import logging
 from pathlib import Path
+
+import numpy as np
 import sympy as sp
+import yaml
+from scipy.integrate import quad
 from sympy.parsing.sympy_parser import (
+    implicit_multiplication_application,
     parse_expr,
     standard_transformations,
-    implicit_multiplication_application,
 )
-import numpy as np
-from scipy.integrate import quad
-import logging
 from sympy.printing.numpy import NumPyPrinter
-from . import error_handler
-from . import engine_interface
+
 from . import console_output as console
-from . import latex_utils
+from . import error_handler, latex_utils
 
 
 class QuadPrinter(NumPyPrinter):
-    """NumPy printer that expands ``Integral`` nodes into ``scipy`` quad calls."""
+    """NumPy printer that expands ``Integral`` nodes into ``scipy``
+    quad calls."""
 
     def _print_Integral(self, expr):
         """Translate SymPy ``Integral`` nodes into ``quad`` expressions."""
@@ -35,7 +36,7 @@ class QuadPrinter(NumPyPrinter):
         a_code = self._print(a)
         b_code = self._print(b)
         integrand_code = self._print(integrand)
-        return f"quad(lambda {var_code}: {integrand_code}, {a_code}, {b_code})[0]"
+        return f"quad(lambda {var_code}: {integrand_code}, {a_code}, " f"{b_code})[0]"
 
 
 def _latex_to_sympy_str(expr: str) -> str:
@@ -44,17 +45,18 @@ def _latex_to_sympy_str(expr: str) -> str:
 
 
 def _compile_sympy_expr(sym_expr, args):
-    """Compile a SymPy expression into a callable handling ``Integral`` nodes."""
+    """Compile a SymPy expression into a callable that evaluates
+    ``Integral`` nodes."""
     # SymPy can convert expressions directly to Python functions, but it does
     # not evaluate ``Integral`` objects by default. When an integral is present
     # we expand it into a call to ``scipy.integrate.quad`` so the resulting
     # callable is fully numerical.
     if sym_expr.atoms(sp.Integral):
-        printer = QuadPrinter({'strict': False})
+        printer = QuadPrinter({"strict": False})
         code = printer.doprint(sym_expr)
         lambda_src = f"lambda {', '.join(str(a) for a in args)}: {code}"
-        return eval(lambda_src, {'np': np, 'quad': quad})
-    return sp.lambdify(args, sym_expr, 'numpy')
+        return eval(lambda_src, {"np": np, "quad": quad})
+    return sp.lambdify(args, sym_expr, "numpy")
 
 
 def generate_callables(cache_path):
@@ -76,17 +78,20 @@ def generate_callables(cache_path):
 
     logger = logging.getLogger()
 
-    z = sp.symbols('z')
-    param_syms = [sp.symbols(p['python_var']) for p in model_data['parameters']]
-    local_dict = {p['python_var']: sym for p, sym in zip(model_data['parameters'], param_syms)}
-    local_dict['z'] = z
-    # Allow YAML equations to reference the full 'sympy' prefix as well as shorthand
-    local_dict['sympy'] = sp
+    z = sp.symbols("z")
+    param_syms = [sp.symbols(p["python_var"]) for p in model_data["parameters"]]
+    local_dict = {
+        p["python_var"]: sym for p, sym in zip(model_data["parameters"], param_syms)
+    }
+    local_dict["z"] = z
+    # Allow YAML equations to reference the full 'sympy' prefix
+    # as well as shorthand
+    local_dict["sympy"] = sp
 
     funcs = {}
     code_dict = {}
 
-    hz_expr_str = model_data.get('Hz_expression')
+    hz_expr_str = model_data.get("Hz_expression")
     if hz_expr_str:
         try:
             parsed_hz = _latex_to_sympy_str(hz_expr_str)
@@ -97,48 +102,66 @@ def generate_callables(cache_path):
                 + (implicit_multiplication_application,),
             )
             used_syms = {str(s) for s in hz_sym.free_symbols if s != z}
-            param_names = {p['python_var'] for p in model_data['parameters']}
+            param_names = {p["python_var"] for p in model_data["parameters"]}
             missing = used_syms - param_names
             if missing:
+                missing_str = "', '".join(missing)
                 raise ValueError(
-                    "Parameter '" + "', '".join(missing) + "' used in Hz_expression is not defined in model parameters."
+                    f"Parameter '{missing_str}' used in Hz_expression is "
+                    "not defined in model parameters."
                 )
-            # Convert SymPy expression to NumPy callable. Any ``Integral`` terms
-            # are replaced with numerical quad evaluations.
+            # Convert SymPy expression to a NumPy callable.
+            # Any ``Integral`` terms are replaced with numerical
+            # quad evaluations.
             hz_fn = _compile_sympy_expr(hz_sym, (z, *param_syms))
-            funcs['get_Hz_per_Mpc'] = hz_fn
-            code_dict['get_Hz_per_Mpc'] = str(hz_sym)
-            model_data['valid_for_distance_metrics'] = True
+            funcs["get_Hz_per_Mpc"] = hz_fn
+            code_dict["get_Hz_per_Mpc"] = str(hz_sym)
+            model_data["valid_for_distance_metrics"] = True
 
             def _dm(z_val, *params):
                 """Comoving distance integral valid for scalars or arrays."""
-                integrand = lambda zp: 299792.458 / hz_fn(zp, *params)
+
+                def integrand(zp):
+                    """Return c/H(z) at redshift ``zp``."""
+                    return 299792.458 / hz_fn(zp, *params)
+
                 if np.isscalar(z_val):
                     # ``quad`` expects scalar limits; cast to float explicitly.
                     return quad(integrand, 0, float(z_val), limit=100)[0]
 
                 # For arrays, compute the integral element-wise and
-                # preserve the input shape.
+                # preserve shape.
                 z_flat = np.ravel(z_val)
                 results = [quad(integrand, 0, float(z), limit=100)[0] for z in z_flat]
                 return np.reshape(results, np.shape(z_val))
 
-            if 'get_comoving_distance_Mpc' not in funcs:
-                funcs['get_comoving_distance_Mpc'] = _dm
-                code_dict['get_comoving_distance_Mpc'] = 'integral(c/H(z))'
-            if 'get_luminosity_distance_Mpc' not in funcs:
-                funcs['get_luminosity_distance_Mpc'] = lambda zv, *p: (1 + zv) * _dm(zv, *p)
-                code_dict['get_luminosity_distance_Mpc'] = '(1+z)*DC'
-            if 'get_angular_diameter_distance_Mpc' not in funcs:
-                funcs['get_angular_diameter_distance_Mpc'] = lambda zv, *p: _dm(zv, *p) / (1 + zv)
-                code_dict['get_angular_diameter_distance_Mpc'] = 'DC/(1+z)'
-            if 'get_DV_Mpc' not in funcs:
+            if "get_comoving_distance_Mpc" not in funcs:
+                funcs["get_comoving_distance_Mpc"] = _dm
+                code_dict["get_comoving_distance_Mpc"] = "integral(c/H(z))"
+            if "get_luminosity_distance_Mpc" not in funcs:
+
+                def _dl(zv, *p):
+                    """Luminosity distance D_L in Mpc."""
+                    return (1 + zv) * _dm(zv, *p)
+
+                funcs["get_luminosity_distance_Mpc"] = _dl
+                code_dict["get_luminosity_distance_Mpc"] = "(1+z)*DC"
+            if "get_angular_diameter_distance_Mpc" not in funcs:
+
+                def _da(zv, *p):
+                    """Angular diameter distance D_A in Mpc."""
+                    return _dm(zv, *p) / (1 + zv)
+
+                funcs["get_angular_diameter_distance_Mpc"] = _da
+                code_dict["get_angular_diameter_distance_Mpc"] = "DC/(1+z)"
+            if "get_DV_Mpc" not in funcs:
+
                 def _dv(z_val, *params):
-                    """Volume-averaged distance D_V valid for scalars or arrays."""
+                    """Compute volume-averaged distance D_V."""
                     dm_val = _dm(z_val, *params)
                     hz_val = hz_fn(z_val, *params)
 
-                    term = dm_val ** 2 * 299792.458 * z_val / hz_val
+                    term = dm_val**2 * 299792.458 * z_val / hz_val
 
                     if np.isscalar(z_val):
                         if z_val > 0 and hz_val != 0:
@@ -148,17 +171,24 @@ def generate_callables(cache_path):
                     result = np.zeros_like(z_val, dtype=float)
                     mask = (z_val > 0) & (hz_val != 0)
                     term_arr = term[mask]
-                    result[mask] = np.where(term_arr >= 0, np.power(term_arr, 1/3), np.nan)
+                    result[mask] = np.where(
+                        term_arr >= 0, np.power(term_arr, 1 / 3), np.nan
+                    )
                     return result
 
-                funcs['get_DV_Mpc'] = _dv
-                code_dict['get_DV_Mpc'] = '((DC^2 * c*z/H)^1/3)'
-            logger.info("Derived distance functions from symbolic Hz_expression in model YAML.")
+                funcs["get_DV_Mpc"] = _dv
+                code_dict["get_DV_Mpc"] = "((DC^2 * c*z/H)^1/3)"
+            logger.info(
+                "Derived distance functions from symbolic "
+                "Hz_expression in model YAML."
+            )
 
             # --- Derive sound horizon at recombination (r_s) ---
-            rs_expr_str = model_data.get('rs_expression')
-            param_names = {p['python_var'] for p in model_data['parameters']}
-            param_index = {p['python_var']: i for i, p in enumerate(model_data['parameters'])}
+            rs_expr_str = model_data.get("rs_expression")
+            param_names = {p["python_var"] for p in model_data["parameters"]}
+            param_index = {
+                p["python_var"]: i for i, p in enumerate(model_data["parameters"])
+            }
 
             if rs_expr_str:
                 try:
@@ -169,30 +199,41 @@ def generate_callables(cache_path):
                         transformations=standard_transformations
                         + (implicit_multiplication_application,),
                     )
-                    used = {str(s) for s in rs_sym.free_symbols} - {'z'}
+                    used = {str(s) for s in rs_sym.free_symbols} - {"z"}
                     missing_rs = used - param_names
                     if missing_rs:
+                        missing_str = "', '".join(missing_rs)
                         raise ValueError(
-                            "Parameter '" + "', '".join(missing_rs) + "' used in rs_expression is not defined in model parameters."
+                            f"Parameter '{missing_str}' used in rs_expression "
+                            "is not defined in model parameters."
                         )
-                    # ``Integral`` terms here are also expanded to calls to ``quad``.
+                    # ``Integral`` terms here are also expanded to calls to
+                    # ``quad``.
                     rs_fn_sym = _compile_sympy_expr(rs_sym, tuple(param_syms))
-                    funcs['get_sound_horizon_rs_Mpc'] = lambda *p: float(rs_fn_sym(*p))
-                    code_dict['get_sound_horizon_rs_Mpc'] = str(rs_sym)
-                    model_data['valid_for_bao'] = True
-                    logger.info("Derived r_s from symbolic rs_expression in model YAML.")
+
+                    def _rs_fn(*p):
+                        """Return the sound horizon r_s in Mpc."""
+                        return float(rs_fn_sym(*p))
+
+                    funcs["get_sound_horizon_rs_Mpc"] = _rs_fn
+                    code_dict["get_sound_horizon_rs_Mpc"] = str(rs_sym)
+                    model_data["valid_for_bao"] = True
+                    logger.info(
+                        "Derived r_s from symbolic rs_expression in model " "YAML.",
+                    )
                 except Exception as e:
-                    error_handler.report_error(f"Failed to parse rs_expression: {e}")
-                    raise ValueError(f"Failed to parse rs_expression: {e}") from e
+                    msg = f"Failed to parse rs_expression: {e}"
+                    error_handler.report_error(msg)
+                    raise ValueError(msg) from e
             elif (
-                'Omega_b' in param_names
-                and 'Omega_gamma' in param_names
-                and ('z_rec' in param_names or 'z_recomb' in param_names)
-                and 'get_Hz_per_Mpc' in funcs
+                "Omega_b" in param_names
+                and "Omega_gamma" in param_names
+                and ("z_rec" in param_names or "z_recomb" in param_names)
+                and "get_Hz_per_Mpc" in funcs
             ):
-                ob_i = param_index['Omega_b']
-                og_i = param_index['Omega_gamma']
-                zr_key = 'z_rec' if 'z_rec' in param_names else 'z_recomb'
+                ob_i = param_index["Omega_b"]
+                og_i = param_index["Omega_gamma"]
+                zr_key = "z_rec" if "z_rec" in param_names else "z_recomb"
                 zr_i = param_index[zr_key]
 
                 def _rs(*params):
@@ -202,40 +243,51 @@ def generate_callables(cache_path):
                     zrec = params[zr_i]
 
                     def sound_speed(zv):
-                        """Return baryon-photon sound speed in km/s at redshift ``zv``."""
-                        return 299792.458 / np.sqrt(3 * (1 + 3 * Ob_val / (4 * Og_val) / (1 + zv)))
+                        """Return baryon-photon sound speed in km/s."""
+                        return 299792.458 / np.sqrt(
+                            3 * (1 + 3 * Ob_val / (4 * Og_val) / (1 + zv))
+                        )
 
                     h0_val = hz_fn(0.0, *params)
 
                     def hz_with_radiation(zv):
-                        """Return H(z) including a simple radiation density term."""
+                        """Return H(z) with a radiation density term."""
                         base = hz_fn(zv, *params)
-                        rad_sq = (h0_val ** 2) * Og_val * (1 + zv) ** 4
-                        return np.sqrt(base ** 2 + rad_sq)
+                        rad_sq = (h0_val**2) * Og_val * (1 + zv) ** 4
+                        return np.sqrt(base**2 + rad_sq)
 
-                    integrand = lambda zv: sound_speed(zv) / hz_with_radiation(zv)
+                    def integrand(zv):
+                        """Sound-horizon integrand c_s/H(z)."""
+                        return sound_speed(zv) / hz_with_radiation(zv)
+
                     result, _ = quad(integrand, zrec, np.inf, limit=100)
                     return result
 
-                funcs['get_sound_horizon_rs_Mpc'] = _rs
-                code_dict['get_sound_horizon_rs_Mpc'] = 'quad(c_s/H(z))'
-                model_data['valid_for_bao'] = True
-                logger.info("Derived r_s using fallback integral from Hz_expression.")
+                funcs["get_sound_horizon_rs_Mpc"] = _rs
+                code_dict["get_sound_horizon_rs_Mpc"] = "quad(c_s/H(z))"
+                model_data["valid_for_bao"] = True
+                logger.info(
+                    "Derived r_s using fallback integral from " "Hz_expression.",
+                )
             else:
                 console.write(
-                    "\u26A0\uFE0F  Model does not define all necessary parameters for computing r_s. BAO scaling may be unavailable."
+                    "\u26A0\uFE0F  Model lacks parameters for computing "
+                    "r_s. BAO scaling may be unavailable."
                 )
-                model_data['valid_for_bao'] = False
+                model_data["valid_for_bao"] = False
         except Exception as e:
-            error_handler.report_error(f"Failed to parse Hz_expression: {e}")
-            raise ValueError(f"Failed to parse Hz_expression: {e}") from e
+            msg = f"Failed to parse Hz_expression: {e}"
+            error_handler.report_error(msg)
+            raise ValueError(msg) from e
     else:
         console.write(
-            "\u26A0\uFE0F  Model does not define H(z). Distance-based observables such as BAO, comoving distances, and luminosity distances will be unavailable."
+            "\u26A0\uFE0F  Model does not define H(z). Distance-based "
+            "observables such as BAO, comoving distances, and luminosity "
+            "distances will be unavailable."
         )
-        model_data['valid_for_distance_metrics'] = False
-        model_data['valid_for_bao'] = False
-    for name, expr in model_data.get('equations', {}).items():
+        model_data["valid_for_distance_metrics"] = False
+        model_data["valid_for_bao"] = False
+    for name, expr in model_data.get("equations", {}).items():
         if not isinstance(expr, str):
             # Textual equations are preserved but not parsed into functions
             continue
@@ -251,39 +303,39 @@ def generate_callables(cache_path):
             fn = _compile_sympy_expr(sym_expr, (z, *param_syms))
             # Quick sanity evaluation using midpoints of parameter bounds
             try:
-                mid_params = tuple(sum(p['bounds']) / 2.0 for p in model_data['parameters'])
+                mid_params = tuple(
+                    sum(p["bounds"]) / 2.0 for p in model_data["parameters"]
+                )
                 test_args = (0.5,) + mid_params
                 fn(*test_args)
             except Exception as eval_e:
                 error_handler.report_error(
-                    f"Generated function '{name}' raised an error when tested: {eval_e}"
+                    f"Generated function '{name}' raised an error when "
+                    f"tested: {eval_e}"
                 )
             funcs[name] = fn
             code_dict[name] = str(sym_expr)
         except Exception as e:
-            error_handler.report_error(f"Failed to parse equation '{name}': {e}")
-            raise ValueError(f"Failed to parse equation '{name}': {e}") from e
+            msg = f"Failed to parse equation '{name}': {e}"
+            error_handler.report_error(msg)
+            raise ValueError(msg) from e
 
-    if (
-        'distance_modulus_model' not in funcs
-        and 'get_luminosity_distance_Mpc' in funcs
-    ):
+    if "distance_modulus_model" not in funcs and "get_luminosity_distance_Mpc" in funcs:
+
         def _mu(zv, *params):
             """Compute distance modulus from luminosity distance in Mpc."""
-            dl = funcs['get_luminosity_distance_Mpc'](zv, *params)
-            with np.errstate(divide='ignore', invalid='ignore'):
+            dl = funcs["get_luminosity_distance_Mpc"](zv, *params)
+            with np.errstate(divide="ignore", invalid="ignore"):
                 mu = 5 * np.log10(dl) + 25.0
             mu = np.where(np.asarray(dl) > 0, mu, np.nan)
             return mu
 
-        funcs['distance_modulus_model'] = _mu
-        code_dict['distance_modulus_model'] = '5*log10(DL_Mpc)+25'
+        funcs["distance_modulus_model"] = _mu
+        code_dict["distance_modulus_model"] = "5*log10(DL_Mpc)+25"
         logger.info("Derived distance_modulus_model from luminosity distance.")
 
-    model_data['generated_code'] = code_dict
+    model_data["generated_code"] = code_dict
     with cache_path.open("w") as f:
         yaml.safe_dump(model_data, f, sort_keys=False, allow_unicode=True)
 
     return funcs, model_data
-
-


### PR DESCRIPTION
## Summary
- replace lambda expressions in model_coder with named helpers and docstrings
- align isort and flake8 with Black's style
- document lint adjustments in CHANGELOG

## Testing
- `pre-commit run --files copernican_lib/csv_writer.py copernican_lib/model_coder.py copernican_lib/model_parser.py copernican_lib/optim_utils.py copernican_lib/utils.py CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6897b8b11ef0832f93b7b8c050168b26