### PR TITLE
Run pre-commit formatting for version and engine exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Add one line for each substantive commit or pull request directly under the late
 
 ## Unreleased
 
+- 2025-08-09: Formatted version and engine exports for style (AI assistant)
 - 2025-08-09: Wrapped test file imports, docstrings and assertions for 79-char compliance (AI assistant)
 - 2025-08-09: Shortened lines in `engines/cosmo_engine_comb.py` (AI assistant)
 - 2025-08-09: Wrapped long lines across data parsers for 79-character compliance (AI assistant)

--- a/copernican_lib/version.py
+++ b/copernican_lib/version.py
@@ -29,4 +29,3 @@ def get_version() -> str:
 
 
 __all__ = ["get_version"]
-

--- a/engines/__init__.py
+++ b/engines/__init__.py
@@ -6,5 +6,5 @@
 from . import cosmo_engine_comb
 
 __all__ = [
-    'cosmo_engine_comb',
+    "cosmo_engine_comb",
 ]


### PR DESCRIPTION
## Summary
- format `copernican_lib/version.py` and `engines/__init__.py` with pre-commit for style consistency
- document formatting cleanup in `CHANGELOG.md`

## Testing
- `pre-commit run --files CHANGELOG.md copernican_lib/version.py engines/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6897cff300bc832fa2555e20fcd9e9b3