### PR TITLE
Add psutil dependency and ensure CI installs project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,13 @@ jobs:
         with:
           python-version: '3.11' # match minimum project requirement
 
-      - name: Install dependencies
+      - name: Install project dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install . pre-commit pyinstaller # project, linting, and build tools
+          pip install .
+
+      - name: Install tooling
+        run: pip install pre-commit pyinstaller # linting and build tools
 
       - name: Run pre-commit
         run: pre-commit run --all-files # fail fast on style issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Add one line for each substantive commit or pull request directly under the late
 - 2025-08-09: Wrapped test file imports, docstrings and assertions for 79-char compliance (AI assistant)
 - 2025-08-09: Shortened lines in `engines/cosmo_engine_comb.py` (AI assistant)
 - 2025-08-09: Wrapped long lines across data parsers for 79-character compliance (AI assistant)
+- 2025-08-09: Added `psutil` dependency and ensured CI installs project before running tests (AI assistant)
 
 ### Version Bump Rules
 - **MAJOR**: incompatible API changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "camb==1.6.2", # pin to ensure Python 3.11 wheels
     "PyYAML",
     "astropy",
+    "psutil",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add `psutil` to project dependencies
- install project in CI before running tests
- document new dependency

## Testing
- `pre-commit run --files pyproject.toml .github/workflows/ci.yml CHANGELOG.md`
- `python copernican.py --run-tests`

------
https://chatgpt.com/codex/tasks/task_e_6897d55308dc832f91369e6a32e6b6ad