### PR TITLE
docs: update version and clarify version policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Add one line for each substantive commit or pull request directly under the late
 ## Unreleased
 
 - 2025-08-11: Declared `setuptools_scm` as a runtime dependency (AI assistant)
+- 2025-08-10: Updated README version and clarified `setuptools_scm`-based versioning (AI assistant)
 - 2025-08-10: Gracefully handle missing `setuptools_scm` by importing it lazily (AI assistant)
 - 2025-08-10: Removed tracked `copernican_suite.egg-info` and added to `.gitignore` (AI assistant)
 - 2025-08-10: Derived fallback version from Git worktree using `setuptools_scm` (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.6.2
-**Last Updated:** 2025-08-09
+**Version:** 3.6.7
+**Last Updated:** 2025-08-10
 
 The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
 Support for gravitational waves and standard siren events is planned for future releases.
@@ -375,7 +375,9 @@ The Copernican Suite is distributed under the terms of the [Copernican Suite Lic
 The project now follows [Semantic Versioning](https://semver.org/). Versions are
 listed as `MAJOR.MINOR.PATCH`, where breaking changes increment `MAJOR`, new
 features increment `MINOR` and bug fixes increment `PATCH`. Package builds use
-`setuptools_scm` to derive the version from Git tags.
+`setuptools_scm` to derive the version from Git tags, so the version string is
+never hard-coded. Runtime code should call
+`copernican_lib.version.get_version` to obtain the current version.
 
 The `MINOR` value only increases when the suite gains a new data type or a
 similarly significant feature, such as introducing CMB support or a new engine.


### PR DESCRIPTION
## Summary
- correct README to version 3.6.7
- clarify in Versioning Policy that versions come from `setuptools_scm` and are not hard-coded
- note documentation change in changelog

## Testing
- `pre-commit run --files README.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68984bcc5334832fbcfa8d2b70d6c50e