### PR TITLE
Document camb pin and packaging requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ Under the hood the program follows a clear pipeline:
 
 ## Dependencies
 This project requires **Python 3.11 or later** and relies on `numpy`, `scipy`, `matplotlib`,
-`pandas`, `sympy`, `jsonschema` and `camb`. If any packages are missing the
-program prints an OS-specific install command listing only those missing packages and exits so you can install them
-manually. Running under an older Python version results in an immediate error
+`pandas`, `sympy`, `jsonschema` and `camb==1.6.2`.
+If any packages are missing the program prints an OS-specific install command
+listing only those missing packages and exits so you can install them manually.
+Running under an older Python version results in an immediate error
 and exit code 1. Future engines may also depend on `numba` or GPU libraries.
  
 ## Building & Installation

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -5,6 +5,9 @@ using PyInstaller. Each provided spec file bundles the project source code so
 the resulting binary can run without an existing checkout of the repository or a
 pre-installed copy of Python.
 
+Builds should target Python 3.11 or later and include `camb==1.6.2` to match
+the suite's runtime requirements.
+
 ## Windows `.exe`
 1. Install PyInstaller: `pip install pyinstaller`.
 2. Run `pyinstaller copernican_win.spec`.


### PR DESCRIPTION
## Summary
- Note that the suite depends on `camb==1.6.2` in the README
- Clarify in the packaging guide that builds target Python 3.11+ and include `camb==1.6.2`

## Testing
- `pre-commit run --files README.md docs/*`


------
https://chatgpt.com/codex/tasks/task_e_689854af82c0832fa8fb78d19f34f2ec