### PR TITLE
docs: add line length guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ To keep the project maintainable all contributors, human or AI, must follow thes
 11. **Use raw strings or escape backslashes explicitly to avoid invalid escape sequence warnings in docstrings or string literals.**
 12. **Run `pre-commit` on all modified files before committing to enforce Black, Isort, Ruff and Flake8 checks.**
 13. **Do not redistribute the Copernican Suite in full or assert patent claims; the license forbids these actions.**
+14. **Keep individual lines under 79 characters to maintain readability.**
 
 Failure to follow these guidelines will compromise the Copernican Suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Add one line for each substantive commit or pull request directly under the late
 
 ## Unreleased
 
+- 2025-08-10: Added 79-char line-length rule to development laws (AI assistant)
 - 2025-08-11: Declared `setuptools_scm` as a runtime dependency (AI assistant)
 - 2025-08-10: Updated README version and clarified `setuptools_scm`-based versioning (AI assistant)
 - 2025-08-10: Gracefully handle missing `setuptools_scm` by importing it lazily (AI assistant)

--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ See `CHANGELOG.md` for complete version history.
 > 11. **Use raw strings or escape backslashes explicitly to avoid invalid escape sequence warnings in docstrings or string literals.**
 > 12. **Run `pre-commit` on all modified files before committing to enforce Black, Isort, Ruff and Flake8 checks.**
 > 13. **Do not redistribute the Copernican Suite in full or assert patent claims; the license forbids these actions.**
+> 14. **Keep individual lines under 79 characters to maintain readability.**
 >
 > Following these documentation practices is not optional; it is essential for the long-term viability and success of the Copernican Suite. Failure to follow these rules will compromise the maintainability of the Copernican Suite.
 


### PR DESCRIPTION
## Summary
- document 79-character line length limit in development laws
- mirror line length rule in README
- log new guideline in changelog

## Testing
- `pre-commit run --files AGENTS.md README.md`
- `pre-commit run --files CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_689859710374832f8de56a7de923d9a1