### PR TITLE
Use platform-specific PyInstaller specs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,13 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest] # test on major operating systems
+        include:
+          - os: ubuntu-latest
+            spec: copernican_linux.spec
+          - os: macos-latest
+            spec: copernican_macos.spec
+          - os: windows-latest
+            spec: copernican_win.spec
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -34,14 +40,14 @@ jobs:
         run: pre-commit run --all-files # fail fast on style issues
 
       - name: Execute unit tests
-        run: python copernican.py --run-tests # run suite via CLI and fail on test errors
+        run: python copernican.py --run-tests # run tests via CLI
 
       - name: Build executables
-        run: pyinstaller --onefile copernican.py # produce standalone binary
+        run: pyinstaller ${{ matrix.spec }} # produce standalone binary
 
       - name: Upload build artifacts
         if: success() # only upload when previous steps succeed
         uses: actions/upload-artifact@v4
         with:
           name: copernican-${{ matrix.os }} # differentiate artifact by OS
-          path: dist/* # PyInstaller output directory
+          path: dist/ # PyInstaller output directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Add one line for each substantive commit or pull request directly under the late
 
 ## Unreleased
 
+## Version 3.6.9
+
+- 2025-08-10: Use per-OS PyInstaller specs and archive dist/ (AI assistant)
+
 ## Version 3.6.8
 
 - 2025-08-10: Prepared 3.6.8 release and opened new Unreleased section (AI assistant)


### PR DESCRIPTION
## Summary
- build executables from OS-specific PyInstaller spec files
- upload the `dist/` directory as the GitHub Actions artifact
- document CI build changes in the changelog

## Testing
- `python -m pre_commit run --files .github/workflows/ci.yml CHANGELOG.md`
- `python copernican.py --run-tests`

------
https://chatgpt.com/codex/tasks/task_e_689865fe351c832f8151fc1e43005289