### PR TITLE
ci: ensure mac builds use universal2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
           - os: windows-latest
             spec: copernican_win.spec
     runs-on: ${{ matrix.os }}
+    env:
+      PYTHON: python
     defaults:
       run:
         shell: bash # use bash for consistent behaviour across platforms
@@ -24,26 +26,34 @@ jobs:
         uses: actions/checkout@v4 # pull source code
 
       - name: Set up Python
+        if: matrix.os != 'macos-latest'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11' # match minimum project requirement
 
+      - name: Install universal2 Python
+        if: matrix.os == 'macos-latest'
+        run: |
+          curl -LO https://www.python.org/ftp/python/3.11.9/python-3.11.9-macos11.pkg
+          sudo installer -pkg python-3.11.9-macos11.pkg -target /
+          echo "PYTHON=/Library/Frameworks/Python.framework/Versions/3.11/bin/python3" >> "$GITHUB_ENV"
+
       - name: Install project dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install .
+          $PYTHON -m pip install --upgrade pip
+          $PYTHON -m pip install .
 
       - name: Install tooling
-        run: pip install pre-commit pyinstaller # linting and build tools
+        run: $PYTHON -m pip install pre-commit pyinstaller # linting and build tools
 
       - name: Run pre-commit
-        run: pre-commit run --all-files # fail fast on style issues
+        run: $PYTHON -m pre_commit run --all-files # fail fast on style issues
 
       - name: Execute unit tests
-        run: python copernican.py --run-tests # run tests via CLI
+        run: $PYTHON copernican.py --run-tests # run tests via CLI
 
       - name: Build executables
-        run: pyinstaller ${{ matrix.spec }} # produce standalone binary
+        run: $PYTHON -m PyInstaller ${{ matrix.spec }} # produce standalone binary
 
       - name: Upload build artifacts
         if: success() # only upload when previous steps succeed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Add one line for each substantive commit or pull request directly under the late
 
 ## Unreleased
 
+## Version 3.6.10
+
+- 2025-08-10: Fix CI pre-commit invocation to use correct module name (AI assistant)
+- 2025-08-10: Ensure macOS build uses universal2 Python and document requirement (AI assistant)
+
 ## Version 3.6.9
 
 - 2025-08-10: Use per-OS PyInstaller specs and archive dist/ (AI assistant)

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ list and entry points used by Python's packaging tools. It is generated
 automatically and does not need to be tracked in version control.
 
 Standalone executables can be created with the PyInstaller spec files included
-at the repository root. See [docs/packaging.md](docs/packaging.md) for platform
-specific build commands and macOS signing instructions.
+at the repository root. macOS builds **must** target `universal2` so the bundle
+runs on both Intel and Apple Silicon. See
+[docs/packaging.md](docs/packaging.md) for platform specific build commands and
+macOS signing instructions.
 
 
 ## Directory Layout

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,9 +1,9 @@
 # Packaging Guide
 
-This guide describes how to build standalone executables for the Copernican Suite
-using PyInstaller. Each provided spec file bundles the project source code so
-the resulting binary can run without an existing checkout of the repository or a
-pre-installed copy of Python.
+This guide describes how to build standalone executables for the Copernican
+Suite using PyInstaller. Each provided spec file bundles the project source
+code so the resulting binary can run without an existing checkout of the
+repository or a pre-installed copy of Python.
 
 Builds should target Python 3.11 or later and include `camb==1.6.2` to match
 the suite's runtime requirements.
@@ -14,7 +14,11 @@ the suite's runtime requirements.
 3. The `dist/copernican.exe` file contains the suite and all bundled sources.
 
 ## macOS universal2 `.app`
-1. Install PyInstaller on a macOS system.
+The macOS build **must** target `universal2` so the bundle runs on Intel and
+Apple Silicon. Install the universal2 Python distribution from python.org to
+ensure all compiled dependencies include both architectures.
+
+1. Install the python.org universal2 build of Python and PyInstaller.
 2. Run `pyinstaller copernican_macos.spec`.
 3. The `dist/Copernican.app` bundle supports both Intel and Apple Silicon.
 
@@ -24,7 +28,8 @@ Once you have an Apple Developer ID, the bundle can be signed and notarized:
 ```bash
 codesign --deep --force --options runtime \
   --sign "Developer ID Application: YOUR NAME (TEAMID)" dist/Copernican.app
-hdiutil create -fs HFS+ -volname Copernican -srcfolder dist/Copernican.app dist/copernican.dmg
+hdiutil create -fs HFS+ -volname Copernican \
+  -srcfolder dist/Copernican.app dist/copernican.dmg
 xcrun notarytool submit dist/copernican.dmg --apple-id YOUR_ID@example.com \
   --team-id TEAMID --password YOUR_APP_SPECIFIC_PASSWORD --wait
 xcrun stapler staple dist/Copernican.app


### PR DESCRIPTION
## Summary
- install python.org universal2 build in macOS CI job to produce fat binaries
- document that macOS executables must target universal2 and require universal2 Python
- record macOS universal2 requirement in changelog
- fix pre-commit invocation in CI so lint step runs

## Testing
- `pre-commit run --files .github/workflows/ci.yml CHANGELOG.md`
- `python copernican.py --run-tests`

------
https://chatgpt.com/codex/tasks/task_e_689897bab814832fa4faaab18af54d4c