### PR TITLE
Fix macOS build spec to avoid CI failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Add one line for each substantive commit or pull request directly under the late
 
 ## Unreleased
 
+- 2025-08-11: Make macOS PyInstaller spec use universal2 only on macOS to
+  prevent CI failures (AI assistant)
 ## Version 3.6.10
 
 - 2025-08-10: Fix CI pre-commit invocation to use correct module name (AI assistant)

--- a/copernican_macos.spec
+++ b/copernican_macos.spec
@@ -1,10 +1,16 @@
 # -*- mode: python ; coding: utf-8 -*-
 """
-PyInstaller specification for building a universal2 macOS application bundle of
-the Copernican Suite. All project sources are included so the generated
-``Copernican.app`` runs without external dependencies. The bundle may be signed
-and notarised once an Apple Developer ID is available.
+PyInstaller specification for building a macOS application bundle of the
+Copernican Suite. All project sources are included so the generated
+``Copernican.app`` runs without external dependencies. The bundle may be
+signed and notarised once an Apple Developer ID is available. The build keeps
+universal2 support on macOS while remaining portable for other platforms.
 """
+
+import sys
+
+TARGET_ARCH = "universal2" if sys.platform == "darwin" else None
+# Use host architecture on non-mac platforms to keep CI builds portable.
 
 block_cipher = None
 
@@ -20,7 +26,7 @@ a = Analysis(
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},
-    target_arch='universal2',
+    target_arch=TARGET_ARCH,
 )
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
@@ -34,7 +40,7 @@ exe = EXE(
     [],
     name='Copernican',
     console=False,
-    target_arch='universal2',
+    target_arch=TARGET_ARCH,
 )
 
 app = BUNDLE(


### PR DESCRIPTION
## Summary
- keep universal2 bundles on macOS but avoid forcing the architecture on other platforms
- document the macOS spec change in the changelog

## Testing
- `python -m unittest discover`
- `pre-commit run --files copernican_macos.spec CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68989faa8e84832fa24f3c34cf18c0b1