### PR TITLE
Fix macOS build spec to avoid CI failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Add one line for each substantive commit or pull request directly under the late
 
 ## Unreleased
 
+- 2025-08-11: Remove ``target_arch`` from macOS spec on non-mac systems to
+  fix Linux and Windows CI builds (AI assistant)
+- 2025-08-11: Make macOS PyInstaller spec use universal2 only on macOS to
+  prevent CI failures (AI assistant)
 ## Version 3.6.10
 
 - 2025-08-10: Fix CI pre-commit invocation to use correct module name (AI assistant)

--- a/copernican_macos.spec
+++ b/copernican_macos.spec
@@ -1,10 +1,17 @@
 # -*- mode: python ; coding: utf-8 -*-
 """
-PyInstaller specification for building a universal2 macOS application bundle of
-the Copernican Suite. All project sources are included so the generated
-``Copernican.app`` runs without external dependencies. The bundle may be signed
-and notarised once an Apple Developer ID is available.
+PyInstaller specification for building a macOS application bundle of the
+Copernican Suite. All project sources are included so the generated
+``Copernican.app`` runs without external dependencies. The bundle may be
+signed and notarised once an Apple Developer ID is available. The build keeps
+universal2 support on macOS while remaining portable for other platforms.
 """
+
+import sys
+
+# ``target_arch`` is only valid on macOS. Passing the argument on other
+# platforms causes PyInstaller to abort, so we include it conditionally.
+ARCH_ARGS = {"target_arch": "universal2"} if sys.platform == "darwin" else {}
 
 block_cipher = None
 
@@ -20,7 +27,7 @@ a = Analysis(
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},
-    target_arch='universal2',
+    **ARCH_ARGS,
 )
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
@@ -34,7 +41,7 @@ exe = EXE(
     [],
     name='Copernican',
     console=False,
-    target_arch='universal2',
+    **ARCH_ARGS,
 )
 
 app = BUNDLE(


### PR DESCRIPTION
## Summary
- omit `target_arch` when building the macOS spec on non-mac platforms so PyInstaller doesn't abort
- document the cross-platform `target_arch` fix in the changelog

## Testing
- `python -m pre_commit run --files copernican_macos.spec CHANGELOG.md`
- `python -m unittest discover`
- `python -m PyInstaller copernican_linux.spec`


------
https://chatgpt.com/codex/tasks/task_e_68989faa8e84832fa24f3c34cf18c0b1