### PR TITLE
docs: wrap markdown lines to 79 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## How to Log Changes
-Add one line for each substantive commit or pull request directly under the latest version header. AI assistant warning: please, always check the current date when logging new changes, and datestamp them with a current date! Don't put dates that are in the future or in the past! Follow this template: 
+Add one line for each substantive commit or pull request directly under the
+latest version header. AI assistant warning: please, always check the current
+date when logging new changes, and datestamp them with a current date! Don't
+put dates that are in the future or in the past! Follow this template:
 ```
 ## Version 1.1.0
 - 2025-05-27: Added plotting and CSV (Apostol Apostolov) 
@@ -9,11 +12,15 @@ Add one line for each substantive commit or pull request directly under the late
 - 2025-05-26: Created copernican.py (Apostol Apostolov)
 
 ```
-## Log changes here (place the newest version directly below this line and keep one blank line. Version headers run newest to oldest, and within each version the newest entries come first):
+## Log changes here
+(place the newest version directly below this line and keep one blank line.
+Version headers run newest to oldest, and within each version the newest
+entries come first):
 
 ## Unreleased
 
-- 2025-08-11: Set formatter line length to 79 and wrap existing lines (AI assistant)
+- 2025-08-11: Set formatter line length to 79 and wrap existing lines (AI
+  assistant)
 
 ## Version 3.6.11
 
@@ -27,8 +34,10 @@ Add one line for each substantive commit or pull request directly under the late
   
 ## Version 3.6.10
 
-- 2025-08-10: Fix CI pre-commit invocation to use correct module name (AI assistant)
-- 2025-08-10: Ensure macOS build uses universal2 Python and document requirement (AI assistant)
+- 2025-08-10: Fix CI pre-commit invocation to use correct module name (AI
+  assistant)
+- 2025-08-10: Ensure macOS build uses universal2 Python and document
+  requirement (AI assistant)
 
 ## Version 3.6.9
 
@@ -36,18 +45,26 @@ Add one line for each substantive commit or pull request directly under the late
 
 ## Version 3.6.8
 
-- 2025-08-10: Prepared 3.6.8 release and opened new Unreleased section (AI assistant)
+- 2025-08-10: Prepared 3.6.8 release and opened new Unreleased section (AI
+  assistant)
 - 2025-08-10: Added 79-char line-length rule to development laws (AI assistant)
 - 2025-08-11: Declared `setuptools_scm` as a runtime dependency (AI assistant)
-- 2025-08-10: Updated README version and clarified `setuptools_scm`-based versioning (AI assistant)
-- 2025-08-10: Gracefully handle missing `setuptools_scm` by importing it lazily (AI assistant)
-- 2025-08-10: Removed tracked `copernican_suite.egg-info` and added to `.gitignore` (AI assistant)
-- 2025-08-10: Derived fallback version from Git worktree using `setuptools_scm` (AI assistant)
+- 2025-08-10: Updated README version and clarified `setuptools_scm`-based
+  versioning (AI assistant)
+- 2025-08-10: Gracefully handle missing `setuptools_scm` by importing it lazily
+  (AI assistant)
+- 2025-08-10: Removed tracked `copernican_suite.egg-info` and added to
+  `.gitignore` (AI assistant)
+- 2025-08-10: Derived fallback version from Git worktree using `setuptools_scm`
+  (AI assistant)
 - 2025-08-09: Formatted version and engine exports for style (AI assistant)
-- 2025-08-09: Wrapped test file imports, docstrings and assertions for 79-char compliance (AI assistant)
+- 2025-08-09: Wrapped test file imports, docstrings and assertions for 79-char
+  compliance (AI assistant)
 - 2025-08-09: Shortened lines in `engines/cosmo_engine_comb.py` (AI assistant)
-- 2025-08-09: Wrapped long lines across data parsers for 79-character compliance (AI assistant)
-- 2025-08-09: Added `psutil` dependency and ensured CI installs project before running tests (AI assistant)
+- 2025-08-09: Wrapped long lines across data parsers for 79-character
+  compliance (AI assistant)
+- 2025-08-09: Added `psutil` dependency and ensured CI installs project before
+  running tests (AI assistant)
 
 ### Version Bump Rules
 - **MAJOR**: incompatible API changes.
@@ -76,331 +93,466 @@ Add one line for each substantive commit or pull request directly under the late
   79-column compliance (AI assistant)
 
 ## Version 3.6.3
-- 2025-08-09: Wrapped long lines across `copernican_lib` modules and `copernican.py` for 79-column compliance (AI assistant)
-- 2025-08-09: Lowered minimum Python version to 3.11, pinned `camb` to 1.6.2, updated CI and documentation (AI assistant)
+- 2025-08-09: Wrapped long lines across `copernican_lib` modules and
+  `copernican.py` for 79-column compliance (AI assistant)
+- 2025-08-09: Lowered minimum Python version to 3.11, pinned `camb` to 1.6.2,
+  updated CI and documentation (AI assistant)
 
 ## Version 3.6.2
-- 2025-08-09: Configured pre-commit with Black, Isort, Ruff and Flake8 and added licensing reminders to contributor docs (AI assistant)
+- 2025-08-09: Configured pre-commit with Black, Isort, Ruff and Flake8 and
+  added licensing reminders to contributor docs (AI assistant)
 
 ## Version 3.6.1
-- 2025-08-09: Delegated `--run-tests` to `python -m unittest discover`, expanded regression and interface tests, and updated CI to run the full suite on every push (AI assistant)
+- 2025-08-09: Delegated `--run-tests` to `python -m unittest discover`,
+  expanded regression and interface tests, and updated CI to run the full
+  suite on every push (AI assistant)
 
 ## Version 3.6.0
-- 2025-08-09: Centralised version handling via `copernican_lib.version`, routed modules through the helper, configured `setuptools_scm` fallback and documented SemVer bump rules (AI assistant)
+- 2025-08-09: Centralised version handling via `copernican_lib.version`, routed
+  modules through the helper, configured `setuptools_scm` fallback and
+  documented SemVer bump rules (AI assistant)
 
 ## Version 3.5.3
-- 2025-08-09: Added PyInstaller build specifications for Windows, macOS and Linux, bundled project sources and documented macOS signing (AI assistant)
+- 2025-08-09: Added PyInstaller build specifications for Windows, macOS and
+  Linux, bundled project sources and documented macOS signing (AI assistant)
 
 ## Version 3.5.2
-- 2025-08-09: Added cross-platform CI workflow using GitHub Actions (AI assistant)
+- 2025-08-09: Added cross-platform CI workflow using GitHub Actions (AI
+  assistant)
 
 ## Version 3.5.1
-- 2025-08-08: Expanded comments across codebase, restructured plot footer documentation and enlarged technical docs (AI assistant)
+- 2025-08-08: Expanded comments across codebase, restructured plot footer
+  documentation and enlarged technical docs (AI assistant)
 
 ## Version 3.5.0
-- 2025-08-07: Added comprehensive development plan summarizing project goals (AI assistant)
-- 2025-08-05: Expanded subscript and superscript tables to cover full Latin and Greek alphabets, digits and common operators; updated docs and bumped version (AI assistant)
+- 2025-08-07: Added comprehensive development plan summarizing project goals
+  (AI assistant)
+- 2025-08-05: Expanded subscript and superscript tables to cover full Latin and
+  Greek alphabets, digits and common operators; updated docs and bumped
+  version (AI assistant)
 
 ## Version 3.4.4
-- 2025-08-04: Replaced unsupported ``\textbf`` footer styling with ``\mathbf`` and preserved spaces to prevent plot save failures (AI assistant)
+- 2025-08-04: Replaced unsupported ``\textbf`` footer styling with ``\mathbf``
+  and preserved spaces to prevent plot save failures (AI assistant)
 
 ## Version 3.4.3
-- 2025-08-04: Dropped HTML tags from plot footers, centralised footer generation and kept dataset names spaced; bumped version (AI assistant)
+- 2025-08-04: Dropped HTML tags from plot footers, centralised footer
+  generation and kept dataset names spaced; bumped version (AI assistant)
 
 ## Version 3.4.2
-- 2025-08-04: Adopted HTML footer template preserving dataset spacing and bumped version (AI assistant)
+- 2025-08-04: Adopted HTML footer template preserving dataset spacing and
+  bumped version (AI assistant)
 
 ## Version 3.4.1
-- 2025-08-04: Added rule requiring concise, descriptive function and identifier names and synchronized documentation (AI assistant)
+- 2025-08-04: Added rule requiring concise, descriptive function and identifier
+  names and synchronized documentation (AI assistant)
 
 ## Version 3.4.0
-- 2025-08-04: Centralised dataset metadata loading in `data_loaders.py`, removed metadata handling from parsers and updated documentation (AI assistant)
+- 2025-08-04: Centralised dataset metadata loading in `data_loaders.py`,
+  removed metadata handling from parsers and updated documentation (AI
+  assistant)
 
 ## Version 3.3.8
-- 2025-08-04: Replaced dataset name attributes with `dataset_name_sanitized`, preserved original `dataset_name`, and refreshed documentation (AI assistant)
+- 2025-08-04: Replaced dataset name attributes with `dataset_name_sanitized`,
+  preserved original `dataset_name`, and refreshed documentation (AI
+  assistant)
 
 ## Version 3.3.7
-- 2025-08-04: Updated metadata key references to use `author` and refreshed documentation; bumped version (AI assistant)
+- 2025-08-04: Updated metadata key references to use `author` and refreshed
+  documentation; bumped version (AI assistant)
 
 ## Version 3.3.6
-- 2025-08-04: Added BibTeX metadata fields and updated citations across public datasets; refreshed documentation and version numbers (AI assistant)
+- 2025-08-04: Added BibTeX metadata fields and updated citations across public
+  datasets; refreshed documentation and version numbers (AI assistant)
 
 ## Version 3.3.5
-- 2025-08-03: Documented absence of joint covariance for BOSS DR12 data and parser's block-diagonal approach in docs and README (AI assistant)
+- 2025-08-03: Documented absence of joint covariance for BOSS DR12 data and
+  parser's block-diagonal approach in docs and README (AI assistant)
 
 ## Version 3.3.4
-- 2025-08-03: Added regression test for BOSS DR12 BAO parser validating covariance handling and error paths (AI assistant)
+- 2025-08-03: Added regression test for BOSS DR12 BAO parser validating
+  covariance handling and error paths (AI assistant)
 
 ## Version 3.3.3
-- 2025-08-03: Integrated full BOSS DR12 BAO covariance by combining dM/Hz and D_V/F_AP inputs; updated documentation and version (AI assistant)
+- 2025-08-03: Integrated full BOSS DR12 BAO covariance by combining dM/Hz and
+  D_V/F_AP inputs; updated documentation and version (AI assistant)
 
 ## Version 3.3.2
-- 2025-08-03: Corrected BOSS DR12 BAO conversion to include redshift scaling, fixed compound parser scaling bug and added escape-sequence guideline; bumped version (AI assistant)
+- 2025-08-03: Corrected BOSS DR12 BAO conversion to include redshift scaling,
+  fixed compound parser scaling bug and added escape-sequence guideline;
+  bumped version (AI assistant)
 
 ## Version 3.3.1
-- 2025-08-03: Renamed BAO test dataset to compound dataset, improved BAO parsers and documentation, and bumped version (AI assistant)
+- 2025-08-03: Renamed BAO test dataset to compound dataset, improved BAO
+  parsers and documentation, and bumped version (AI assistant)
 
 ## Version 3.3.0
-- 2025-07-31: Added BOSS DR12 BAO consensus dataset with full covariance and skipped placeholder folders; bumped version (AI assistant)
+- 2025-07-31: Added BOSS DR12 BAO consensus dataset with full covariance and
+  skipped placeholder folders; bumped version (AI assistant)
 
 ## Version 3.2.1
-- 2025-07-31: Reordered Pantheon+ covariance matrix to match sorted data and updated documentation; bumped version (AI assistant)
+- 2025-07-31: Reordered Pantheon+ covariance matrix to match sorted data and
+  updated documentation; bumped version (AI assistant)
 
 ## Version 3.2.0
-- 2025-07-31: Standardized all console output through `console_output.py`, added automatic log renaming and bumped version (AI assistant)
+- 2025-07-31: Standardized all console output through `console_output.py`,
+  added automatic log renaming and bumped version (AI assistant)
 
 ## Version 3.1.1
-- 2025-07-31: Updated JLA parser to use published SALT2 parameters and documented them; bumped project version (AI assistant)
+- 2025-07-31: Updated JLA parser to use published SALT2 parameters and
+  documented them; bumped project version (AI assistant)
 
 ## Version 3.1.0
-- 2025-07-31: Reverted project to version 3.1.0 state and removed universal constants (AI assistant)
-- 2025-07-30: Replaced `^` with `**` for exponentiation across all model YAML files and documented LaTeX syntax (AI assistant)
+- 2025-07-31: Reverted project to version 3.1.0 state and removed universal
+  constants (AI assistant)
+- 2025-07-30: Replaced `^` with `**` for exponentiation across all model YAML
+  files and documented LaTeX syntax (AI assistant)
 
 ## Version 3.0.1
-- 2025-07-31: Fixed CAMB parameter map exponent syntax in cosmo_model_usmf2.yml to prevent runtime errors (AI assistant)
+- 2025-07-31: Fixed CAMB parameter map exponent syntax in cosmo_model_usmf2.yml
+  to prevent runtime errors (AI assistant)
 
 ## Version 3.0.0
-- 2025-07-30: Dropped all remaining JSON dataset support and expanded documentation (AI assistant)
+- 2025-07-30: Dropped all remaining JSON dataset support and expanded
+  documentation (AI assistant)
 
 ## Version 2.1.0
-- 2025-07-30: Switched cached models and LaTeX mappings to YAML and removed JSON usage across the codebase (AI assistant)
-- 2025-07-30: Converted all dataset metadata and the BAO compound dataset to YAML (AI assistant)
+- 2025-07-30: Switched cached models and LaTeX mappings to YAML and removed
+  JSON usage across the codebase (AI assistant)
+- 2025-07-30: Converted all dataset metadata and the BAO compound dataset to
+  YAML (AI assistant)
 
 ## Version 2.0.7
-- 2025-07-30: Corrected malformed tab in USMFv2 description to pass YAML parsing (AI assistant)
-- 2025-07-30: Expanded inline comments and documentation to clarify workflow logic (AI assistant)
-- 2025-07-30: Synchronized development laws between README.md and AGENTS.md (AI assistant)
+- 2025-07-30: Corrected malformed tab in USMFv2 description to pass YAML
+  parsing (AI assistant)
+- 2025-07-30: Expanded inline comments and documentation to clarify workflow
+  logic (AI assistant)
+- 2025-07-30: Synchronized development laws between README.md and AGENTS.md (AI
+  assistant)
 - 2025-07-30: Removed unused JLA covariance fallback logic (AI assistant)
 
 ## Version 2.0.6
-- 2025-07-30: Expanded comments across the codebase and added a session-start reminder in AGENTS (AI assistant)
-- 2025-07-30: Added RNG seeding, improved SNe chi-squared validation and expanded tests (AI assistant)
-- 2025-07-30: Consolidated AI development guidelines into a single README section (AI assistant)
+- 2025-07-30: Expanded comments across the codebase and added a session-start
+  reminder in AGENTS (AI assistant)
+- 2025-07-30: Added RNG seeding, improved SNe chi-squared validation and
+  expanded tests (AI assistant)
+- 2025-07-30: Consolidated AI development guidelines into a single README
+  section (AI assistant)
 
 ## Version 2.0.5
-- 2025-07-30: Verified latex_mappings.json validity and kept fallback; reordered changelog and clarified instructions (AI assistant)
+- 2025-07-30: Verified latex_mappings.json validity and kept fallback;
+  reordered changelog and clarified instructions (AI assistant)
 
 ## Version 2.0.4
-- 2025-07-30: Documented stub GW and siren parsers returning None (AI assistant)
+- 2025-07-30: Documented stub GW and siren parsers returning None (AI
+  assistant)
 
 ## Version 2.0.3
-- 2025-07-30: Removed Unicode escape sequences from model YAML files and converted abstracts and descriptions to block scalars (AI assistant)
+- 2025-07-30: Removed Unicode escape sequences from model YAML files and
+  converted abstracts and descriptions to block scalars (AI assistant)
 
 ## Version 2.0.2
-- 2025-07-30: Console output now renders parameter names with Unicode Greek letters and subscripts (AI assistant)
+- 2025-07-30: Console output now renders parameter names with Unicode Greek
+  letters and subscripts (AI assistant)
 
 ## Version 2.0.1
-- 2025-07-30: Vectorised BAO chi-squared and updated YAML documentation (AI assistant)
+- 2025-07-30: Vectorised BAO chi-squared and updated YAML documentation (AI
+  assistant)
 
 ## Version 2.0.0
-- 2025-07-30: Migrated all models to YAML and removed JSON support (AI assistant)
+- 2025-07-30: Migrated all models to YAML and removed JSON support (AI
+  assistant)
 
 ## Version 2.0.3
-- 2025-07-30: Removed Unicode escape sequences from model YAML files and converted abstracts and descriptions to block scalars (AI assistant)
+- 2025-07-30: Removed Unicode escape sequences from model YAML files and
+  converted abstracts and descriptions to block scalars (AI assistant)
 
 
 ## Version 1.19.3
-- 2025-07-29: Fixed parsing of LaTeX names containing `\rm` and bumped version (AI assistant)
+- 2025-07-29: Fixed parsing of LaTeX names containing `\rm` and bumped version
+  (AI assistant)
 
 ## Version 1.19.2
-- 2025-07-29: Normalized LaTeX parameter names in all models and updated example docs (AI assistant)
+- 2025-07-29: Normalized LaTeX parameter names in all models and updated
+  example docs (AI assistant)
 
 ## Version 1.19.1
-- 2025-07-29: Added missing LaTeX names to LCDM parameters and bumped version (AI assistant)
+- 2025-07-29: Added missing LaTeX names to LCDM parameters and bumped version
+  (AI assistant)
 
 ## Version 1.19.0
-- 2025-07-29: Removed parameter-name fallback and made `latex_name` mandatory in all models (AI assistant)
+- 2025-07-29: Removed parameter-name fallback and made `latex_name` mandatory
+  in all models (AI assistant)
 
 ## Version 1.18.3
-- 2025-07-29: Fallback sound-horizon integral now looks for `Omega_b`, `Omega_gamma` and `z_rec`/`z_recomb` instead of legacy aliases (AI assistant)
+- 2025-07-29: Fallback sound-horizon integral now looks for `Omega_b`,
+  `Omega_gamma` and `z_rec`/`z_recomb` instead of legacy aliases (AI
+  assistant)
 
 ## Version 1.18.2
-- 2025-07-29: Fixed parsing failures by removing \rm from parameter names in expressions and bumped versions (AI assistant)
+- 2025-07-29: Fixed parsing failures by removing \rm from parameter names in
+  expressions and bumped versions (AI assistant)
 
 ## Version 1.18.1
-- 2025-07-29: Replaced legacy parameter aliases with full LaTeX names across models and documentation (AI assistant)
+- 2025-07-29: Replaced legacy parameter aliases with full LaTeX names across
+  models and documentation (AI assistant)
 
 ## Version 1.18.0
-- 2025-07-28: Removed math delimiters and double backslash requirement in model files; added implicit multiplication (AI assistant)
+- 2025-07-28: Removed math delimiters and double backslash requirement in model
+  files; added implicit multiplication (AI assistant)
 
 ## Version 1.17.0
-- 2025-07-28: Extended latex_mappings with extra symbols, functions and macros; bumped version (AI assistant)
+- 2025-07-28: Extended latex_mappings with extra symbols, functions and macros;
+  bumped version (AI assistant)
 
 ## Version 1.16.0
-- 2025-07-28: Centralized LaTeX mappings and added latex_utils module (AI assistant)
+- 2025-07-28: Centralized LaTeX mappings and added latex_utils module (AI
+  assistant)
 
 ## Version 1.15.0
-- 2025-07-28: Added automatic python_var generation and improved LaTeX handling (AI assistant)
+- 2025-07-28: Added automatic python_var generation and improved LaTeX handling
+  (AI assistant)
 
 ## Version 1.14.11
-- 2025-07-28: Stripped size macros from plot labels and bumped version to 1.14.11 (AI assistant)
+- 2025-07-28: Stripped size macros from plot labels and bumped version to
+  1.14.11 (AI assistant)
 
 ## Version 1.14.10
-- 2025-07-28: Expanded model JSON guide with supported functions and common mistakes (AI assistant)
+- 2025-07-28: Expanded model JSON guide with supported functions and common
+  mistakes (AI assistant)
 
 ## Version 1.14.9
-- 2025-07-26: Reduced CMB title padding to avoid overlap with residual plots (AI assistant)
+- 2025-07-26: Reduced CMB title padding to avoid overlap with residual plots
+  (AI assistant)
 - 2025-07-27: Improved LaTeX parsing for additional macros (AI assistant)
-- 2025-07-27: Fixed bracket handling in LaTeX parser to avoid parse failures (AI assistant)
-- 2025-07-27: Documented JSON escape requirement for LaTeX macros (AI assistant)
+- 2025-07-27: Fixed bracket handling in LaTeX parser to avoid parse failures
+  (AI assistant)
+- 2025-07-27: Documented JSON escape requirement for LaTeX macros (AI
+  assistant)
 
 ## Version 1.14.8
-- 2025-07-26: Improved footer spacing, unified CMB legends and added verbose dataset summaries (AI assistant)
+- 2025-07-26: Improved footer spacing, unified CMB legends and added verbose
+  dataset summaries (AI assistant)
 
 ## Version 1.14.7
-- 2025-07-26: Combined JLA systematic and statistical covariances and updated parser logic (AI assistant)
+- 2025-07-26: Combined JLA systematic and statistical covariances and updated
+  parser logic (AI assistant)
 
 ## Version 1.14.6
-- 2025-07-26: Unified info box spacing with margins, adjusted footer placement and fixed CMB title overlap (AI assistant)
+- 2025-07-26: Unified info box spacing with margins, adjusted footer placement
+  and fixed CMB title overlap (AI assistant)
 
 ## Version 1.14.5
-- 2025-07-26: Documented JLA covariance fallback and tightened info box layout (AI assistant)
+- 2025-07-26: Documented JLA covariance fallback and tightened info box layout
+  (AI assistant)
 
 ## Version 1.14.4
-- 2025-07-27: Handled near-singular JLA covariance by falling back to diagonal errors (AI assistant)
+- 2025-07-27: Handled near-singular JLA covariance by falling back to diagonal
+  errors (AI assistant)
 
 ## Version 1.14.3
-- 2025-07-27: Removed deprecated UniStra SNe data and fixed JLA covariance handling (AI assistant)
-- 2025-07-27: Improved fit report outputs and enlarged plot dimensions (AI assistant)
+- 2025-07-27: Removed deprecated UniStra SNe data and fixed JLA covariance
+  handling (AI assistant)
+- 2025-07-27: Improved fit report outputs and enlarged plot dimensions (AI
+  assistant)
 
 ## Version 1.14.2
-- 2025-07-26: Lightened grid lines, widened plot margins and fixed BAO info box equation parsing (AI assistant)
+- 2025-07-26: Lightened grid lines, widened plot margins and fixed BAO info box
+  equation parsing (AI assistant)
 
 ## Version 1.14.1
-- 2025-07-26: Human intervention in CHANGELOG.md due to messed up order, dates and lack of template (Apostol Apostolov)
-- 2025-07-26: Unified plot style and improved info boxes across all data types (AI assistant)
+- 2025-07-26: Human intervention in CHANGELOG.md due to messed up order, dates
+  and lack of template (Apostol Apostolov)
+- 2025-07-26: Unified plot style and improved info boxes across all data types
+  (AI assistant)
 
 ## Version 1.14.0
-- 2025-07-25: Added JLA 2014 dataset with full covariance matrix and new metadata field `authors_all` (AI assistant)
-- 2025-07-25: Fixed version string handling and updated documentation (AI assistant)
+- 2025-07-25: Added JLA 2014 dataset with full covariance matrix and new
+  metadata field `authors_all` (AI assistant)
+- 2025-07-25: Fixed version string handling and updated documentation (AI
+  assistant)
 
 ## Version 1.13.1
 - 2025-07-25: Renamed test BAO dataset and updated documentation (AI assistant)
 
 ## Version 1.13.0
-- 2025-07-24: Enforced automatic SemVer bumps and updated version references (AI assistant)
+- 2025-07-24: Enforced automatic SemVer bumps and updated version references
+  (AI assistant)
 
 ## Version 1.12.9
-- 2025-07-19: Expanded and clarified documentation; explained `.egg-info` folder and added CONTRIBUTING guide (AI assistant)
+- 2025-07-19: Expanded and clarified documentation; explained `.egg-info`
+  folder and added CONTRIBUTING guide (AI assistant)
 
 ## Version 1.12.8
-- 2025-07-19: Updated logger to avoid duplicate console output and capture user input (AI assistant)
-- 2025-07-19: Footer lines now rendered with smaller font to prevent overlap (AI assistant)
+- 2025-07-19: Updated logger to avoid duplicate console output and capture user
+  input (AI assistant)
+- 2025-07-19: Footer lines now rendered with smaller font to prevent overlap
+  (AI assistant)
 
 ## Version 1.12.7
-- 2025-07-16: Log now records console output verbatim and strips absolute paths (AI assistant)
+- 2025-07-16: Log now records console output verbatim and strips absolute paths
+  (AI assistant)
 
 ## Version 1.12.6
-- 2025-07-16: Improved footer wrapping, plot legends and info boxes with combined chi2; tweaked BAO residuals (AI assistant)
+- 2025-07-16: Improved footer wrapping, plot legends and info boxes with
+  combined chi2; tweaked BAO residuals (AI assistant)
 
 ## Version 1.12.5
-- 2025-07-16: Ignored virtual env directories when scanning imports for dependency check (AI assistant)
-- 2025-07-16: Removed automatic dependency installation and virtual environment logic (AI assistant)
-- 2025-07-16: Implemented BAO residual plots with smoothed averages (AI assistant)
-- 2025-07-16: Added smoothed residual averages to all plots and extended footer wrapping (AI assistant)
-- 2025-07-16: Dependency check now prints install command with only missing packages (AI assistant)
-- 2025-07-16: Dependency checker parses imports via AST and prints OS-aware install instructions (AI assistant)
-- 2025-07-16: Fixed logger crash and missing AST import in dependency check (AI assistant)
+- 2025-07-16: Ignored virtual env directories when scanning imports for
+  dependency check (AI assistant)
+- 2025-07-16: Removed automatic dependency installation and virtual environment
+  logic (AI assistant)
+- 2025-07-16: Implemented BAO residual plots with smoothed averages (AI
+  assistant)
+- 2025-07-16: Added smoothed residual averages to all plots and extended footer
+  wrapping (AI assistant)
+- 2025-07-16: Dependency check now prints install command with only missing
+  packages (AI assistant)
+- 2025-07-16: Dependency checker parses imports via AST and prints OS-aware
+  install instructions (AI assistant)
+- 2025-07-16: Fixed logger crash and missing AST import in dependency check (AI
+  assistant)
 
 ## Version 1.12.4
-- 2025-07-15: Fixed CMB spectrum scaling bug and added Dl verification test (AI assistant)
-- 2025-07-15: Updated documentation and developer guide with raw string rule (AI assistant)
-- 2025-07-15: Converted math docstrings to raw strings to silence escape warnings (AI assistant)
-- 2025-07-15: Fixed dependency check for Python 3.13 `find_spec` ValueError (AI assistant)
+- 2025-07-15: Fixed CMB spectrum scaling bug and added Dl verification test (AI
+  assistant)
+- 2025-07-15: Updated documentation and developer guide with raw string rule
+  (AI assistant)
+- 2025-07-15: Converted math docstrings to raw strings to silence escape
+  warnings (AI assistant)
+- 2025-07-15: Fixed dependency check for Python 3.13 `find_spec` ValueError (AI
+  assistant)
 
 ## Version 1.12.3
-- 2025-07-13: Unified timestamp handling and console output format updated (AI assistant)
+- 2025-07-13: Unified timestamp handling and console output format updated (AI
+  assistant)
 
 ## Version 1.12.2
-- 2025-07-10: Unified dataset metadata files and expanded plot footers (AI assistant)
+- 2025-07-10: Unified dataset metadata files and expanded plot footers (AI
+  assistant)
 - 2025-07-10: Fixed file name sanitization for Planck dataset (AI assistant)
 
 ## Version 1.12.1
-- 2025-07-10: Dynamic BAO metadata parsing and verbose fit summaries (AI assistant)
+- 2025-07-10: Dynamic BAO metadata parsing and verbose fit summaries (AI
+  assistant)
 
 ## Version 1.11.9
-- 2025-07-10: Automatic virtual environment setup and start scripts for Windows, macOS and Linux. Cancelling a run now removes its log file (AI assistant)
+- 2025-07-10: Automatic virtual environment setup and start scripts for
+  Windows, macOS and Linux. Cancelling a run now removes its log file (AI
+  assistant)
 
 ## Version 1.11.8
-- 2025-07-09: Added official JLA and Pantheon+ dataset names and short identifiers (AI assistant)
+- 2025-07-09: Added official JLA and Pantheon+ dataset names and short
+  identifiers (AI assistant)
 - 2025-07-09: Simplified plot footers and updated documentation (AI assistant)
 
 ## Version 1.11.7
-- 2025-07-09: Renamed Pantheon+ files and made parser auto-detect dataset names (AI assistant)
-- 2025-07-09: Moved chi-squared helpers back into the engine and removed chi2_helper module (AI assistant)
+- 2025-07-09: Renamed Pantheon+ files and made parser auto-detect dataset names
+  (AI assistant)
+- 2025-07-09: Moved chi-squared helpers back into the engine and removed
+  chi2_helper module (AI assistant)
 
 ## Version 1.11.6
-- 2025-07-09: Removed deprecated 1.4b and numba engines and set combined engine as default (AI assistant)
+- 2025-07-09: Removed deprecated 1.4b and numba engines and set combined engine
+  as default (AI assistant)
 
 ## Version 1.11.5
-- 2025-07-09: Documented SNe refinement step in workflow section of README (AI assistant)
-- 2025-07-08: Added SNe pre-fit step to combined engine to improve convergence and updated documentation (AI assistant)
-- 2025-07-08: Updated minimum Python version to 3.12 and synced README (AI assistant)
-- 2025-07-08: Added runtime check for Python version and documented exit behavior (AI assistant)
+- 2025-07-09: Documented SNe refinement step in workflow section of README (AI
+  assistant)
+- 2025-07-08: Added SNe pre-fit step to combined engine to improve convergence
+  and updated documentation (AI assistant)
+- 2025-07-08: Updated minimum Python version to 3.12 and synced README (AI
+  assistant)
+- 2025-07-08: Added runtime check for Python version and documented exit
+  behavior (AI assistant)
 
 ## Version 1.11.4
-- 2025-07-08: Expressions in all cosmo_model JSON files converted to LaTeX and parser updated (AI assistant)
+- 2025-07-08: Expressions in all cosmo_model JSON files converted to LaTeX and
+  parser updated (AI assistant)
 
 ## Version 1.11.3
-- 2025-07-07: Fixed missing extra CMB parameters in run_cmb_analysis and bumped version (AI assistant)
+- 2025-07-07: Fixed missing extra CMB parameters in run_cmb_analysis and bumped
+  version (AI assistant)
 
 ## Version 1.11.2
-- 2025-07-07: Moved chi-squared helpers to chi2_helper module and updated docs (AI assistant)
+- 2025-07-07: Moved chi-squared helpers to chi2_helper module and updated docs
+  (AI assistant)
 
 ## Version 1.11.1
-- 2025-07-07: Unified SNe data processing and chi-squared helpers (AI assistant)
+- 2025-07-07: Unified SNe data processing and chi-squared helpers (AI
+  assistant)
 
 
 ## Version 1.10.1-beta (Development Release)
-- 2025-07-07: Unified CMB handling with SNe and BAO, removed engine interface fallbacks, updated docs (AI assistant)
+- 2025-07-07: Unified CMB handling with SNe and BAO, removed engine interface
+  fallbacks, updated docs (AI assistant)
 
 ## Version 1.9.3-beta (Development Release)
-- 2025-07-07: Fixed parameter list mutation in combined engine and bumped version (AI assistant)
-- 2025-07-07: Removed deprecated L-BFGS-B solver options to silence SciPy warnings (AI assistant)
-- 2025-07-07: Increased CMB cache precision to six significant digits (AI assistant)
+- 2025-07-07: Fixed parameter list mutation in combined engine and bumped
+  version (AI assistant)
+- 2025-07-07: Removed deprecated L-BFGS-B solver options to silence SciPy
+  warnings (AI assistant)
+- 2025-07-07: Increased CMB cache precision to six significant digits (AI
+  assistant)
 
 ## Version 1.9.2-beta (Development Release)
-- 2025-07-07: Bumped version to 1.9.2-beta and expanded code comments (AI assistant)
+- 2025-07-07: Bumped version to 1.9.2-beta and expanded code comments (AI
+  assistant)
 
 ## Version 1.9.1-beta (Development Release)
-- 2025-07-07: Renamed scripts package to copernican_lib and updated documentation (AI assistant)
+- 2025-07-07: Renamed scripts package to copernican_lib and updated
+  documentation (AI assistant)
 
 ## Version 1.9.0-beta (Development Release)
-- 2025-07-07: Centralized optimization wrappers and updated documentation (AI assistant)
+- 2025-07-07: Centralized optimization wrappers and updated documentation (AI
+  assistant)
 
 ## Version 1.8.5-beta (Development Release)
-- 2025-07-07: Enforced spawn start method and restricted JSON validation to main process (AI assistant)
+- 2025-07-07: Enforced spawn start method and restricted JSON validation to
+  main process (AI assistant)
 
 ## Version 1.8.4-beta (Development Release)
-- 2025-07-07: Restored compatibility of chi_squared_cmb with plugin interface (AI assistant)
-- 2025-07-07: Bumped development version and updated documentation (AI assistant)
-- 2025-07-07: Documented engine-plugin architecture and updated JSON example (AI assistant)
-- 2025-07-07: Revised AGENTS overview and expanded README with developer guide (AI assistant)
-- 2025-07-07: Fixed test discovery and matplotlib cleanup in run-tests mode (AI assistant)
+- 2025-07-07: Restored compatibility of chi_squared_cmb with plugin interface
+  (AI assistant)
+- 2025-07-07: Bumped development version and updated documentation (AI
+  assistant)
+- 2025-07-07: Documented engine-plugin architecture and updated JSON example
+  (AI assistant)
+- 2025-07-07: Revised AGENTS overview and expanded README with developer guide
+  (AI assistant)
+- 2025-07-07: Fixed test discovery and matplotlib cleanup in run-tests mode (AI
+  assistant)
 
 ## Version 1.8.3-beta (Development Release)
-- 2025-07-06: Rewrote combined engine for true joint optimisation (AI assistant)
+- 2025-07-06: Rewrote combined engine for true joint optimisation (AI
+  assistant)
 - 2025-07-06: Fixed CMB chi-squared interface and allowed fitting of CAMB
   parameters (AI assistant)
 
 ## Version 1.8.2-beta (Development Release)
 - 2025-07-06: Optimized CMB evaluation with cached CAMB calls (AI assistant)
-- 2025-07-06: Enabled true joint fitting with optional SALT2 parameters (AI assistant)
+- 2025-07-06: Enabled true joint fitting with optional SALT2 parameters (AI
+  assistant)
 
 ## Version 1.8.1-beta (Development Release)
-- 2025-07-06: Made combined-fit engine verbose and fixed docstring escape warning (AI assistant)
+- 2025-07-06: Made combined-fit engine verbose and fixed docstring escape
+  warning (AI assistant)
 
 ## Version 1.8.0-beta (Development Release)
-- 2025-07-06: Added combined-fit engine and optional test execution (AI assistant)
+- 2025-07-06: Added combined-fit engine and optional test execution (AI
+  assistant)
 - 2025-07-06: Bumped version to 1.8.0-beta (AI assistant)
-- 2025-07-06: Integrated combined-fit workflow and updated documentation (AI assistant)
+- 2025-07-06: Integrated combined-fit workflow and updated documentation (AI
+  assistant)
 
 ## Version 1.7.12-beta (Development Release)
-- 2025-07-06: Added TE/EE spectrum handling and improved cosmic variance plotting (AI assistant)
+- 2025-07-06: Added TE/EE spectrum handling and improved cosmic variance
+  plotting (AI assistant)
 - 2025-07-06: Bumped version to 1.7.12-beta (AI assistant)
 
 ## Version 1.7.11-beta (Development Release)
-- 2025-07-06: Fixed Planck 2018 lite parser and trimmed covariance to TT block (AI assistant)
+- 2025-07-06: Fixed Planck 2018 lite parser and trimmed covariance to TT block
+  (AI assistant)
 - 2025-07-06: Bumped version to 1.7.11-beta (AI assistant)
 
 ## Version 1.7.10-beta (Development Release)
@@ -408,42 +560,61 @@ Add one line for each substantive commit or pull request directly under the late
 - 2025-07-06: Bumped version to 1.7.10-beta (AI assistant)
 
 ## Version 1.7.9-beta (Development Release)
-- 2025-07-06: Fixed Planck lite scaling and covariance endianness (AI assistant)
-- 2025-07-06: Enhanced default CMB wrapper and engine spectra output (AI assistant)
-- 2025-07-06: Updated documentation and version bump to 1.7.9-beta (AI assistant)
+- 2025-07-06: Fixed Planck lite scaling and covariance endianness (AI
+  assistant)
+- 2025-07-06: Enhanced default CMB wrapper and engine spectra output (AI
+  assistant)
+- 2025-07-06: Updated documentation and version bump to 1.7.9-beta (AI
+  assistant)
 
 ## Version 1.7.8-beta (Development Release)
-- 2025-07-06: Added dedicated CMB analysis stage with verbose logging (AI assistant)
-- 2025-07-06: Updated documentation and version bump to 1.7.8-beta (AI assistant)
+- 2025-07-06: Added dedicated CMB analysis stage with verbose logging (AI
+  assistant)
+- 2025-07-06: Updated documentation and version bump to 1.7.8-beta (AI
+  assistant)
 
 ## Version 1.7.7-beta (Development Release)
-- 2025-07-06: Overhauled Planck parser with µK² conversion and TE/EE support (AI assistant)
-- 2025-07-06: Redesigned CMB plot with log scaling and variance shading (AI assistant)
-- 2025-07-06: Documentation updates and version bump to 1.7.7-beta (AI assistant)
+- 2025-07-06: Overhauled Planck parser with µK² conversion and TE/EE support
+  (AI assistant)
+- 2025-07-06: Redesigned CMB plot with log scaling and variance shading (AI
+  assistant)
+- 2025-07-06: Documentation updates and version bump to 1.7.7-beta (AI
+  assistant)
 
 ## Version 1.7.6-beta (Development Release)
 - 2025-07-05: Bumped COPERNICAN_VERSION and docs to 1.7.6-beta. (AI assistant)
-- 2025-07-06: Added TE/EE spectrum handling in parser, engine and plotter. (AI assistant)
-- 2025-07-06: Improved Planck lite parser covariance checks with fallback warnings. (AI assistant)
-- 2025-07-06: Fixed chi-squared label formatting warnings in plotter. (AI assistant)
+- 2025-07-06: Added TE/EE spectrum handling in parser, engine and plotter. (AI
+  assistant)
+- 2025-07-06: Improved Planck lite parser covariance checks with fallback
+  warnings. (AI assistant)
+- 2025-07-06: Fixed chi-squared label formatting warnings in plotter. (AI
+  assistant)
 
 ## Version 1.7.5-beta (Development Release)
 - 2025-07-05: Removal of user-selectable test mode. (AI assistant)
 - 2025-07-05: Automatic functional tests run at startup. (AI assistant)
 - 2025-07-05: Updated documentation and model guide. (AI assistant)
-- 2025-07-05: Clarified CMB requirements in cosmo_model_guide and bumped guide version. (AI assistant)
+- 2025-07-05: Clarified CMB requirements in cosmo_model_guide and bumped guide
+  version. (AI assistant)
 - 2025-07-05: Documented automatic startup test suite in README. (AI assistant)
 
 ## Version 1.7.4-beta (Development Release)
-- 2025-07-05: Fixed unit conversion (K\u00b2 \u2192 \u03bcK\u00b2) by applying a 1e12 scale factor (AI assistant)
-- 2025-07-05: Added neutrino density mapping (`omnuh2`) to the \u039bCDM parameter map (AI assistant)
+- 2025-07-05: Fixed unit conversion (K\u00b2 \u2192 \u03bcK\u00b2) by applying
+  a 1e12 scale factor (AI assistant)
+- 2025-07-05: Added neutrino density mapping (`omnuh2`) to the \u039bCDM
+  parameter map (AI assistant)
 
 ## Version 1.7.3-beta (Development Release)
-- 2025-07-05: Fixed Planck covariance reader for ASCII data and ensured CMB parameters use SNe best-fit values (AI assistant)
-- 2025-07-05: Corrected Planck covariance parsing for binary Fortran record (AI assistant)
-- 2025-07-05: Re-added integral expression support using numerical quadrature (AI assistant)
-- 2025-07-05: Added `_wrap_math` helper and updated parameter label rendering (AI assistant)
-- 2025-07-05: Updated LICENSE.md with new definitions and effective date (AI assistant)
+- 2025-07-05: Fixed Planck covariance reader for ASCII data and ensured CMB
+  parameters use SNe best-fit values (AI assistant)
+- 2025-07-05: Corrected Planck covariance parsing for binary Fortran record (AI
+  assistant)
+- 2025-07-05: Re-added integral expression support using numerical quadrature
+  (AI assistant)
+- 2025-07-05: Added `_wrap_math` helper and updated parameter label rendering
+  (AI assistant)
+- 2025-07-05: Updated LICENSE.md with new definitions and effective date (AI
+  assistant)
 - 2025-07-05: Restored 1.6.4 and 1.6.5 changelog entries (AI assistant)
 
 ## Version 1.7.2-beta (Development Release)
@@ -454,71 +625,98 @@ Add one line for each substantive commit or pull request directly under the late
 ## Version 1.7.1-beta (Development Release)
 - 2025-07-05: Updated version references to 1.7.1-beta (AI assistant)
 - 2025-07-05: Implemented Planck 2018 lite CMB parser (AI assistant)
-- 2025-07-05: Added `valid_for_cmb` flag and updated plugin validation (AI assistant)
-- 2025-07-05: Added CAMB-based CMB analysis and chi-squared routines (AI assistant)
-- 2025-07-05: Added cmb.param_map metadata to models and documentation (AI assistant)
+- 2025-07-05: Added `valid_for_cmb` flag and updated plugin validation (AI
+  assistant)
+- 2025-07-05: Added CAMB-based CMB analysis and chi-squared routines (AI
+  assistant)
+- 2025-07-05: Added cmb.param_map metadata to models and documentation (AI
+  assistant)
 - 2025-07-05: Stored CAMB parameter order in Planck 2018 parser (AI assistant)
-- 2025-07-05: Added automatic CMB wrapper and parameter mapping helper (AI assistant)
-- 2025-07-05: run_cmb_analysis now converts fitted parameters with get_camb_params (AI assistant)
+- 2025-07-05: Added automatic CMB wrapper and parameter mapping helper (AI
+  assistant)
+- 2025-07-05: run_cmb_analysis now converts fitted parameters with
+  get_camb_params (AI assistant)
 
 ## Version 1.7.0-beta (Development Release)
-- 2025-07-05: Skip CMB evaluation when model sets valid_for_cmb=false (AI assistant)
+- 2025-07-05: Skip CMB evaluation when model sets valid_for_cmb=false (AI
+  assistant)
 - 2025-07-05: Implemented CMB spectrum plotting (AI assistant)
 - 2025-07-05: Added CMB residual CSV export (AI assistant)
-- 2025-07-05: Documented cmb.param_map usage and parser param_names attribute (AI assistant)
+- 2025-07-05: Documented cmb.param_map usage and parser param_names attribute
+  (AI assistant)
 - 2025-07-05: Bumped version to 1.7.0 and reorganized changelog (AI assistant)
-- 2025-07-05: Removed obsolete CMB placeholder parser and dataset (AI assistant)
-- 2025-07-05: Added CAMB dependency to pyproject and updated docs (AI assistant)
-- 2025-07-05: Corrected CMB spectrum units and Planck parser to use D_l (AI assistant)
+- 2025-07-05: Removed obsolete CMB placeholder parser and dataset (AI
+  assistant)
+- 2025-07-05: Added CAMB dependency to pyproject and updated docs (AI
+  assistant)
+- 2025-07-05: Corrected CMB spectrum units and Planck parser to use D_l (AI
+  assistant)
 - 2025-07-05: Removed DEV NOTE headers from pyproject.toml (AI assistant)
 
 ## Version 1.6.5 (Patch Release)
-- 2025-06-23: Fixed plot info boxes to display equations from the selected alternative theory and ensured Greek letters render correctly (AI assistant)
-- 2025-06-23: Updated README and AGENTS documentation for corrected JSON schema and version bump (AI assistant)
+- 2025-06-23: Fixed plot info boxes to display equations from the selected
+  alternative theory and ensured Greek letters render correctly (AI
+  assistant)
+- 2025-06-23: Updated README and AGENTS documentation for corrected JSON schema
+  and version bump (AI assistant)
 
 ## Version 1.6.4 (Patch Release)
-- 2025-06-23: Added numerical quadrature support for Integral expressions (AI assistant)
+- 2025-06-23: Added numerical quadrature support for Integral expressions (AI
+  assistant)
 
 ## Version 1.6.3 (Patch Release)
-- 2025-06-22: Restored `pyproject.toml` and silenced Pandas whitespace warning (AI assistant)
-- 2025-06-22: Declared Python 3.13.1+ requirement in pyproject and README (AI assistant)
+- 2025-06-22: Restored `pyproject.toml` and silenced Pandas whitespace warning
+  (AI assistant)
+- 2025-06-22: Declared Python 3.13.1+ requirement in pyproject and README (AI
+  assistant)
 
 ## Version 1.6.2 (Patch Release)
 - 2025-06-22: Added LCDM equations and sound horizon formula (AI assistant)
 
 ## Version 1.6.1 (Patch Release)
 - Restored model equations in plot info boxes.
-- 2025-06-22: Fixed plot crashes when model equations used display-mode dollar signs (AI assistant)
+- 2025-06-22: Fixed plot crashes when model equations used display-mode dollar
+  signs (AI assistant)
 - Added standardized plot footer with run metadata.
 - start.command cleaned up.
 - 2025-06-21: Documented stable plotting style and algorithms (AI assistant)
-- 2025-06-21: Clarified when MINOR vs PATCH increments occur in README (AI assistant)
+- 2025-06-21: Clarified when MINOR vs PATCH increments occur in README (AI
+  assistant)
 
 ## Version 1.6 (Stable Release)
-- 2025-06-21: Fixed trailing text in start.command and ensured newline (AI assistant)
-- 2025-06-21: First stable release with reliable SNe Ia and BAO calculations (AI assistant)
-- 2025-06-21: Legacy DEV NOTE headers removed from source files and notes migrated to `CHANGELOG.md` (AI assistant)
+- 2025-06-21: Fixed trailing text in start.command and ensured newline (AI
+  assistant)
+- 2025-06-21: First stable release with reliable SNe Ia and BAO calculations
+  (AI assistant)
+- 2025-06-21: Legacy DEV NOTE headers removed from source files and notes
+  migrated to `CHANGELOG.md` (AI assistant)
 - 2025-06-21: Plugin now exposes model equations and filename (AI assistant)
 - 2025-06-21: Plugin filename stored during JSON loading (AI assistant)
-- 2025-06-21: Plots now include a timestamped footer with comparison details (AI assistant)
+- 2025-06-21: Plots now include a timestamped footer with comparison details
+  (AI assistant)
 
 ## Version 1.5.1 (Development Release)
-- 2025-06-20: Added CHANGELOG template and updated docs to reference it (AI assistant)
+- 2025-06-20: Added CHANGELOG template and updated docs to reference it (AI
+  assistant)
 - Removed ``initial_guess`` from JSON models; parameter guesses now computed
   automatically from bounds.
 - Consolidated model metadata: ``theory`` block removed and equations moved
   under ``equations``.
 - Documentation updated to reflect declarative model design.
-- Development protocol revised: DEV NOTE markers removed in favor of documenting changes in `CHANGELOG.md` or `AGENTS.md`.
-- Schema documentation updated: `abstract` and `description` are now mandatory and all contributors summarize updates in `CHANGELOG.md`.
-- 2025-06-20: Added explicit `rs_expression` to `cosmo_model_lcdm.json` and migrated legacy documentation notes to `CHANGELOG.md` (AI assistant)
+- Development protocol revised: DEV NOTE markers removed in favor of
+  documenting changes in `CHANGELOG.md` or `AGENTS.md`.
+- Schema documentation updated: `abstract` and `description` are now mandatory
+  and all contributors summarize updates in `CHANGELOG.md`.
+- 2025-06-20: Added explicit `rs_expression` to `cosmo_model_lcdm.json` and
+  migrated legacy documentation notes to `CHANGELOG.md` (AI assistant)
 
 ## Version 1.5.0 (Development Release)
 - Data files and parsers reorganized under ``data/<type>/<source>/``.
 - Parser selection now based on data source only.
 - Removed deprecated `parsers/` directory and UniStra h2 parser.
 - Updated documentation for version 1.5.0.
-- Hotfix: Prompts list friendly dataset names with a clear title for every selection.
+- Hotfix: Prompts list friendly dataset names with a clear title for every
+  selection.
 
 ## Version 1.5f (Development Release)
 - Completed Phase 6: JSON schema extended with optional fields for CMB,
@@ -529,11 +727,14 @@ Add one line for each substantive commit or pull request directly under the late
   run a printed `pip install` command when packages are missing.
 - Hotfix 7: `Hz_expression` added to JSON models and compiled automatically for
   distance predictions.
-- Hotfix 8: Sound horizon `r_s` is now computed automatically when possible using
+- Hotfix 8: Sound horizon `r_s` is now computed automatically when possible
+  using
   a fallback integral if `rs_expression` is missing.
-- Hotfix 9: Parser auto-discovery now searches the project's top-level `parsers`
+- Hotfix 9: Parser auto-discovery now searches the project's top-level
+  `parsers`
   directory instead of a nonexistent `scripts/parsers` folder.
-- Hotfix 10: Fixed BAO smooth curve generation by allowing `_dm` to accept array
+- Hotfix 10: Fixed BAO smooth curve generation by allowing `_dm` to accept
+  array
   redshift values.
 
 ## Version 1.5e (Development Release)
@@ -547,11 +748,13 @@ Add one line for each substantive commit or pull request directly under the late
   packages are missing.
 
 ## Version 1.5c (Development Release)
-- Completed Phase 3: engine_interface now validates plugins and engines use the new abstraction layer.
+- Completed Phase 3: engine_interface now validates plugins and engines use the
+  new abstraction layer.
 - Updated documentation and headers for version 1.5c.
 
 ## Version 1.5b (Development Release)
-- Completed Phase 2: parser caches validated JSON and coder generates callables with sanity checks.
+- Completed Phase 2: parser caches validated JSON and coder generates callables
+  with sanity checks.
 - Updated documentation and headers for version 1.5b.
 
 ## Version 1.5a (Development Release)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 **Version:** 3.6.11
 **Last Updated:** 2025-08-11
 
-The Copernican Suite is a Python toolkit for testing cosmological models against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and Cosmic Microwave Background (CMB) data.
-Support for gravitational waves and standard siren events is planned for future releases.
-The suite provides a modular architecture so new models, data parsers and computational engines can be plugged in with minimal effort.
+The Copernican Suite is a Python toolkit for testing cosmological models
+against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
+Cosmic Microwave Background (CMB) data.
+Support for gravitational waves and standard siren events is planned for future
+releases.
+The suite provides a modular architecture so new models, data parsers and
+computational engines can be plugged in with minimal effort.
 Additional design notes can be found under the `docs/` directory.
 
 ---
@@ -22,7 +26,8 @@ Additional design notes can be found under the `docs/` directory.
 10. [Plot Footers and Metadata](#plot-footers-and-metadata)
 11. [Creating New Models](#creating-new-models)
 12. [Developer Guide](#developer-guide)
-13. [AI-driven and human development laws and protocols](#6-ai-driven-and-human-development-laws-and-protocols)
+13. [AI-driven and human development laws and protocols](#6-ai-driven-and-
+    human-development-laws-and-protocols)
 14. [License](#license)
 15. [Versioning Policy](#versioning-policy)
 16. [API Overview](docs/api_overview.md)
@@ -42,14 +47,16 @@ simple command line interface. Results are saved as plots and CSV files in the
 `./output/` directory.
 Under the hood the program follows a clear pipeline:
 1. **Dependency Check** – `copernican.py` scans for required packages and
-   prints an install command tailored to your OS listing only the missing packages.
+   prints an install command tailored to your OS listing only the missing
+packages.
 2. **Initialization** – the output directory is created and logging begins.
 3. **Configuration** – the user chooses a model and a computation engine
    from `./engines/`.  The default `cosmo_engine_comb.py` performs a
    combined optimisation across SNe, BAO and CMB, including optional
    SALT2 nuisance parameters when available. Constant values in a model's
   `cmb.param_map` are treated as
-  additional fit parameters so CMB spectra can be matched precisely. Data parsers are discovered automatically under
+  additional fit parameters so CMB spectra can be matched precisely. Data
+parsers are discovered automatically under
   `data/<type>/<source>` and models are loaded from `cosmo_model_*.yml`.
   Folders named `placeholder` are ignored so unfinished datasets do not appear
   in the selection menus.
@@ -66,7 +73,10 @@ Under the hood the program follows a clear pipeline:
    combined optimisation. The chi-squared contribution is then calculated.
 7. **Spectra Caching** – unlensed CAMB spectra are cached using parameter
    keys rounded to six significant digits.
-8. **Output Generation** – `copernican_lib/logger.py`, `copernican_lib/plotter.py` and `copernican_lib/csv_writer.py` handle logs, plots and tables. The log file is renamed at the end of each run to match the output timestamp.
+8. **Output Generation** – `copernican_lib/logger.py`,
+   `copernican_lib/plotter.py` and `copernican_lib/csv_writer.py` handle
+   logs, plots and tables. The log file is renamed at the end of each run to
+   match the output timestamp.
 9. **Loop or Exit** – the user may evaluate another model or quit, at which
    point temporary cache files are cleaned automatically.
 
@@ -74,18 +84,22 @@ Under the hood the program follows a clear pipeline:
 1. Ensure Python 3.11 or later is available. Launch the suite via the `start`
    script for your platform (`start.command`, `start.bat` or `start.sh`). The
    program checks for required Python packages at startup and prints an install
-   command appropriate for your OS listing only the missing packages. Running with an older Python
+   command appropriate for your OS listing only the missing packages. Running
+with an older Python
    version will print an error and exit immediately.
 2. Follow the interactive prompts to choose a model, preferred data sources and
    computation engine.
-3. Execute `python3 copernican.py --run-tests` or run `python -m unittest discover`
-   to verify the reference model and parsers. The `--run-tests` flag delegates to
+3. Execute `python3 copernican.py --run-tests` or run `python -m unittest
+   discover`
+   to verify the reference model and parsers. The `--run-tests` flag delegates
+to
    `python -m unittest discover` to gather all modules under `tests/`.
 4. Plots and CSV results will appear in the `output/` folder when the run
    completes.
 
 ## Dependencies
-This project requires **Python 3.11 or later** and relies on `numpy`, `scipy`, `matplotlib`,
+This project requires **Python 3.11 or later** and relies on `numpy`, `scipy`,
+`matplotlib`,
 `pandas`, `sympy`, `jsonschema` and `camb==1.6.2`.
 If any packages are missing the program prints an OS-specific install command
 listing only those missing packages and exits so you can install them manually.
@@ -109,7 +123,8 @@ pip install .    # regular install
 pip install -e . # editable for development
 ```
 
-Installing the suite with `pip` creates a `copernican_suite.egg-info` directory.
+Installing the suite with `pip` creates a `copernican_suite.egg-info`
+directory.
 This folder contains package metadata such as the version number, dependency
 list and entry points used by Python's packaging tools. It is generated
 automatically and does not need to be tracked in version control.
@@ -126,7 +141,8 @@ macOS signing instructions.
 models/           - YAML model definitions containing all theory text and
                     equations. Optional `.md` files may provide human-readable
                     summaries but are not required.
-engines/          - Computational backends (e.g. `cosmo_engine_comb.py` for combined fits)
+engines/          - Computational backends (e.g. `cosmo_engine_comb.py` for
+                    combined fits)
 data/             - Observation data organized as ``data/<type>/<source>/``
   cmb/planck2018lite/ - Planck 2018 lite TT/TE/EE spectra and covariance
                          (binary Fortran matrix)
@@ -150,17 +166,23 @@ should not be modified by AI-driven code changes.
 
 ## Engine and Plugin Architecture
 The program compiles model equations into Python functions at runtime. When a
-`cosmo_model_*.yml` file is selected, `copernican_lib/model_parser.py` validates the
-content and `copernican_lib/model_coder.py` converts the symbolic expressions into
-NumPy-ready callables. `copernican_lib/engine_interface.build_plugin` attaches these
-functions to a lightweight plugin object that exposes a stable API. Every engine
+`cosmo_model_*.yml` file is selected, `copernican_lib/model_parser.py`
+validates the
+content and `copernican_lib/model_coder.py` converts the symbolic expressions
+into
+NumPy-ready callables. `copernican_lib/engine_interface.build_plugin` attaches
+these
+functions to a lightweight plugin object that exposes a stable API. Every
+engine
 operates solely through this plugin and decides how parameters are fitted. The
 main workflow simply loads the plugin, selects an engine from `./engines/` and
 invokes its functions. New engines can therefore implement alternate strategies
 —such as SNe-only fits or fully combined optimisations—without modifying the
 rest of the codebase.
-Generic chi-squared helpers are now part of `engines/cosmo_engine_comb.py` under
-a dedicated helper block, keeping `model_coder.py` focused on translating models.
+Generic chi-squared helpers are now part of `engines/cosmo_engine_comb.py`
+under
+a dedicated helper block, keeping `model_coder.py` focused on translating
+models.
 
 The helper `chi_squared_cmb` now accepts either a plugin and parameter
 vector or a ready CAMB dictionary. This flexibility lets future engines reuse
@@ -174,7 +196,8 @@ the same CMB calculation regardless of their own fitting scheme.
    spectra with full covariance so additional datasets can be dropped in with
   minimal effort. The BOSS DR12 BAO parser combines the consensus dM, Hz,
   $D_V$ and $F_{AP}$ measurements with their covariance matrices to yield
-  $D_M/r_s$, $D_H/r_s$ and $D_V/r_s$. The public [SDSS DR12 archive](https://data.sdss.org/sas/dr12/boss/) does not provide a
+  $D_M/r_s$, $D_H/r_s$ and $D_V/r_s$. The public [SDSS DR12
+archive](https://data.sdss.org/sas/dr12/boss/) does not provide a
   joint covariance matrix for these observables, so `cosmo_parser_bossdr12.py`
   follows a block-diagonal approach that assumes the $dM/Hz$ and $D_V/F_{AP}$
   sets are uncorrelated.
@@ -183,7 +206,8 @@ the same CMB calculation regardless of their own fitting scheme.
 - After each run you may choose to evaluate another model or exit. Cache files
   are cleaned automatically.
 - When a run finishes the suite prints the abstract text from each model along
-  with a summary of the best-fit parameters and individual chi-squared values for
+  with a summary of the best-fit parameters and individual chi-squared values
+for
   SNe, BAO and CMB.
 
 ## Plot Footers and Metadata
@@ -216,15 +240,18 @@ See `cosmo_model_template.yml` for a detailed template.
 2. *(Optional)* Create `cosmo_model_name.md` if you want a human-friendly
    summary of the same content. The suite does not read this file.
 3. Include an `Hz_expression` written in LaTeX math form defining `H(z)` using
-   your model parameters. Explicit `*` is optional since implicit multiplication
+   your model parameters. Explicit `*` is optional since implicit
+multiplication
    is now supported, though adding it can improve readability.
 4. Optionally provide an `rs_expression` in LaTeX for the sound horizon at
    recombination or include the parameters `Omega_b`, `Omega_gamma` and either
    `z_rec` or `z_recomb`. The suite will then
    derive `r_s` automatically using a numerical integral. Use `\infty` when an
    integral extends to infinity.
-5. Python code must never appear in `cosmo_model_*.yml`; all expressions are written in LaTeX.
-6. Backslashes may be written normally; the parser automatically escapes them so
+5. Python code must never appear in `cosmo_model_*.yml`; all expressions are
+   written in LaTeX.
+6. Backslashes may be written normally; the parser automatically escapes them
+   so
    LaTeX commands like `\frac` work without doubled characters.
 7. Expressions may include `Integral(...)` terms with explicit limits. They are
    evaluated numerically with SciPy's `quad` when the model is loaded.
@@ -240,12 +267,18 @@ See `cosmo_model_template.yml` for a detailed template.
     common operators.
 
 **Common mistakes**
-* Missing `*` between variables and parentheses results in a `'Symbol' object is not callable` error.
+* Missing `*` between variables and parentheses results in a `'Symbol' object
+  is not callable` error.
 * Using `oo` for infinite limits fails; write `\infty` instead.
-* Referencing `H(z)` inside `rs_expression` is unsupported—repeat the formula or rely on the fallback parameters.
+* Referencing `H(z)` inside `rs_expression` is unsupported—repeat the formula
+  or rely on the fallback parameters.
    
 The LaTeX parser supports a subset of math syntax including `\frac`,
-subscripts and superscripts, common functions (`\log`, `\ln`, `\exp`, `\sin`, `\cos`, `\tan`, `\csc`, `\sec`, `\cot`, `\arcsin`, `\arccos`, `\arctan`, `\sinh`, `\cosh`, `\tanh`, `\coth`, `\sech`, `\csch`, `\arcsinh`, `\arccosh`, `\arctanh`, `\sqrt`, `\abs`, `\floor`, `\ceil`), Greek letters such as `\alpha` and `\beta`, and
+subscripts and superscripts, common functions (`\log`, `\ln`, `\exp`, `\sin`,
+`\cos`, `\tan`, `\csc`, `\sec`, `\cot`, `\arcsin`, `\arccos`, `\arctan`,
+`\sinh`, `\cosh`, `\tanh`, `\coth`, `\sech`, `\csch`, `\arcsinh`, `\arccosh`,
+`\arctanh`, `\sqrt`, `\abs`, `\floor`, `\ceil`), Greek letters such as `\alpha`
+and `\beta`, and
 macros that adjust bracket size like `\left`, `\right`, `\bigl` and `\bigr`.
 Thin spaces (`\,`) and font switches (`\rm`) are ignored. Unsupported sizing
 macros are removed from plot labels to keep Matplotlib's MathText parser happy.
@@ -300,7 +333,8 @@ When a `cmb.param_map` object is provided, the mapping is stored on the plugin
 as `CMB_PARAM_MAP`. Call `plugin.get_camb_params(values)` to convert a list of
 cosmological parameters into a dictionary for CAMB. Constant numeric values in
 the mapping are interpreted as extra fit parameters by combined-fit engines so
-that the CMB spectrum can be adjusted independently. The engines themselves call
+that the CMB spectrum can be adjusted independently. The engines themselves
+call
 CAMB using this mapping; the plugin no longer provides a fallback
 `compute_cmb_spectrum` implementation. When `valid_for_cmb` is `false` the
 suite skips the CMB evaluation stage for that model.
@@ -315,15 +349,18 @@ minimal padding so each label fits neatly between CMB subplots.
 cache. This allows the domain-specific YAML language to evolve while remaining
 compatible with older models.
 `model_parser.py` validates this structure and `model_coder.py` translates the
-LaTeX expressions into NumPy-ready callables. When `Hz_expression` is present it is
+LaTeX expressions into NumPy-ready callables. When `Hz_expression` is present
+it is
 compiled into `get_Hz_per_Mpc` and related distance functions used by
 `engine_interface.py`. If an `rs_expression` or the parameters `Omega_b`,
 `Omega_gamma` and either `z_rec` or `z_recomb` are provided, a callable
 `get_sound_horizon_rs_Mpc` is also generated.
 
 ## Developer Guide
-Document every change in `CHANGELOG.md`. Each substantive update must add an entry using the template `- YYYY-MM-DD: short summary (author)`.
-Legacy `dev_note` headers embedded in source files have been removed in favour of changelog entries.
+Document every change in `CHANGELOG.md`. Each substantive update must add an
+entry using the template `- YYYY-MM-DD: short summary (author)`.
+Legacy `dev_note` headers embedded in source files have been removed in favour
+of changelog entries.
 Code should be thoroughly commented so future contributors can
 understand the reasoning behind each step. The documentation in `README.md` and
 `AGENTS.md` must be updated whenever behavior or structure changes.
@@ -331,7 +368,9 @@ See `CHANGELOG.md` for the complete project history.
 The short file `CONTRIBUTING.md` summarises the basic workflow for submitting
 patches and links back to these guidelines.
 
-The Copernican Suite License forbids redistributing the full suite and prohibits patent filings or assertions. All contributions must adhere to these restrictions.
+The Copernican Suite License forbids redistributing the full suite and
+prohibits patent filings or assertions. All contributions must adhere to these
+restrictions.
 
 To start developing, install the suite in editable mode:
 
@@ -339,7 +378,8 @@ To start developing, install the suite in editable mode:
 pip install -e .
 ```
 
-Install and run the pre-commit hooks to apply Black, Isort, Ruff and Flake8 checks:
+Install and run the pre-commit hooks to apply Black, Isort, Ruff and Flake8
+checks:
 
 ```bash
 pre-commit install
@@ -353,17 +393,21 @@ python -m unittest discover
 python copernican.py --run-tests  # uses unittest discovery internally
 ```
 
-Continuous integration verifies style, tests, and builds executables on Windows, macOS, and Debian-based Linux using GitHub Actions.
+Continuous integration verifies style, tests, and builds executables on
+Windows, macOS, and Debian-based Linux using GitHub Actions.
 
 Multiprocessing is used by several engines. The program enforces the `spawn`
 start method when it launches so that each worker process begins with a fresh
-Python interpreter. Model YAML files are validated with `jsonschema` only in the
+Python interpreter. Model YAML files are validated with `jsonschema` only in
+the
 main process; child processes simply read the sanitized cache.
-All engines import progress helpers from `copernican_lib/optim_utils.py` so that
+All engines import progress helpers from `copernican_lib/optim_utils.py` so
+that
 evaluation counting and reporting remain consistent across backends.
 
 New models are described entirely by YAML. Copy an existing file from `models/`
-and consult `cosmo_model_template.yml` for the full schema. Additional engines may
+and consult `cosmo_model_template.yml` for the full schema. Additional engines
+may
 be placed under `engines/` and must follow the interface in
 `copernican_lib/engine_interface.py`.
 
@@ -372,10 +416,13 @@ not modify them unless explicitly instructed.
 
 
 ## License
-The Copernican Suite is distributed under the terms of the [Copernican Suite License (CSL)](LICENSE.md). The license forbids redistributing the software in full and disallows patent filings or assertions.
+The Copernican Suite is distributed under the terms of the [Copernican Suite
+License (CSL)](LICENSE.md). The license forbids redistributing the software in
+full and disallows patent filings or assertions.
 
 ## Versioning Policy
-The project now follows [Semantic Versioning](https://semver.org/). Versions are
+The project now follows [Semantic Versioning](https://semver.org/). Versions
+are
 listed as `MAJOR.MINOR.PATCH`, where breaking changes increment `MAJOR`, new
 features increment `MINOR` and bug fixes increment `PATCH`. Package builds use
 `setuptools_scm` to derive the version from Git tags, so the version string is
@@ -390,17 +437,30 @@ altering `MAJOR.MINOR`.
 ## 4. Workflow Overview
 
 1.  **Dependency Check**: `copernican.py` scans for missing packages and
-    prints an OS-specific install command containing only those packages if any are absent.
+    prints an OS-specific install command containing only those packages if any
+are absent.
 2.  **Optional Tests**: Run `copernican.py --run-tests` to execute the
     functional test suite and verify that the LCDM model and data parsers work
-    as expected. This flag performs unittest discovery over the `tests` package.
-3.  **Initialization**: The script starts and creates the `./output/` directory for all results.
-4.  **Random Seed Setup**: The global NumPy RNG is seeded so any stochastic algorithms remain reproducible. The chosen seed is written to the log.
-5.  **Configuration**: The user specifies the file paths for the model and data files.
-6.  **SNe Ia Fitting**: The `cosmo_engine` fits the parameters of both the ΛCDM model and the alternative model to the SNe Ia data. When `cosmo_engine_comb.py` is selected this step refines the parameters before the full joint optimisation.
-7.  **BAO Analysis**: Using the best-fit parameters, the engine calculates BAO observables for each model.
-8.  **CMB Analysis**: Each model's CMB spectrum is evaluated against the selected dataset. The combined engine performs this after completing the joint optimisation.
-9.  **Output Generation**: `plotter`, `csv_writer` and `logger` save plots, tables and logs using a consistent format. Plots now use a white background with very light grey, solid grid lines for clarity.
+    as expected. This flag performs unittest discovery over the `tests`
+package.
+3.  **Initialization**: The script starts and creates the `./output/` directory
+    for all results.
+4.  **Random Seed Setup**: The global NumPy RNG is seeded so any stochastic
+    algorithms remain reproducible. The chosen seed is written to the log.
+5.  **Configuration**: The user specifies the file paths for the model and data
+    files.
+6.  **SNe Ia Fitting**: The `cosmo_engine` fits the parameters of both the ΛCDM
+    model and the alternative model to the SNe Ia data. When
+    `cosmo_engine_comb.py` is selected this step refines the parameters
+    before the full joint optimisation.
+7.  **BAO Analysis**: Using the best-fit parameters, the engine calculates BAO
+    observables for each model.
+8.  **CMB Analysis**: Each model's CMB spectrum is evaluated against the
+    selected dataset. The combined engine performs this after completing
+    the joint optimisation.
+9.  **Output Generation**: `plotter`, `csv_writer` and `logger` save plots,
+    tables and logs using a consistent format. Plots now use a white
+    background with very light grey, solid grid lines for clarity.
 10. **Loop or Exit**: The user is prompted to run another evaluation or exit.
 
 ---
@@ -411,26 +471,51 @@ See `CHANGELOG.md` for complete version history.
 
 ## 6. Development laws and protocols for human and AI contributors
 
-> **To any AI or human developer, including my future self, that modifies this codebase:**
+> **To any AI or human developer, including my future self, that modifies this
+codebase:**
 >
-> This project is developed through a combination of human direction and AI implementation. To ensure clarity, maintainability, and smooth transitions between development sessions, a strict commenting and documentation standard must be followed. The `AGENTS.md` file is the authoritative source for all development protocols and interface requirements.
+> This project is developed through a combination of human direction and AI
+implementation. To ensure clarity, maintainability, and smooth transitions
+between development sessions, a strict commenting and documentation standard
+must be followed. The `AGENTS.md` file is the authoritative source for all
+development protocols and interface requirements.
 >
-> 1. **Summarize every change in `CHANGELOG.md` using the changelog template.** Legacy `dev_note` headers should be migrated to the changelog when touched.
-> 2. **Comment the code extensively.** Explain the "why" as well as the "what", clarifying both obvious and non-obvious, simple or complex logic or algorithms.
-> 3. **Keep comments synchronized with the actual code.** Whenever behaviour changes, update all nearby comments immediately so future contributors can rely on them.
-> 4. **Update documentation**, including this `AGENTS.md` and `README.md`, whenever behaviour or structure changes. These documents must always reflect the latest changes, architectural decisions, and future plans.
-> 5. **Keep these laws synchronized across `README.md` and `AGENTS.md`.** Amendments to any rule require an explicit human request.
-> 6. **Bump the project version according to Semantic Versioning whenever changes introduce new features, fixes or breaking changes.**
-> 7. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in any file.**
-> 8. **Re-read the "Development laws and protocols for human and AI contributors" section in `README.md` at the start of every development session.**
-> 9. **Document every module, function and class with clear "what" and "why" explanations.** Comments and docstrings should describe not only the behaviour but also the rationale behind it.
-> 10. **Use concise, descriptive function and identifier names that accurately convey their purpose without unnecessary length.**
-> 11. **Use raw strings or escape backslashes explicitly to avoid invalid escape sequence warnings in docstrings or string literals.**
-> 12. **Run `pre-commit` on all modified files before committing to enforce Black, Isort, Ruff and Flake8 checks.**
-> 13. **Do not redistribute the Copernican Suite in full or assert patent claims; the license forbids these actions.**
+> 1. **Summarize every change in `CHANGELOG.md` using the changelog template.**
+Legacy `dev_note` headers should be migrated to the changelog when touched.
+> 2. **Comment the code extensively.** Explain the "why" as well as the "what",
+clarifying both obvious and non-obvious, simple or complex logic or algorithms.
+> 3. **Keep comments synchronized with the actual code.** Whenever behaviour
+changes, update all nearby comments immediately so future contributors can rely
+on them.
+> 4. **Update documentation**, including this `AGENTS.md` and `README.md`,
+whenever behaviour or structure changes. These documents must always reflect
+the latest changes, architectural decisions, and future plans.
+> 5. **Keep these laws synchronized across `README.md` and `AGENTS.md`.**
+Amendments to any rule require an explicit human request.
+> 6. **Bump the project version according to Semantic Versioning whenever
+changes introduce new features, fixes or breaking changes.**
+> 7. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in
+any file.**
+> 8. **Re-read the "Development laws and protocols for human and AI
+contributors" section in `README.md` at the start of every development
+session.**
+> 9. **Document every module, function and class with clear "what" and "why"
+explanations.** Comments and docstrings should describe not only the behaviour
+but also the rationale behind it.
+> 10. **Use concise, descriptive function and identifier names that accurately
+convey their purpose without unnecessary length.**
+> 11. **Use raw strings or escape backslashes explicitly to avoid invalid
+escape sequence warnings in docstrings or string literals.**
+> 12. **Run `pre-commit` on all modified files before committing to enforce
+Black, Isort, Ruff and Flake8 checks.**
+> 13. **Do not redistribute the Copernican Suite in full or assert patent
+claims; the license forbids these actions.**
 > 14. **Keep individual lines under 79 characters to maintain readability.**
 >
-> Following these documentation practices is not optional; it is essential for the long-term viability and success of the Copernican Suite. Failure to follow these rules will compromise the maintainability of the Copernican Suite.
+> Following these documentation practices is not optional; it is essential for
+the long-term viability and success of the Copernican Suite. Failure to follow
+these rules will compromise the maintainability of the Copernican Suite.
 
 See [docs/api_overview.md](docs/api_overview.md) for the scripting API.
-All contributors must re-read this section at the beginning of every development session. The AGENTS.md file now instructs this explicitly.
+All contributors must re-read this section at the beginning of every
+development session. The AGENTS.md file now instructs this explicitly.


### PR DESCRIPTION
## Summary
- wrap long lines in changelog and README to respect 79-character limit

## Testing
- `pre-commit run --files CHANGELOG.md README.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_689a54b51ba0832f8714b1fa3812ea6b