### PR TITLE
Fix BAO parser import in test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ entries come first):
 
 - 2025-08-11: Set formatter line length to 79 and wrap existing lines (AI
   assistant)
+- 2025-08-11: Load BAO parser via importlib in tests to avoid package import
+  errors (AI assistant)
 
 ## Version 3.6.11
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 """Basic functional tests for the Copernican Suite."""
 
+import importlib.util
 import unittest
 from pathlib import Path
 
@@ -11,10 +12,23 @@ import copernican_lib.data_loaders as data_loaders
 import copernican_lib.engine_interface as engine_interface
 import copernican_lib.model_coder as model_coder
 import copernican_lib.model_parser as model_parser
-
-# Ensure compound BAO parser registration
-import data.bao.compound.cosmo_parser_compound  # noqa: F401
 import engines.cosmo_engine_comb as engine
+
+# Ensure compound BAO parser registration without requiring package installs
+parser_path = (
+    Path(__file__).resolve().parents[1]
+    / "data"
+    / "bao"
+    / "compound"
+    / "cosmo_parser_compound.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "cosmo_parser_compound",
+    parser_path,
+)
+if spec and spec.loader:
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
 
 
 class FunctionalTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary
- load BAO parser via importlib so tests run without data package installed
- document test fix in changelog

## Testing
- `pre-commit run --files tests/test_core.py CHANGELOG.md`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_689a60675ef8832faabb36043f6e5024