### PR TITLE
Forward CLI args in start.command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ entries come first):
 
 ## Unreleased
 
+- 2025-08-12: Forward CLI args in start.command; wrap comments (AI assistant)
 - 2025-08-11: Improve CI to export Python path, build universal2 macOS
   binaries and verify Copernican.app artifact (AI assistant)
 - 2025-08-11: Wrapped long lines across docs and scripts for readability (AI

--- a/start.command
+++ b/start.command
@@ -1,15 +1,11 @@
 #!/bin/bash
 
 # This script will launch the Copernican Suite.
-# It ensures that it runs from the same directory where the script is
-# located.
-
-# Change directory to the script's location. This is crucial for it to
-# find copernican.py.
+# Ensure the script runs from its own directory so copernican.py is found.
 cd "$(dirname "$0")"
 
 # Run the Python script using the python3 interpreter.
-python3 copernican.py
+python3 copernican.py "$@"
 
 # The terminal window will remain open after the script finishes
 # so you can review the output. You can close it manually.


### PR DESCRIPTION
## Summary
- let start.command pass through CLI arguments to copernican.py
- wrap long comments in start.command for line-length consistency

## Testing
- `pre-commit run --files start.command CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_689bc4080820832fa60c1fda4a8c0523