### PR TITLE
Use dataset IDs for output filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ entries come first):
   documenting the compound BAO dataset (AI assistant)
 - 2025-08-12: Revamped test suite with verbose logging, bounded optimiser
   iterations and explicit dataset paths (AI assistant)
+- 2025-08-13: Standardised `dataset_id` metadata and output filenames
+  (AI assistant)
 
 ## Version 3.6.12
 

--- a/copernican_lib/csv_writer.py
+++ b/copernican_lib/csv_writer.py
@@ -58,11 +58,11 @@ def save_sne_results_detailed_csv(
         df_out[f"mu_model_{alt_model_name}"] = np.nan
         df_out[f"residual_{alt_model_name}"] = np.nan
 
-    dataset_name = sne_data_df.attrs.get("dataset_name_sanitized", "SNe_data")
-    model_comparison_name = f"LCDM-vs-{alt_model_name}"
+    dataset_id = sne_data_df.attrs.get("dataset_id", "sne_data")
+    model_comparison_name = f"vs-{alt_model_name}"
     filename = generate_filename(
-        "sne-detailed-data",
-        dataset_name,
+        "sne-data",
+        dataset_id,
         "csv",
         model_name=model_comparison_name,
         timestamp=timestamp,
@@ -118,11 +118,11 @@ def save_bao_results_csv(
         ratio = diff / df_out["error"]
         df_out[f"chi2_contrib_{alt_model_name_safe}"] = ratio**2
 
-    dataset_name = bao_data_df.attrs.get("dataset_name_sanitized", "BAO_data")
-    model_comparison_name = f"LCDM-vs-{alt_model_name}"
+    dataset_id = bao_data_df.attrs.get("dataset_id", "bao_data")
+    model_comparison_name = f"vs-{alt_model_name}"
     filename = generate_filename(
-        "bao-detailed-data",
-        dataset_name,
+        "bao-data",
+        dataset_id,
         "csv",
         model_name=model_comparison_name,
         timestamp=timestamp,
@@ -234,11 +234,11 @@ def save_cmb_results_csv(
             ]
         ] = np.nan
 
-    dataset_name = cmb_data_df.attrs.get("dataset_name_sanitized", "CMB_data")
-    model_comparison_name = f"LCDM-vs-{alt_name_safe}"
+    dataset_id = cmb_data_df.attrs.get("dataset_id", "cmb_data")
+    model_comparison_name = f"vs-{alt_name_safe}"
     filename = generate_filename(
-        "cmb-detailed-data",
-        dataset_name,
+        "cmb-data",
+        dataset_id,
         "csv",
         model_name=model_comparison_name,
         timestamp=timestamp,

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -7,7 +7,7 @@ import logging
 import os
 
 from . import console_output as console
-from .utils import load_metadata_from_dir
+from .utils import check_dataset_id, load_metadata_from_dir
 
 # Each parser is registered via a decorator so that ``copernican.py`` can list
 # available data sources dynamically. The loaders below simply call the
@@ -192,6 +192,9 @@ def _discover_parsers():
                         )
                         entry["data_dir"] = src_dir
                         registry[dataset_name] = entry
+                        dataset_id = meta.get("dataset_id")
+                        if dataset_id:
+                            registry[dataset_id] = entry
                     # If the parser registered with an explicit name, simply
                     # update the description if metadata provides one.
                     else:
@@ -201,6 +204,9 @@ def _discover_parsers():
                                 "description",
                                 registry[dataset_name].get("description", ""),
                             )
+                            dataset_id = meta.get("dataset_id")
+                            if dataset_id:
+                                registry[dataset_id] = registry[dataset_name]
 
 
 # Discover parsers at import time so that functions like
@@ -252,14 +258,10 @@ def _log_dataset_info(df, data_type, logger):
     # DataFrame attributes.
     if df is None or df.empty:
         return
-    # Prefer the human-readable dataset name but fall back to the sanitized
-    # identifier when only that field is available.  Loaders attach both
-    # ``dataset_name`` (original string) and ``dataset_name_sanitized``
-    # (underscored variant).
-    name = df.attrs.get(
-        "dataset_name",
-        df.attrs.get("dataset_name_sanitized", ""),
-    )
+    # Prefer the human-readable dataset name but fall back to ``dataset_id``
+    # when only the identifier is available. Loaders attach both fields so
+    # that logs remain descriptive while filenames stay concise.
+    name = df.attrs.get("dataset_name", df.attrs.get("dataset_id", ""))
     logger.info(
         f"Loaded {data_type} dataset '{name}' with {len(df)} rows.",
     )
@@ -302,10 +304,13 @@ def load_sne_data(source_key=None, **kwargs):
             data_df.attrs["source_key"] = source_key
             dataset_name = data_df.attrs.get("dataset_name", source_key)
             data_df.attrs["dataset_name"] = dataset_name
-            data_df.attrs["dataset_name_sanitized"] = dataset_name.replace(
-                " ",
-                "_",
+            dataset_id = check_dataset_id(
+                data_df.attrs.get(
+                    "dataset_id",
+                    dataset_name.replace(" ", "_").lower(),
+                )
             )
+            data_df.attrs["dataset_id"] = dataset_id
             logger.info(
                 f"Successfully loaded {len(data_df)} SNe data points.",
             )
@@ -353,10 +358,13 @@ def load_bao_data(source_key=None, **kwargs):
             data_df.attrs["source_key"] = source_key
             dataset_name = data_df.attrs.get("dataset_name", source_key)
             data_df.attrs["dataset_name"] = dataset_name
-            data_df.attrs["dataset_name_sanitized"] = dataset_name.replace(
-                " ",
-                "_",
+            dataset_id = check_dataset_id(
+                data_df.attrs.get(
+                    "dataset_id",
+                    dataset_name.replace(" ", "_").lower(),
+                )
             )
+            data_df.attrs["dataset_id"] = dataset_id
             logger.info(
                 f"Successfully loaded {len(data_df)} BAO data points.",
             )
@@ -404,10 +412,13 @@ def load_cmb_data(source_key=None, **kwargs):
             data_df.attrs["source_key"] = source_key
             dataset_name = data_df.attrs.get("dataset_name", source_key)
             data_df.attrs["dataset_name"] = dataset_name
-            data_df.attrs["dataset_name_sanitized"] = dataset_name.replace(
-                " ",
-                "_",
+            dataset_id = check_dataset_id(
+                data_df.attrs.get(
+                    "dataset_id",
+                    dataset_name.replace(" ", "_").lower(),
+                )
             )
+            data_df.attrs["dataset_id"] = dataset_id
             logger.info(
                 f"Successfully loaded {len(data_df)} CMB data points.",
             )
@@ -463,10 +474,13 @@ def load_gw_data(source_key=None, **kwargs):
             data_df.attrs["source_key"] = source_key
             dataset_name = data_df.attrs.get("dataset_name", source_key)
             data_df.attrs["dataset_name"] = dataset_name
-            data_df.attrs["dataset_name_sanitized"] = dataset_name.replace(
-                " ",
-                "_",
+            dataset_id = check_dataset_id(
+                data_df.attrs.get(
+                    "dataset_id",
+                    dataset_name.replace(" ", "_").lower(),
+                )
             )
+            data_df.attrs["dataset_id"] = dataset_id
             logger.info(
                 f"Successfully loaded {len(data_df)} GW data points.",
             )
@@ -518,10 +532,13 @@ def load_siren_data(source_key=None, **kwargs):
             data_df.attrs["source_key"] = source_key
             dataset_name = data_df.attrs.get("dataset_name", source_key)
             data_df.attrs["dataset_name"] = dataset_name
-            data_df.attrs["dataset_name_sanitized"] = dataset_name.replace(
-                " ",
-                "_",
+            dataset_id = check_dataset_id(
+                data_df.attrs.get(
+                    "dataset_id",
+                    dataset_name.replace(" ", "_").lower(),
+                )
             )
+            data_df.attrs["dataset_id"] = dataset_id
             # fmt: off
             msg = (
                 f"Successfully loaded {len(data_df)} standard siren "

--- a/copernican_lib/plotter.py
+++ b/copernican_lib/plotter.py
@@ -100,9 +100,7 @@ def compose_footer(base_line: str, data_attrs: dict) -> list[tuple[str, bool]]:
         line breaks.
     """
 
-    dataset_name = data_attrs.get(
-        "dataset_name", data_attrs.get("dataset_name_sanitized", "")
-    )
+    dataset_name = data_attrs.get("dataset_name", "")
     # Escape characters that could break TeX-style formatting used for
     # bold text while preserving spaces in the displayed name.
     safe_name = (
@@ -267,7 +265,8 @@ def plot_hubble_diagram(
     """Generate and save a Hubble diagram and residuals plot."""
     ensure_dir_exists(plot_dir)
     logger = get_logger()
-    dataset_name = sne_data_df.attrs.get("dataset_name_sanitized", "SNe_data")
+    dataset_name = sne_data_df.attrs.get("dataset_name", "SNe data")
+    dataset_id = sne_data_df.attrs.get("dataset_id", "sne_data")
     logger.info(f"Generating Hubble Diagram for {dataset_name}...")
 
     _apply_common_style()
@@ -559,12 +558,13 @@ def plot_hubble_diagram(
         )
         y -= line_height
 
-    model_comparison_name = (
-        f"{lcdm_plugin.MODEL_NAME}-vs-" f"{alt_model_plugin.MODEL_NAME}"
+    alt_model_name = alt_model_plugin.MODEL_NAME.replace(" ", "_").replace(
+        ".", ""
     )
+    model_comparison_name = f"vs-{alt_model_name}"
     filename = generate_filename(
         "hubble-plot",
-        dataset_name,
+        dataset_id,
         "png",
         model_name=model_comparison_name,
         timestamp=timestamp,
@@ -591,7 +591,8 @@ def plot_bao_observables(
     """Generate and save a plot of BAO observables versus redshift."""
     ensure_dir_exists(plot_dir)
     logger = get_logger()
-    dataset_name = bao_data_df.attrs.get("dataset_name_sanitized", "BAO_data")
+    dataset_name = bao_data_df.attrs.get("dataset_name", "BAO data")
+    dataset_id = bao_data_df.attrs.get("dataset_id", "bao_data")
     logger.info(f"Generating BAO Plot for {dataset_name}...")
 
     _apply_common_style()
@@ -899,12 +900,13 @@ def plot_bao_observables(
         )
         y -= line_height
 
-    model_comparison_name = (
-        f"{lcdm_plugin.MODEL_NAME}-vs-" f"{alt_model_plugin.MODEL_NAME}"
+    alt_model_name = alt_model_plugin.MODEL_NAME.replace(" ", "_").replace(
+        ".", ""
     )
+    model_comparison_name = f"vs-{alt_model_name}"
     filename = generate_filename(
         "bao-plot",
-        dataset_name,
+        dataset_id,
         "png",
         model_name=model_comparison_name,
         timestamp=timestamp,
@@ -932,7 +934,8 @@ def plot_cmb_spectrum(
     """Generate and save a CMB power spectrum plot with residuals."""
     ensure_dir_exists(plot_dir)
     logger = get_logger()
-    dataset_name = cmb_data_df.attrs.get("dataset_name_sanitized", "CMB_data")
+    dataset_name = cmb_data_df.attrs.get("dataset_name", "CMB data")
+    dataset_id = cmb_data_df.attrs.get("dataset_id", "cmb_data")
     logger.info(f"Generating CMB Spectrum Plot for {dataset_name}...")
 
     _apply_common_style()
@@ -1260,12 +1263,13 @@ def plot_cmb_spectrum(
         )
         y -= line_height
 
-    model_comparison_name = (
-        f"{lcdm_plugin.MODEL_NAME}-vs-" f"{alt_model_plugin.MODEL_NAME}"
+    alt_model_name = alt_model_plugin.MODEL_NAME.replace(" ", "_").replace(
+        ".", ""
     )
+    model_comparison_name = f"vs-{alt_model_name}"
     filename = generate_filename(
         "cmb-plot",
-        dataset_name,
+        dataset_id,
         "png",
         model_name=model_comparison_name,
         timestamp=timestamp,

--- a/copernican_lib/utils.py
+++ b/copernican_lib/utils.py
@@ -22,45 +22,51 @@ def get_timestamp():
     return time.strftime("%Y%m%d_%H%M%S")
 
 
+def check_dataset_id(dataset_id: str) -> str:
+    """Return ``dataset_id`` stripped of forbidden characters.
+
+    The Copernican Suite expects ``dataset_id`` to be safe for file
+    paths. Any unexpected characters such as spaces or path separators are
+    dropped rather than replaced so that a slightly malformed identifier
+    cannot corrupt directory structures.
+    """
+
+    forbidden = set(' \\/:*?"<>|')
+    return "".join(ch for ch in dataset_id if ch not in forbidden)
+
+
 def generate_filename(
     file_type,
-    dataset_name,
+    dataset_id,
     ext,
     model_name="",
     timestamp=None,
 ):
-    """Generates a harmonized filename for all outputs.
+    """Generate a harmonized filename for all outputs.
 
     Parameters
     ----------
     file_type : str
         Short descriptor of the file's contents.
-    dataset_name : str
-        Human readable dataset identifier.
+    dataset_id : str
+        Identifier used in output filenames. It should already comply
+        with :func:`check_dataset_id` rules.
     ext : str
         File extension without the leading period.
     model_name : str, optional
-        Name of the cosmological model, used when comparing multiple models.
+        Name of the cosmological model, used when comparing multiple
+        models.
     timestamp : str, optional
-        Timestamp string applied to the filename. When ``None`` the current
-        timestamp is generated.
+        Timestamp string applied to the filename. When ``None`` the
+        current timestamp is generated.
     """
     sanitized_type = file_type.replace("_", "-").lower()
     sanitized_model = model_name.replace("_", "-").replace(".", "")
-    # Remove whitespace, file extensions and unsafe path characters so the
-    # resulting filename is portable across platforms.
-    sanitized_dataset = (
-        dataset_name.replace("_", "-")
-        .replace(" ", "")
-        .replace("/", "-")
-        .replace(".yml", "")
-        .replace(".yaml", "")
-        .replace(".dat", "")
-    )
+    checked_id = check_dataset_id(dataset_id)
     base_name = (
-        f"{sanitized_type}-{sanitized_model}-{sanitized_dataset}"
+        f"{sanitized_type}-{sanitized_model}-{checked_id}"
         if sanitized_model
-        else f"{sanitized_type}-{sanitized_dataset}"
+        else f"{sanitized_type}-{checked_id}"
     )
     ts = timestamp or get_timestamp()
     return f"{base_name}_{ts}.{ext}"

--- a/docs/bao_compound_dataset_format.md
+++ b/docs/bao_compound_dataset_format.md
@@ -29,6 +29,7 @@ data_points:
 Example `metadata_compound.yml`:
 ```yaml
 dataset_name: Compound BAO dataset
+dataset_id: compound_bao_set
 description: Compilation of BAO distance measurements without a covariance
   matrix
 citation: N/A
@@ -71,9 +72,9 @@ diagonal errors.
 All observable types use the naming convention `DV_over_rs`, `DM_over_rs` or
 `DH_over_rs` to indicate $D_V$, $D_M$ or $D_H$ divided by the sound horizon.
 The parser converts the YAML to a Pandas `DataFrame` and the data loader
-attaches the metadata to the `.attrs` attribute. In addition to the original
-`dataset_name`, a sanitized version `dataset_name_sanitized` replaces spaces
-with underscores for safe filenames. The same `metadata_*.yml` structure with
-`dataset_name`, `description`, `notes` and `citation` is used for **all**
+attaches the metadata to the `.attrs` attribute. In addition to the
+original `dataset_name`, a `dataset_id` is supplied for constructing
+output filenames. The same `metadata_*.yml` structure with `dataset_name`,
+`dataset_id`, `description`, `notes` and `citation` is used for **all**
 datasets so plot footers render the dataset name in bold, followed by its
 description, notes and a separate citation line.

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -22,15 +22,14 @@ progress datasets do not appear in interactive menus. When a dataset becomes
 usable simply rename the folder and supply a valid parser and metadata file.
 
 Every dataset folder also provides a `metadata_*.yml` describing the
-source. Fields such as `dataset_name`, `description`, `citation`, the full
-`author` list and accompanying BibTeX information (for example `title`,
-`volume`, `journal` and `DOI`) are read by
+source. Fields such as `dataset_name`, `dataset_id`, `description`,
+`citation`, the full `author` list and accompanying BibTeX information
+(for example `title`, `volume`, `journal` and `DOI`) are read by
 `copernican_lib/data_loaders.py` after the parser returns so individual
 parsers remain metadata-agnostic. Parsed DataFrames expose the same
-information on their `.attrs` property and include `dataset_name_sanitized`,
-where spaces are replaced by underscores for safe filenames. See
-`dataset_metadata.md` for a full description of these fields. The reference
-files remain read-only.
+information on their `.attrs` property, and `dataset_id` is used when
+constructing output filenames. See `dataset_metadata.md` for a full
+description of these fields. The reference files remain read-only.
 
 ## Supernovae Datasets
 

--- a/docs/dataset_metadata.md
+++ b/docs/dataset_metadata.md
@@ -1,12 +1,14 @@
 # Dataset Metadata Fields
 
 Each dataset folder contains a `metadata_*.yml` file that describes the
-source. All fields are optional except for `dataset_name` and
-`description`.
+source. All fields are optional except for `dataset_name`, `dataset_id`
+and `description`.
 
 - `dataset_name` -- Short human-readable identifier used in logs, plot
-  footers and CSV headers. Footers preserve the original spacing; a
-  sanitized variant is generated separately for filenames.
+  footers and CSV headers.
+- `dataset_id` -- Short identifier used in filenames. It must omit spaces
+  and forbidden characters: `/`, `\`, `:`, `*`, `?`, `"`, `<`, `>` and
+  `|`, yet still convey which dataset is referenced.
 - `description` -- Brief explanation of the dataset origin.
 - `citation` -- Formatted as "FirstAuthor et al. - J. Vol (Year) Pages - DOI:
   URL".
@@ -31,12 +33,11 @@ source. All fields are optional except for `dataset_name` and
 The metadata file is loaded automatically by the data loaders via
 `copernican_lib.utils.load_metadata_from_dir` after the parser returns and
 attached to the parsed `DataFrame` through the ``.attrs`` dictionary.
-Loaders store the original `dataset_name` along with a sanitized variant,
-`dataset_name_sanitized`, where spaces are replaced by underscores for safe
-filenames. Plot footers render the dataset name in bold followed by
-`: description notes` on the second line and the citation on a third
-line. Custom fields are preserved and can be used by new engines or
-analysis scripts.
+Loaders store both the human-readable `dataset_name` and the filename
+friendly `dataset_id`. Plot footers render the dataset name in bold,
+followed by `: description notes` on the second line and the citation on
+a third line. Custom fields are preserved and can be used by new engines
+or analysis scripts.
 
 ### Best Practices
 

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -406,8 +406,8 @@ def fit_sne_parameters(sne_data_df, model_plugin):
     logger = logging.getLogger()
     engine_interface.validate_plugin(model_plugin)
     dataset_name = sne_data_df.attrs.get(
-        "dataset_name_sanitized",
-        "UnknownSNeDataset",
+        "dataset_id",
+        "unknown_sne_dataset",
     )
     model_name_str = getattr(model_plugin, "MODEL_NAME", "UnknownModel")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -53,7 +53,7 @@ class FunctionalTestCase(unittest.TestCase):
 
     def test_engine_routines(self):
         """Run a smoke test across the main engine routines."""
-        sne_df = data_loaders.load_sne_data("JLA 2014")
+        sne_df = data_loaders.load_sne_data("jla_2014")
         self.assertIsNotNone(sne_df)
         sne_df = sne_df.head(3)
         if sne_df.attrs.get("covariance_matrix_inv") is not None:
@@ -93,7 +93,7 @@ class FunctionalTestCase(unittest.TestCase):
 
     def test_combined_fit(self):
         """Check that the combined fit pipeline returns finite χ² values."""
-        sne_df = data_loaders.load_sne_data("JLA 2014").head(2)
+        sne_df = data_loaders.load_sne_data("jla_2014").head(2)
         if sne_df.attrs.get("covariance_matrix_inv") is not None:
             attrs = sne_df.attrs
             attrs["covariance_matrix_inv"] = attrs["covariance_matrix_inv"][

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -18,7 +18,11 @@ class DataLoaderRegistryTestCase(unittest.TestCase):
         prev = data_loaders.SNE_PARSERS.copy()
         try:
             with tempfile.TemporaryDirectory() as tmp:
-                meta = {"dataset_name": "Dummy SNe", "description": "test set"}
+                meta = {
+                    "dataset_name": "Dummy SNe",
+                    "dataset_id": "dummy_sne",
+                    "description": "test set",
+                }
                 with open(
                     os.path.join(tmp, "metadata_dummy.yml"),
                     "w",
@@ -41,6 +45,7 @@ class DataLoaderRegistryTestCase(unittest.TestCase):
 
                 df = data_loaders.load_sne_data("Dummy SNe")
                 self.assertEqual(df.attrs["dataset_name"], "Dummy SNe")
+                self.assertEqual(df.attrs["dataset_id"], "dummy_sne")
                 self.assertEqual(len(df), 1)
         finally:
             data_loaders.SNE_PARSERS = prev


### PR DESCRIPTION
## Summary
- add dataset_id validation and use it for output file naming
- register dataset_id with data loaders and drop LCDM from comparison names
- document dataset_id field and update tests

## Testing
- `pre-commit run --files CHANGELOG.md copernican_lib/utils.py copernican_lib/csv_writer.py copernican_lib/data_loaders.py copernican_lib/plotter.py docs/bao_compound_dataset_format.md docs/data_overview.md docs/dataset_metadata.md engines/cosmo_engine_comb.py tests/test_data_loaders.py tests/test_core.py`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_689bd8a93260832fb060a9217d638f58