### PR TITLE
Bootstrap start scripts with automatic virtualenv setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ output/.DS_Store
 .vscode/
 /.vscode
 copernican_suite.egg-info
+.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
-## Unreleased
- - 2025-08-13: Added regression tests for BOSS DR12 BAO parsing and LCDM
-   chi-squared residuals (AI assistant)
+## Version 3.6.13
+- 2025-08-15: Start scripts now create and reuse a local virtual environment,
+  installing dependencies automatically (AI assistant)
+- 2025-08-13: Added regression tests for BOSS DR12 BAO parsing and LCDM
+  chi-squared residuals (AI assistant)
 
 - 2025-08-13: Use full BAO covariance when available and test coverage
   (AI assistant)

--- a/README.md
+++ b/README.md
@@ -82,13 +82,12 @@ parsers are discovered automatically under
    point temporary cache files are cleaned automatically.
 
 ## Quick Start
-1. Ensure Python 3.11 or later is available. Launch the suite via the `start`
-   script for your platform (`start.command`, `start.bat` or `start.sh`). The
-   program checks for required Python packages at startup and prints an
-install
-   command appropriate for your OS listing only the missing packages. Running
-with an older Python
-   version will print an error and exit immediately.
+1. Ensure Python 3.11 or later is available. Launch the suite with the `start`
+   script for your platform (`start.command`, `start.bat` or `start.sh`). Each
+   script creates a `.venv` directory, upgrades `pip` and installs the project
+   automatically. Missing interpreters trigger OS specific install hints.
+   Running with an older Python version prints an error and exits
+   immediately.
 2. Follow the interactive prompts to choose a model, preferred data sources
    and
    computation engine.
@@ -111,9 +110,9 @@ and exit code 1. Future engines may also depend on `numba` or GPU libraries.
 
 ## Building & Installation
 Windows users should open `start.bat`, macOS users should run `start.command`,
-and Linux users can execute `start.sh`.  These helpers simply run
-`python copernican.py` from the repository root. Make sure the required
-dependencies are installed using `pip` before launching the suite:
+and Linux users can execute `start.sh`. These helpers now create a local
+virtual environment, upgrade `pip` and install the package automatically
+before launching the suite. You can also start the program manually:
 
 ```bash
 python copernican.py

--- a/start.bat
+++ b/start.bat
@@ -1,9 +1,41 @@
-
 @echo off
+REM Start the Copernican Suite on Windows.
+REM
+REM The script locates a Python interpreter, sets up a virtual environment and
+REM re-executes itself inside that environment so later runs reuse it.
 
-REM Launch the Copernican Suite on Windows
-
+setlocal
 cd %~dp0
 
+if not "%VIRTUAL_ENV%"=="" goto run
+
+REM Locate python.exe or the py launcher.
+where python >NUL 2>NUL
+if %ERRORLEVEL%==0 (
+    set "PYTHON=python"
+) else (
+    where py >NUL 2>NUL
+    if %ERRORLEVEL%==0 (
+        set "PYTHON=py"
+    ) else (
+        echo Python is not installed.
+        echo Install it with "winget install -e --id Python.Python.3" ^
+or visit https://www.python.org/downloads/
+        exit /b 1
+    )
+)
+
+if not exist .venv (
+    %PYTHON% -m venv .venv
+)
+
+call .venv\Scripts\activate.bat
+%PYTHON% -m pip install --upgrade pip
+%PYTHON% -m pip install .
+
+call "%~f0" %*
+goto :eof
+
+:run
 python copernican.py %*
 

--- a/start.command
+++ b/start.command
@@ -1,11 +1,36 @@
 #!/bin/bash
+# Start the Copernican Suite on macOS.
+#
+# The script finds a Python 3 interpreter, prepares a virtual environment and
+# re-executes itself inside that environment so later runs reuse the cached
+# installation.
 
-# This script will launch the Copernican Suite.
-# Ensure the script runs from its own directory so copernican.py is found.
+set -e
 cd "$(dirname "$0")"
 
-# Run the Python script using the python3 interpreter.
-python3 copernican.py "$@"
+# Relaunch from inside the virtual environment when already activated.
+if [ -n "$VIRTUAL_ENV" ]; then
+    exec python copernican.py "$@"
+fi
 
-# The terminal window will remain open after the script finishes
-# so you can review the output. You can close it manually.
+# Locate Python 3 or print macOS specific install hints.
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON=python3
+else
+    echo "Python 3 is not installed." >&2
+    echo "Install it with 'brew install python'." >&2
+    echo "Get it at https://www.python.org/downloads/." >&2
+    exit 1
+fi
+
+# Build the environment when missing.
+if [ ! -d ".venv" ]; then
+    "$PYTHON" -m venv .venv
+fi
+
+# Activate, update pip, install the project and restart the script.
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install .
+exec "$0" "$@"
+

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,36 @@
 #!/bin/bash
-# Launch the Copernican Suite on Linux
+# Start the Copernican Suite on Unix-like systems.
+#
+# The script locates a Python 3 interpreter, creates a local virtual
+# environment if needed, installs the project and re-executes itself inside
+# that environment. Subsequent runs reuse the cached dependencies.
+
+set -e
 cd "$(dirname "$0")"
-exec python3 copernican.py "$@"
+
+# If we are already inside the virtual environment simply launch the suite.
+if [ -n "$VIRTUAL_ENV" ]; then
+    exec python copernican.py "$@"
+fi
+
+# Detect a usable Python 3 interpreter.
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON=python3
+else
+    echo "Python 3 is not installed." >&2
+    echo "Install it with 'sudo apt install python3' or" >&2
+    echo "'brew install python'." >&2
+    echo "Get it at https://www.python.org/downloads/." >&2
+    exit 1
+fi
+
+# Create the virtual environment on first run.
+if [ ! -d ".venv" ]; then
+    "$PYTHON" -m venv .venv
+fi
+
+# Activate the environment, upgrade pip, install the project and re-run.
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install .
+exec "$0" "$@"


### PR DESCRIPTION
## Summary
- ensure `start.sh`, `start.command`, and `start.bat` create and reuse a `.venv` before launching
- add `.venv/` to `.gitignore`
- document automatic environment setup in README and changelog

## Testing
- `pre-commit run --files start.sh start.command start.bat README.md CHANGELOG.md .gitignore`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_689ef1efde04832fb0c6283da0f04ff4