### PR TITLE
Ensure dependency check uses local venv and auto-installs packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,13 +78,13 @@ by the engines instead of being reimplemented inside each backend.
 
 ## 3. Dependency Installation
 `copernican.py` scans all project files for imported modules using Python's
-AST parser to avoid false positives from comments. If any required package is
-missing, the program prints an install command tailored to the current
-operating system and lists only the missing packages. Run that command
-manually to install or upgrade packages (already installed libraries will be
-skipped). This lightweight approach works across Windows, macOS and Linux
-while allowing new engines to introduce additional dependencies without
-manual updates to the documentation.
+AST parser to avoid false positives from comments. When launched through the
+`start.*` scripts the interpreter runs inside the repository's ``.venv``.
+If any required package is missing, the program installs it automatically with
+`pip` and verifies the import before continuing. Running outside ``.venv``
+prompts the user to restart via the appropriate launcher. This lightweight
+approach works across Windows, macOS and Linux while allowing new engines to
+introduce additional dependencies without manual updates to the documentation.
 To install the suite as a package, run `pip install .` at the repository root.
 Use `pip install -e .` if you intend to develop the code.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Version headers run newest to oldest, and within each version the newest
 entries come first):
 
 ## Version 3.6.13
+- 2025-08-15: Automatically install missing packages and enforce `.venv`
+  usage during dependency checks (AI assistant)
 - 2025-08-15: Start scripts now create and reuse a local virtual environment,
   installing dependencies automatically (AI assistant)
 - 2025-08-13: Added regression tests for BOSS DR12 BAO parsing and LCDM

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ simple command line interface. Results are saved as plots and CSV files in the
 `./output/` directory.
 Under the hood the program follows a clear pipeline:
 1. **Dependency Check** – `copernican.py` scans for required packages and
-   prints an install command tailored to your OS listing only the missing
-packages.
+   automatically installs any missing ones using `pip`, verifying each
+import before continuing.
 2. **Initialization** – the output directory is created and logging begins.
 3. **Configuration** – the user chooses a model and a computation engine
    from `./engines/`.  The default `cosmo_engine_comb.py` performs a
@@ -102,17 +102,19 @@ parsers are discovered automatically under
 This project requires **Python 3.11 or later** and relies on `numpy`, `scipy`,
 `matplotlib`,
 `pandas`, `sympy`, `jsonschema` and `camb==1.6.2`.
-If any packages are missing the program prints an OS-specific install command
-listing only those missing packages and exits so you can install them
-manually.
+If any packages are missing the program installs them automatically with
+`pip` and verifies the imports. The script must run inside the repository's
+`.venv`; otherwise it instructs you to launch via `start.*`.
 Running under an older Python version results in an immediate error
 and exit code 1. Future engines may also depend on `numba` or GPU libraries.
 
 ## Building & Installation
 Windows users should open `start.bat`, macOS users should run `start.command`,
-and Linux users can execute `start.sh`. These helpers now create a local
-virtual environment, upgrade `pip` and install the package automatically
-before launching the suite. You can also start the program manually:
+and Linux users can execute `start.sh`. These helpers create a local virtual
+environment, upgrade `pip` and install the package automatically before
+launching the suite. Running `copernican.py` outside this environment prompts
+you to use the appropriate start script. You can also start the program
+manually:
 
 ```bash
 python copernican.py
@@ -452,10 +454,8 @@ altering `MAJOR.MINOR`.
 
 ## 4. Workflow Overview
 
-1.  **Dependency Check**: `copernican.py` scans for missing packages and
-    prints an OS-specific install command containing only those packages if
-any
-are absent.
+1.  **Dependency Check**: `copernican.py` scans for missing packages,
+    installs them automatically with `pip` and verifies the environment.
 2.  **Optional Tests**: Run `copernican.py --run-tests` to execute the
     verbose functional test suite and verify that the LCDM model and data
     parsers work as expected. This flag performs unittest discovery over

--- a/copernican.py
+++ b/copernican.py
@@ -250,34 +250,29 @@ def _gather_required_packages():
     }
 
 
-def _print_install_instructions(missing: list[str]) -> None:
-    """Show platform-specific commands to install missing packages."""
-    # The messages here intentionally rely on plain ``pip`` so users on
-    # any platform can copy & paste them directly.  Additional hints for
-    # Homebrew, APT or pipx are printed when those tools are available
-    # to guide less experienced users.
-    pkgs = " ".join(sorted(set(missing)))
-    pip_cmd = f"{Path(sys.executable).name} -m pip install {pkgs}"
-    console.write("Please install them with:")
-    console.write(f"  {pip_cmd}")
-
-    sys_name = platform.system()
-    if sys_name == "Darwin" and shutil.which("brew"):
-        console.write(f"  brew install python && {pip_cmd}")
-    elif sys_name == "Linux":
-        if shutil.which("apt"):
-            console.write(f"  sudo apt install python3-pip && {pip_cmd}")
-        elif shutil.which("apt-get"):
-            console.write(f"  sudo apt-get install python3-pip && {pip_cmd}")
-    if shutil.which("pipx"):
-        console.write(f"  pipx install {pkgs}")
-
-
 def check_dependencies():
-    """Ensure required packages are installed and activate venv if needed."""
+    """Ensure required packages are installed inside the local ``.venv``.
+
+    The suite bundles a virtual environment under ``.venv`` that is activated
+    by the ``start.*`` launchers.  This check confirms the interpreter is
+    running from that environment before installing any missing packages.
+    Required packages are installed automatically via ``pip`` and re-imported
+    to verify success so the workflow can proceed without manual steps.
+    """
     console.write("--- Running System Dependency Check ---")
+
+    if Path(sys.prefix).resolve().name != ".venv":
+        console.write(
+            (
+                "ERROR: The Copernican Suite must run inside the local "
+                "'.venv'. Launch the appropriate start script for your OS."
+            ),
+            error=True,
+        )
+        exit_clean(1)
+
     required = sorted(_gather_required_packages())
-    missing = []
+    missing: list[str] = []
     for pkg in required:
         try:
             if importlib.util.find_spec(pkg) is None:
@@ -291,9 +286,38 @@ def check_dependencies():
                 missing.append(pkg)
 
     if missing:
-        console.write(f"Missing packages detected: {', '.join(missing)}")
-        _print_install_instructions(missing)
-        exit_clean(1)
+        console.write(
+            f"Missing packages detected: {', '.join(missing)}"
+        )
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", *missing],
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            console.write(
+                "Automatic installation failed. Please check the log and "
+                "install the required packages manually.",
+                error=True,
+            )
+            exit_clean(1)
+
+        failed = []
+        for pkg in missing:
+            try:
+                importlib.import_module(pkg)
+            except Exception:
+                failed.append(pkg)
+        if failed:
+            console.write(
+                (
+                    "Still missing packages after installation: "
+                    f"{', '.join(failed)}"
+                ),
+                error=True,
+            )
+            exit_clean(1)
+        console.write("✅ Packages installed successfully. Continuing...\n")
     else:
         console.write("✅ System Dependency Check Passed. Continuing...\n")
 


### PR DESCRIPTION
## Summary
- Require the Copernican Suite to run inside the bundled `.venv` and guide users to `start.*` scripts if not
- Automatically install missing dependencies with pip and re-import them to confirm success
- Document new dependency behavior in README and AGENTS and log the change in the changelog

## Testing
- `pre-commit run --files copernican.py README.md AGENTS.md CHANGELOG.md`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_689ef517a17c832fb10a4d26109ed188