### PR TITLE
docs: document start script and virtualenv workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Version headers run newest to oldest, and within each version the newest
 entries come first):
 
 ## Version 3.6.13
+- 2025-08-15: Replaced PyInstaller references with start script and `.venv`
+  instructions in documentation (AI assistant)
 - 2025-08-15: Automatically install missing packages and enforce `.venv`
   usage during dependency checks (AI assistant)
 - 2025-08-15: Start scripts now create and reuse a local virtual environment,

--- a/PLAN.md
+++ b/PLAN.md
@@ -31,33 +31,19 @@ when a critical fix warrants a new public release.
   to maintain PEP8 and PEP257 compliance. Failures should stop the pipeline
 and
   signal that the commit needs fixes before merging.
-- After tests and linting, each job will build a platform-specific executable
-  and upload it as an artifact for manual download. These artifacts are
-**not**
-  automatically packaged into a release but serve for iterative testing.
+- After tests and linting, each job uses the platform's start script to verify
+  the automatic virtual-environment workflow. Any logs are uploaded as
+  artifacts for manual inspection.
 - Pre-commit hooks (Black, Isort, Ruff or Flake8) will ensure consistent
   formatting before changes are committed. CI will run `pre-commit run --all-
   files` to guarantee uniform style across platforms.
 
-## Packaging and Executables
-- Use PyInstaller to bundle the interpreter, required libraries and source
-  files into stand-alone executables:
-  - **Windows:** `.exe` built on Windows 10, ensuring compatibility with
-    Windows 10 and later.
-  - **macOS:** an unsigned universal2 `.app` containing both Intel (x86_64)
-    and
-    Apple Silicon (arm64) slices. This build will run on macOS 15.0.1 and
-    later; the Intel slice becomes optional if Apple eventually drops Intel
-    support.
-  - **Linux:** a self-contained binary for Debian-based distributions. A
-    future
-    step may wrap this binary in a `.deb` package for easier installation.
-- The source code will remain bundled alongside the executables to allow
-  reference and derivative projects under the license terms.
-- For now, macOS builds are left unsigned. When desired, an Apple Developer ID
-  certificate will be used to sign and notarize each build. A qualified
-  electronic signature (QES) is insufficient for Gatekeeper; signing must be
-  repeated for every newly produced binary.
+## Packaging and Launchers
+- Distribution relies on the `start.*` scripts which bootstrap a local `.venv`
+  and install dependencies automatically.
+- Users need only a system-wide Python 3.11+ installation.
+- CI verifies the launchers on Windows, macOS and Linux.
+- No standalone executables are planned.
 
 ## Version Management
 - The runtime version is derived from package metadata using
@@ -91,9 +77,8 @@ builds will report that version automatically.
 
 ## Future Directions
 - Introduce a cross-platform GUI built with a toolkit such as Qt/PySide or
-  another suitable framework. The same CI pipeline and PyInstaller process
-will
-  bundle GUI builds when the interface stabilizes.
+  another suitable framework. The same CI pipeline and start scripts will
+  launch GUI builds using the `.venv` workflow when the interface stabilizes.
 - Explore macOS notarization and automated code signing once an Apple
   Developer
   ID certificate is available and the release process is more formalized.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.6.12
+**Version:** 3.6.13
 **Last Updated:** 2025-08-11
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -99,9 +99,10 @@ parsers are discovered automatically under
    completes.
 
 ## Dependencies
-This project requires **Python 3.11 or later** and relies on `numpy`, `scipy`,
-`matplotlib`,
-`pandas`, `sympy`, `jsonschema` and `camb==1.6.2`.
+Only a system-wide Python 3.11+ installation is required. The start scripts
+manage all other dependencies inside the `.venv`. This project relies on
+`numpy`, `scipy`, `matplotlib`, `pandas`, `sympy`, `jsonschema` and
+`camb==1.6.2`.
 If any packages are missing the program installs them automatically with
 `pip` and verifies the imports. The script must run inside the repository's
 `.venv`; otherwise it instructs you to launch via `start.*`.
@@ -133,13 +134,10 @@ This folder contains package metadata such as the version number, dependency
 list and entry points used by Python's packaging tools. It is generated
 automatically and does not need to be tracked in version control.
 
-Standalone executables can be created with the PyInstaller spec files included
-at the repository root. macOS builds **must** target `universal2` so the
-bundle
-runs on both Intel and Apple Silicon. See
-[docs/packaging.md](docs/packaging.md) for platform specific build commands
-and
-macOS signing instructions.
+The suite no longer ships standalone binaries. Launch with `start.bat`,
+`start.command` or `start.sh` to create a local `.venv` and install all
+dependencies automatically. Only a system-wide Python 3.11+ installation is
+required. See [docs/packaging.md](docs/packaging.md) for launcher details.
 
 
 ## Directory Layout

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,46 +1,22 @@
 # Packaging Guide
 
-This guide describes how to build standalone executables for the Copernican
-Suite using PyInstaller. Each provided spec file bundles the project source
-code so the resulting binary can run without an existing checkout of the
-repository or a pre-installed copy of Python.
+Standalone executables are no longer produced. The suite runs directly
+from source using platform launchers:
 
-Builds should target Python 3.11 or later and include `camb==1.6.2` to match
-the suite's runtime requirements.
+- `start.bat` on Windows
+- `start.command` on macOS
+- `start.sh` on Linux
 
-## Windows `.exe`
-1. Install PyInstaller: `pip install pyinstaller`.
-2. Run `pyinstaller copernican_win.spec`.
-3. The `dist/copernican.exe` file contains the suite and all bundled sources.
+Each script creates or reuses a local `.venv`, upgrades `pip` and installs
+all required packages automatically. Only a system-wide Python 3.11+
+installation is needed. Running `copernican.py` outside the virtual
+environment prompts you to relaunch with the appropriate script.
 
-## macOS universal2 `.app`
-The macOS build **must** target `universal2` so the bundle runs on Intel and
-Apple Silicon. Install the universal2 Python distribution from python.org to
-ensure all compiled dependencies include both architectures.
-
-1. Install the python.org universal2 build of Python and PyInstaller.
-2. Run `pyinstaller copernican_macos.spec`.
-3. The `dist/Copernican.app` bundle supports both Intel and Apple Silicon.
-
-### Signing and notarizing
-Once you have an Apple Developer ID, the bundle can be signed and notarized:
+To install the suite as a package, run:
 
 ```bash
-codesign --deep --force --options runtime \
-  --sign "Developer ID Application: YOUR NAME (TEAMID)" dist/Copernican.app
-hdiutil create -fs HFS+ -volname Copernican \
-  -srcfolder dist/Copernican.app dist/copernican.dmg
-xcrun notarytool submit dist/copernican.dmg --apple-id YOUR_ID@example.com \
-  --team-id TEAMID --password YOUR_APP_SPECIFIC_PASSWORD --wait
-xcrun stapler staple dist/Copernican.app
+pip install .
 ```
 
-These steps sign the application, submit it to Apple for notarization and
-staple
-the approval ticket so the app runs without security prompts.
+Use `pip install -e .` for development.
 
-## Linux self-contained binary
-1. Install PyInstaller: `pip install pyinstaller`.
-2. Run `pyinstaller copernican_linux.spec`.
-3. The `dist/copernican` file is a one-file binary containing the full project
-   source.


### PR DESCRIPTION
## Summary
- remove PyInstaller instructions from README, PLAN and packaging guide
- explain start.* launchers and automatic `.venv` dependency handling
- note documentation updates in CHANGELOG

## Testing
- `pre-commit run --files README.md docs/packaging.md PLAN.md CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_689ef8c205f8832f9d6f79b009746d45