### PR TITLE
Update packaging guide with Python setup and troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Version headers run newest to oldest, and within each version the newest
 entries come first):
 
 ## Version 3.6.13
+- 2025-08-15: Expanded packaging guide with Python 3.11 install and build docs
+  (AI assistant)
 - 2025-08-15: Archived PyInstaller spec files and streamlined CI to use a
   cached `.venv` for linting and tests (AI assistant)
 - 2025-08-15: Replaced PyInstaller references with start script and `.venv`

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,22 +1,52 @@
 # Packaging Guide
 
-Standalone executables are no longer produced. The suite runs directly
-from source using platform launchers:
+This document explains how to prepare the suite for development or packaging.
+
+## Install Python 3.11+
+
+### Windows
+1. Download the Python 3.11 installer from https://www.python.org.
+2. Enable "Add python.exe to PATH" during installation.
+3. Open a new Command Prompt and run `python --version` to verify.
+
+### macOS
+1. Install Homebrew from https://brew.sh if it is not already present.
+2. Run `brew install python@3.11`.
+3. Verify the interpreter with `python3.11 --version`.
+
+### Linux
+1. Use your package manager. For Debian or Ubuntu run  
+   `sudo apt install python3.11 python3.11-venv`.
+2. Confirm the install with `python3.11 --version`.
+
+## Bootstrap the virtual environment
+
+Run the launcher in the project root:
 
 - `start.bat` on Windows
 - `start.command` on macOS
 - `start.sh` on Linux
 
-Each script creates or reuses a local `.venv`, upgrades `pip` and installs
-all required packages automatically. Only a system-wide Python 3.11+
-installation is needed. Running `copernican.py` outside the virtual
-environment prompts you to relaunch with the appropriate script.
+The script creates or reuses `.venv`, upgrades `pip` and installs packages.
+Re-run it after pulling updates to refresh the environment.
 
-To install the suite as a package, run:
+## Build optional distributions
+
+Inside `.venv` run:
 
 ```bash
-pip install .
+pip build .
 ```
 
-Use `pip install -e .` for development.
+The command writes source archives and wheels to the `dist/` directory.
 
+## Troubleshooting
+
+- **No module named pip**: run `python -m ensurepip --upgrade` and relaunch
+  launcher.
+- **Packages not updating**: run `pip install -U pip` followed by
+  `pip install -U -r requirements.txt`.
+- **Permission denied**: avoid `sudo pip`; use a writable directory or the
+  provided `.venv`.
+- **Virtual environment missing**: ensure a launcher was used or activate with
+  `source .venv/bin/activate` (`.venv\\Scripts\\activate` on Windows).


### PR DESCRIPTION
## Summary
- Outline Python 3.11 installation on Windows, macOS, and Linux.
- Explain using start scripts to create `.venv` and install dependencies.
- Add optional `pip build` instructions and venv/pip troubleshooting tips.

## Testing
- `python -m unittest discover`
- `pre-commit run --files docs/packaging.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_689f026eb94c832f9e85ce7b3c2c7612