### PR TITLE
Enforce Python 3.11 requirement in start script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.14
+- 2025-08-17: start.sh enforces Python 3.11+ and prints OS install hints
+  (AI assistant)
+
 ## Version 3.6.13
 - 2025-08-16: Expanded README and in-source docstrings; broadened
   documentation across `docs/` (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.6.13
-**Last Updated:** 2025-08-16
+**Version:** 3.6.14
+**Last Updated:** 2025-08-17
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
@@ -83,12 +83,13 @@ parsers are discovered automatically under
    point temporary cache files are cleaned automatically.
 
 ## Quick Start
-1. Ensure Python 3.11 or later is available. Launch the suite with the `start`
-   script for your platform (`start.command`, `start.bat` or `start.sh`). Each
-   script creates a `.venv` directory, upgrades `pip` and installs the project
-   automatically. Missing interpreters trigger OS specific install hints.
-   Running with an older Python version prints an error and exits
-   immediately.
+1. Ensure Python 3.11 or later is available. Launch the suite with the
+   `start` script for your platform (`start.command`, `start.bat` or
+   `start.sh`). Each script creates a `.venv` directory, upgrades `pip` and
+   installs the project automatically. Missing or outdated interpreters
+   print OS specific install tips such as `sudo apt install python3.11
+   python3.11-venv` on Debian or `brew install python@3.11` on macOS before
+   exiting.
 2. Follow the interactive prompts to choose a model, preferred data sources
    and
    computation engine.

--- a/start.sh
+++ b/start.sh
@@ -13,14 +13,27 @@ if [ -n "$VIRTUAL_ENV" ]; then
     exec python copernican.py "$@"
 fi
 
-# Detect a usable Python 3 interpreter.
+## Detect a usable Python 3.11+ interpreter.
 if command -v python3 >/dev/null 2>&1; then
     PYTHON=python3
 else
-    echo "Python 3 is not installed." >&2
-    echo "Install it with 'sudo apt install python3' or" >&2
-    echo "'brew install python'." >&2
-    echo "Get it at https://www.python.org/downloads/." >&2
+    echo "Python 3.11 is not installed." >&2
+    if [ "$(uname)" = "Darwin" ]; then
+        echo "Install it with 'brew install python@3.11'." >&2
+    else
+        echo "Install with 'sudo apt install python3.11 python3.11-venv'." >&2
+    fi
+    exit 1
+fi
+
+# Verify interpreter version.
+if ! "$PYTHON" -c "import sys; exit(not (sys.version_info >= (3,11)))"; then
+    echo "Python 3.11 or newer is required." >&2
+    if [ "$(uname)" = "Darwin" ]; then
+        echo "Install it with 'brew install python@3.11'." >&2
+    else
+        echo "Install with 'sudo apt install python3.11 python3.11-venv'." >&2
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- ensure `start.sh` checks for Python 3.11+ and advises how to install it on macOS or Debian/Ubuntu when missing
- document new interpreter check and bump version to 3.6.14
- record the start script change in the changelog

## Testing
- `pre-commit run --files start.sh README.md CHANGELOG.md`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68a23a6edf58832fb4d670f5b5400bcb