### PR TITLE
Ensure start scripts require Python 3.11+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.15
+- 2025-08-18: start.command and start.bat check for Python 3.11+ and show
+  install hints before creating the virtual environment (AI assistant)
+
 ## Version 3.6.14
 - 2025-08-17: start.sh enforces Python 3.11+ and prints OS install hints
   (AI assistant)

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ parsers are discovered automatically under
    `start.sh`). Each script creates a `.venv` directory, upgrades `pip` and
    installs the project automatically. Missing or outdated interpreters
    print OS specific install tips such as `sudo apt install python3.11
-   python3.11-venv` on Debian or `brew install python@3.11` on macOS before
-   exiting.
+   python3.11-venv` on Debian, `brew install python@3.11` on macOS or
+   `winget install -e --id Python.Python.3.11` on Windows before exiting.
 2. Follow the interactive prompts to choose a model, preferred data sources
    and
    computation engine.

--- a/start.bat
+++ b/start.bat
@@ -18,11 +18,20 @@ if %ERRORLEVEL%==0 (
     if %ERRORLEVEL%==0 (
         set "PYTHON=py"
     ) else (
-        echo Python is not installed.
-        echo Install it with "winget install -e --id Python.Python.3" ^
+        echo Python 3.11 is not installed.
+        echo Install it with "winget install -e --id Python.Python.3.11" ^
 or visit https://www.python.org/downloads/
         exit /b 1
     )
+)
+
+REM Verify interpreter version.
+%PYTHON% -c "import sys; exit(not (sys.version_info >= (3,11)))"
+if errorlevel 1 (
+    echo Python 3.11 or newer is required.
+    echo Install it with "winget install -e --id Python.Python.3.11" ^
+or visit https://www.python.org/downloads/
+    exit /b 1
 )
 
 if not exist .venv (

--- a/start.command
+++ b/start.command
@@ -13,12 +13,20 @@ if [ -n "$VIRTUAL_ENV" ]; then
     exec python copernican.py "$@"
 fi
 
-# Locate Python 3 or print macOS specific install hints.
+## Detect a usable Python 3.11+ interpreter.
 if command -v python3 >/dev/null 2>&1; then
     PYTHON=python3
 else
-    echo "Python 3 is not installed." >&2
-    echo "Install it with 'brew install python'." >&2
+    echo "Python 3.11 is not installed." >&2
+    echo "Install it with 'brew install python@3.11'." >&2
+    echo "Get it at https://www.python.org/downloads/." >&2
+    exit 1
+fi
+
+# Verify interpreter version.
+if ! "$PYTHON" -c "import sys; exit(not (sys.version_info >= (3,11)))"; then
+    echo "Python 3.11 or newer is required." >&2
+    echo "Install it with 'brew install python@3.11'." >&2
     echo "Get it at https://www.python.org/downloads/." >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- verify Python 3.11+ in `start.command` and `start.bat` before creating the virtual environment
- document Windows install hint alongside macOS and Linux
- log addition in `CHANGELOG.md`

## Testing
- `pre-commit run --files CHANGELOG.md README.md start.bat start.command`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68a2bc26e4b8832f861bbc88f774971f