### PR TITLE
Parse Python version before creating venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.16
+- 2025-08-18: Parse interpreter '--version' in start scripts and use
+  'py -3.11' for virtual environments (AI assistant)
+
 ## Version 3.6.15
 - 2025-08-18: start.command and start.bat check for Python 3.11+ and show
   install hints before creating the virtual environment (AI assistant)

--- a/start.bat
+++ b/start.bat
@@ -13,10 +13,12 @@ REM Locate python.exe or the py launcher.
 where python >NUL 2>NUL
 if %ERRORLEVEL%==0 (
     set "PYTHON=python"
+    set "PYTHON_CMD=python"
 ) else (
     where py >NUL 2>NUL
     if %ERRORLEVEL%==0 (
         set "PYTHON=py"
+        set "PYTHON_CMD=py -3.11"
     ) else (
         echo Python 3.11 is not installed.
         echo Install it with "winget install -e --id Python.Python.3.11" ^
@@ -25,20 +27,23 @@ or visit https://www.python.org/downloads/
     )
 )
 
-REM Verify interpreter version.
-%PYTHON% -c "import sys; exit(not (sys.version_info >= (3,11)))"
-if errorlevel 1 (
-    echo Python 3.11 or newer is required.
-    echo Install it with "winget install -e --id Python.Python.3.11" ^
-or visit https://www.python.org/downloads/
-    exit /b 1
+REM Verify interpreter version by parsing '--version' output.
+for /f "tokens=2 delims= " %%v in ('%PYTHON_CMD% --version 2^>NUL') do ^
+    set "PYVERSION=%%v"
+if not defined PYVERSION goto needpython
+for /f "tokens=1-2 delims=." %%a in ("%PYVERSION%") do (
+    set "MAJOR=%%a"
+    set "MINOR=%%b"
 )
+if %MAJOR% LSS 3 goto needpython
+if %MAJOR%==3 if %MINOR% LSS 11 goto needpython
 
 if not exist .venv (
-    %PYTHON% -m venv .venv
+    %PYTHON_CMD% -m venv .venv
 )
 
 call .venv\Scripts\activate.bat
+set PYTHON=python
 %PYTHON% -m pip install --upgrade pip
 %PYTHON% -m pip install .
 
@@ -47,4 +52,10 @@ goto :eof
 
 :run
 python copernican.py %*
+
+:needpython
+echo Python 3.11 or newer is required.
+echo Install it with "winget install -e --id Python.Python.3.11" ^
+or visit https://www.python.org/downloads/
+exit /b 1
 

--- a/start.command
+++ b/start.command
@@ -23,8 +23,13 @@ else
     exit 1
 fi
 
-# Verify interpreter version.
-if ! "$PYTHON" -c "import sys; exit(not (sys.version_info >= (3,11)))"; then
+# Verify interpreter version by parsing '--version' output.
+PY_VERSION="$($PYTHON --version 2>&1 | awk '{print $2}')"
+PY_MAJOR="${PY_VERSION%%.*}"
+PY_MINOR="${PY_VERSION#*.}"
+PY_MINOR="${PY_MINOR%%.*}"
+if [ "$PY_MAJOR" -lt 3 ] || { [ "$PY_MAJOR" -eq 3 ] && \
+    [ "$PY_MINOR" -lt 11 ]; }; then
     echo "Python 3.11 or newer is required." >&2
     echo "Install it with 'brew install python@3.11'." >&2
     echo "Get it at https://www.python.org/downloads/." >&2

--- a/start.sh
+++ b/start.sh
@@ -26,8 +26,13 @@ else
     exit 1
 fi
 
-# Verify interpreter version.
-if ! "$PYTHON" -c "import sys; exit(not (sys.version_info >= (3,11)))"; then
+# Verify interpreter version by parsing '--version' output.
+PY_VERSION="$($PYTHON --version 2>&1 | awk '{print $2}')"
+PY_MAJOR="${PY_VERSION%%.*}"
+PY_MINOR="${PY_VERSION#*.}"
+PY_MINOR="${PY_MINOR%%.*}"
+if [ "$PY_MAJOR" -lt 3 ] || { [ "$PY_MAJOR" -eq 3 ] && \
+    [ "$PY_MINOR" -lt 11 ]; }; then
     echo "Python 3.11 or newer is required." >&2
     if [ "$(uname)" = "Darwin" ]; then
         echo "Install it with 'brew install python@3.11'." >&2


### PR DESCRIPTION
## Summary
- validate interpreter by parsing `--version` output in start scripts
- on Windows, use `py -3.11` for both version checks and virtualenv creation
- log change in the changelog

## Testing
- `pre-commit run --files start.sh start.command start.bat CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68a2e49318a4832fa0f5a21a830e8b7d