### PR TITLE
Document launcher Python 3.11 checks and startup flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,13 +78,16 @@ by the engines instead of being reimplemented inside each backend.
 
 ## 3. Dependency Installation
 `copernican.py` scans all project files for imported modules using Python's
-AST parser to avoid false positives from comments. When launched through the
-`start.*` scripts the interpreter runs inside the repository's ``.venv``.
-If any required package is missing, the program installs it automatically with
-`pip` and verifies the import before continuing. Running outside ``.venv``
-prompts the user to restart via the appropriate launcher. This lightweight
-approach works across Windows, macOS and Linux while allowing new engines to
-introduce additional dependencies without manual updates to the documentation.
+AST parser to avoid false positives from comments. The `start.*` launchers
+verify Python 3.11 or later before creating ``.venv``. If the interpreter is
+missing or outdated they print platform-specific installation commands and
+exit. Once the requirement is met the scripts run inside the repository's
+``.venv``. If any required package is missing, the program installs it
+automatically with `pip` and verifies the import before continuing. Running
+outside ``.venv`` prompts the user to restart via the appropriate launcher.
+This lightweight approach works across Windows, macOS and Linux while allowing
+new engines to introduce additional dependencies without manual updates to the
+documentation.
 To install the suite as a package, run `pip install .` at the repository root.
 Use `pip install -e .` if you intend to develop the code.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.17
+- 2025-08-18: Document launcher enforcement of Python 3.11+ with automatic
+  `.venv` setup and OS install hints (AI assistant)
+
 ## Version 3.6.16
 - 2025-08-18: Parse interpreter '--version' in start scripts and use
   'py -3.11' for virtual environments (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.6.14
-**Last Updated:** 2025-08-17
+**Version:** 3.6.17
+**Last Updated:** 2025-08-18
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
@@ -83,13 +83,13 @@ parsers are discovered automatically under
    point temporary cache files are cleaned automatically.
 
 ## Quick Start
-1. Ensure Python 3.11 or later is available. Launch the suite with the
-   `start` script for your platform (`start.command`, `start.bat` or
-   `start.sh`). Each script creates a `.venv` directory, upgrades `pip` and
-   installs the project automatically. Missing or outdated interpreters
-   print OS specific install tips such as `sudo apt install python3.11
-   python3.11-venv` on Debian, `brew install python@3.11` on macOS or
-   `winget install -e --id Python.Python.3.11` on Windows before exiting.
+1. Run the platform-specific `start` script (`start.command`, `start.bat`
+   or `start.sh`). The launcher verifies Python 3.11+ before creating a
+   `.venv`, upgrading `pip` and installing the project automatically. If
+   the interpreter is missing or too old it prints install tips such as
+   `sudo apt install python3.11 python3.11-venv` on Debian, `brew install
+   python@3.11` on macOS or `winget install -e --id Python.Python.3.11`
+   on Windows before exiting.
 2. Follow the interactive prompts to choose a model, preferred data sources
    and
    computation engine.
@@ -101,15 +101,18 @@ parsers are discovered automatically under
    completes.
 
 ## Dependencies
-Only a system-wide Python 3.11+ installation is required. The start scripts
-manage all other dependencies inside the `.venv`. This project relies on
-`numpy`, `scipy`, `matplotlib`, `pandas`, `sympy`, `jsonschema` and
-`camb==1.6.2`.
+Only a system-wide Python 3.11+ installation is required. The `start.*`
+launchers check the interpreter version, create `.venv` automatically and
+install dependencies. If Python is missing or outdated they print
+platform-specific commands like `sudo apt install python3.11
+python3.11-venv` on Debian, `brew install python@3.11` on macOS or
+`winget install -e --id Python.Python.3.11` on Windows before exiting.
+Inside the virtual environment this project relies on `numpy`, `scipy`,
+`matplotlib`, `pandas`, `sympy`, `jsonschema` and `camb==1.6.2`.
 If any packages are missing the program installs them automatically with
-`pip` and verifies the imports. The script must run inside the repository's
-`.venv`; otherwise it instructs you to launch via `start.*`.
-Running under an older Python version results in an immediate error
-and exit code 1. Future engines may also depend on `numba` or GPU libraries.
+`pip` and verifies the imports. Running outside `.venv` instructs you to
+launch via `start.*`. Future engines may also depend on `numba` or GPU
+libraries.
 
 ## Building & Installation
 Windows users should open `start.bat`, macOS users should run `start.command`,

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -4,20 +4,15 @@ This document explains how to prepare the suite for development or packaging.
 
 ## Install Python 3.11+
 
-### Windows
-1. Download the Python 3.11 installer from https://www.python.org.
-2. Enable "Add python.exe to PATH" during installation.
-3. Open a new Command Prompt and run `python --version` to verify.
+The `start.*` launchers verify Python 3.11+ before bootstrapping the suite.
+If the interpreter is missing or outdated they display one of the following
+commands and exit:
 
-### macOS
-1. Install Homebrew from https://brew.sh if it is not already present.
-2. Run `brew install python@3.11`.
-3. Verify the interpreter with `python3.11 --version`.
+- **Debian/Ubuntu**: `sudo apt install python3.11 python3.11-venv`
+- **macOS**: `brew install python@3.11`
+- **Windows**: `winget install -e --id Python.Python.3.11`
 
-### Linux
-1. Use your package manager. For Debian or Ubuntu run  
-   `sudo apt install python3.11 python3.11-venv`.
-2. Confirm the install with `python3.11 --version`.
+Run the command for your platform, then re-run the launcher.
 
 ## Bootstrap the virtual environment
 
@@ -27,7 +22,8 @@ Run the launcher in the project root:
 - `start.command` on macOS
 - `start.sh` on Linux
 
-The script creates or reuses `.venv`, upgrades `pip` and installs packages.
+The script verifies Python 3.11+, then creates or reuses `.venv`, upgrades
+`pip` and installs packages.
 Re-run it after pulling updates to refresh the environment.
 
 ## Build optional distributions


### PR DESCRIPTION
## Summary
- Clarify in README that `start.*` launchers verify Python 3.11+, create `.venv`, and display OS-specific install commands when Python is missing.
- Expand packaging guide to cover launcher version checks and consolidate Python 3.11 installation commands across platforms.
- Note in AGENTS.md that launchers enforce Python 3.11 before running inside `.venv`.
- Log the new Python 3.11 enforcement and startup workflow in CHANGELOG.

## Testing
- `pre-commit run --files README.md docs/packaging.md AGENTS.md CHANGELOG.md`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68a3692519a8832fae6fb6b7b53c7db9