### PR TITLE
Capture absolute path in macOS launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.18
+- 2025-08-18: start.command resolves absolute path; README notes macOS should
+  run `./start.command` (AI assistant)
+
 ## Version 3.6.17
 - 2025-08-18: Document launcher enforcement of Python 3.11+ with automatic
   `.venv` setup and OS install hints (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.6.17
+**Version:** 3.6.18
 **Last Updated:** 2025-08-18
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -83,13 +83,14 @@ parsers are discovered automatically under
    point temporary cache files are cleaned automatically.
 
 ## Quick Start
-1. Run the platform-specific `start` script (`start.command`, `start.bat`
-   or `start.sh`). The launcher verifies Python 3.11+ before creating a
-   `.venv`, upgrading `pip` and installing the project automatically. If
-   the interpreter is missing or too old it prints install tips such as
-   `sudo apt install python3.11 python3.11-venv` on Debian, `brew install
-   python@3.11` on macOS or `winget install -e --id Python.Python.3.11`
-   on Windows before exiting.
+1. Run the platform-specific `start` script. macOS users should run
+   `./start.command`, Windows users open `start.bat`, and Linux users can
+   execute `./start.sh`. The launcher verifies Python 3.11+ before
+   creating a `.venv`, upgrading `pip` and installing the project
+   automatically. If the interpreter is missing or too old it prints
+   install tips such as `sudo apt install python3.11 python3.11-venv` on
+   Debian, `brew install python@3.11` on macOS or `winget install -e --id
+   Python.Python.3.11` on Windows before exiting.
 2. Follow the interactive prompts to choose a model, preferred data sources
    and
    computation engine.
@@ -115,12 +116,12 @@ launch via `start.*`. Future engines may also depend on `numba` or GPU
 libraries.
 
 ## Building & Installation
-Windows users should open `start.bat`, macOS users should run `start.command`,
-and Linux users can execute `start.sh`. These helpers create a local virtual
-environment, upgrade `pip` and install the package automatically before
-launching the suite. Running `copernican.py` outside this environment prompts
-you to use the appropriate start script. You can also start the program
-manually:
+Windows users should open `start.bat`, macOS users should run
+`./start.command`, and Linux users can execute `./start.sh`. These helpers
+create a local virtual environment, upgrade `pip` and install the package
+automatically before launching the suite. Running `copernican.py` outside
+this environment prompts you to use the appropriate start script. You can
+also start the program manually:
 
 ```bash
 python copernican.py

--- a/start.command
+++ b/start.command
@@ -6,6 +6,7 @@
 # installation.
 
 set -e
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 cd "$(dirname "$0")"
 
 # Relaunch from inside the virtual environment when already activated.
@@ -45,5 +46,5 @@ fi
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install .
-exec "$0" "$@"
+exec "$SCRIPT" "$@"
 


### PR DESCRIPTION
## Summary
- resolve start.command using its absolute path before relaunching
- document that macOS users should run ./start.command
- record changes in CHANGELOG

## Testing
- `pre-commit run --files start.command README.md CHANGELOG.md`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68a389555814832fb2f1626f09caf45a