### PR TITLE
Resolve absolute path before restarting start.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.19
+- 2025-08-18: start.sh resolves absolute path before re-executing (AI assistant)
+
 ## Version 3.6.18
 - 2025-08-18: start.command resolves absolute path; README notes macOS should
   run `./start.command` (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.6.18
+**Version:** 3.6.19
 **Last Updated:** 2025-08-18
 
 The Copernican Suite is a Python toolkit for testing cosmological models

--- a/start.sh
+++ b/start.sh
@@ -6,6 +6,8 @@
 # that environment. Subsequent runs reuse the cached dependencies.
 
 set -e
+# Resolve absolute path to this script before changing directories.
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 cd "$(dirname "$0")"
 
 # If we are already inside the virtual environment simply launch the suite.
@@ -47,8 +49,9 @@ if [ ! -d ".venv" ]; then
     "$PYTHON" -m venv .venv
 fi
 
-# Activate the environment, upgrade pip, install the project and re-run.
+# Activate the environment, upgrade pip, install the project and restart the
+# script.
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install .
-exec "$0" "$@"
+exec "$SCRIPT" "$@"


### PR DESCRIPTION
## Summary
- compute an absolute path to `start.sh` before any directory changes
- restart the script using that path and document the behavior
- bump documentation to version 3.6.19 and log the change

## Testing
- `pre-commit run --files start.sh README.md CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68a39093b8fc832f9196505576d9d918