### PR TITLE
Ensure start.sh detects missing python3.11-venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.20
+- 2025-08-19: start.sh checks for missing 'python3.11-venv' after creating
+  '.venv' and prints installation hint (AI assistant)
+
 ## Version 3.6.19
 - 2025-08-18: start.sh resolves absolute path before re-executing (AI assistant)
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ parsers are discovered automatically under
    install tips such as `sudo apt install python3.11 python3.11-venv` on
    Debian, `brew install python@3.11` on macOS or `winget install -e --id
    Python.Python.3.11` on Windows before exiting.
+   If the virtual environment is incomplete the script suggests installing
+   `python3.11-venv`.
 2. Follow the interactive prompts to choose a model, preferred data sources
    and
    computation engine.
@@ -108,6 +110,8 @@ install dependencies. If Python is missing or outdated they print
 platform-specific commands like `sudo apt install python3.11
 python3.11-venv` on Debian, `brew install python@3.11` on macOS or
 `winget install -e --id Python.Python.3.11` on Windows before exiting.
+They also verify that `.venv/bin/activate` exists and hint to install
+`python3.11-venv` when it does not.
 Inside the virtual environment this project relies on `numpy`, `scipy`,
 `matplotlib`, `pandas`, `sympy`, `jsonschema` and `camb==1.6.2`.
 If any packages are missing the program installs them automatically with

--- a/start.sh
+++ b/start.sh
@@ -46,7 +46,18 @@ fi
 
 # Create the virtual environment on first run.
 if [ ! -d ".venv" ]; then
-    "$PYTHON" -m venv .venv
+    # Allow venv creation to fail so we can emit a clearer message if the
+    # activation script is missing.
+    "$PYTHON" -m venv .venv || true
+fi
+
+# Ensure the virtual environment was created successfully. On Debian-based
+# systems the 'python3.11-venv' package may be missing, leaving out the
+# activation script. Advise the user to install it and abort in that case.
+if [ ! -f ".venv/bin/activate" ]; then
+    echo "Virtual environment support is missing." >&2
+    echo "Install with 'sudo apt install python3.11-venv'." >&2
+    exit 1
 fi
 
 # Activate the environment, upgrade pip, install the project and restart the


### PR DESCRIPTION
## Summary
- check for `.venv/bin/activate` after virtualenv creation and advise installing `python3.11-venv` if absent
- mention the new verification in README Quick Start and Dependencies sections
- log the start.sh improvement in CHANGELOG

## Testing
- `pre-commit run --files start.sh CHANGELOG.md README.md`
- `pre-commit run --files start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a40ae8e1c0832f9cefd910152feed5