### PR TITLE
Clean build directory during installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ output/.DS_Store
 /.vscode
 copernican_suite.egg-info
 .venv/
+build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ new engines to introduce additional dependencies without manual updates to the
 documentation.
 To install the suite as a package, run `pip install .` at the repository root.
 Use `pip install -e .` if you intend to develop the code.
+The start scripts delete any `build/` directory before and after
+`pip install .` to prevent stale build artifacts.
 
 ## 4. YAML Model System
 As of version 2.0 every cosmological model is described by a single YAML file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,17 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.21
+- 2025-08-19: Remove 'build/' before and after 'pip install .' in start
+  scripts, document cleanup and ignore the directory (AI assistant)
+
 ## Version 3.6.20
 - 2025-08-19: start.sh checks for missing 'python3.11-venv' after creating
   '.venv' and prints installation hint (AI assistant)
 
 ## Version 3.6.19
-- 2025-08-18: start.sh resolves absolute path before re-executing (AI assistant)
+- 2025-08-18: start.sh resolves absolute path before re-executing
+  (AI assistant)
 
 ## Version 3.6.18
 - 2025-08-18: start.command resolves absolute path; README notes macOS should

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ parsers are discovered automatically under
    `./start.command`, Windows users open `start.bat`, and Linux users can
    execute `./start.sh`. The launcher verifies Python 3.11+ before
    creating a `.venv`, upgrading `pip` and installing the project
-   automatically. If the interpreter is missing or too old it prints
+   automatically. It deletes any `build/` directory before and after
+   `pip install .` to avoid stale artifacts. If the interpreter is missing
+   or too old it prints
    install tips such as `sudo apt install python3.11 python3.11-venv` on
    Debian, `brew install python@3.11` on macOS or `winget install -e --id
    Python.Python.3.11` on Windows before exiting.
@@ -139,10 +141,11 @@ pip install -e . # editable for development
 ```
 
 Installing the suite with `pip` creates a `copernican_suite.egg-info`
-directory.
-This folder contains package metadata such as the version number, dependency
-list and entry points used by Python's packaging tools. It is generated
-automatically and does not need to be tracked in version control.
+directory. The launchers also delete any temporary `build/` directory before
+and after installation so build artifacts are never tracked. This folder
+contains package metadata such as the version number, dependency list and
+entry points used by Python's packaging tools. It is generated automatically
+and does not need to be tracked in version control.
 
 The suite no longer ships standalone binaries. Launch with `start.bat`,
 `start.command` or `start.sh` to create a local `.venv` and install all

--- a/start.bat
+++ b/start.bat
@@ -45,7 +45,11 @@ if not exist .venv (
 call .venv\Scripts\activate.bat
 set PYTHON=python
 %PYTHON% -m pip install --upgrade pip
+REM Remove any 'build' directory before and after 'pip install .'
+REM to avoid stale build artifacts.
+if exist build rmdir /s /q build
 %PYTHON% -m pip install .
+if exist build rmdir /s /q build
 
 call "%~f0" %*
 goto :eof

--- a/start.command
+++ b/start.command
@@ -42,9 +42,13 @@ if [ ! -d ".venv" ]; then
     "$PYTHON" -m venv .venv
 fi
 
-# Activate, update pip, install the project and restart the script.
+# Activate, update pip, install the project and restart the script. Delete
+# any 'build/' directory before and after 'pip install .'
+# to avoid stale build artifacts.
 source .venv/bin/activate
 python -m pip install --upgrade pip
+rm -rf build
 python -m pip install .
+rm -rf build
 exec "$SCRIPT" "$@"
 

--- a/start.sh
+++ b/start.sh
@@ -61,8 +61,11 @@ if [ ! -f ".venv/bin/activate" ]; then
 fi
 
 # Activate the environment, upgrade pip, install the project and restart the
-# script.
+# script. Delete any 'build/' directory before and after 'pip install .'
+# to avoid stale build artifacts.
 source .venv/bin/activate
 python -m pip install --upgrade pip
+rm -rf build
 python -m pip install .
+rm -rf build
 exec "$SCRIPT" "$@"


### PR DESCRIPTION
## Summary
- delete any existing build/ directory before and after `pip install .` in start scripts
- document build cleanup and ignore the generated folder

## Testing
- `pre-commit run --files start.sh start.command start.bat .gitignore README.md AGENTS.md CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68a40caf2cd4832f876e5c8f70b5b1ee