### PR TITLE
Switch to pull-request tests workflow and harden console output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,12 @@
-name: CI
+name: Tests
 
 on:
-  push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  test:
-    name: Test
+  tests:
+    name: Lint and Test
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -55,12 +55,12 @@ jobs:
         shell: pwsh
         run: .\.venv\Scripts\pre-commit run --all-files
 
-      - name: Execute unit tests
+      - name: Run unit tests
         if: runner.os != 'Windows'
         shell: bash
         run: .venv/bin/python copernican.py --run-tests
 
-      - name: Execute unit tests (Windows)
+      - name: Run unit tests (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: .\.venv\Scripts\python copernican.py --run-tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,10 @@ Use `pip install -e .` if you intend to develop the code.
 The start scripts delete any `build/` directory before and after
 `pip install .` to prevent stale build artifacts.
 
+Pull requests run a GitHub Actions workflow named ``Tests`` that executes
+pre-commit checks and the full unit suite on Ubuntu, macOS and Windows.
+Only pull requests trigger the workflow to avoid duplicate push builds.
+
 ## 4. YAML Model System
 As of version 2.0 every cosmological model is described by a single YAML file
 `cosmo_model_*.yml`. All theory text, equations and parameters reside in this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.22
+- 2025-08-19: Replace legacy CI with pull-request-only ``Tests`` workflow and
+  document behaviour (AI assistant)
+- 2025-08-19: ``console_output.write`` now degrades gracefully on consoles
+  lacking Unicode support (AI assistant)
+
 ## Version 3.6.21
 - 2025-08-19: Rename CI job to 'test' for clarity (AI assistant)
 - 2025-08-19: Remove 'build/' before and after 'pip install .' in start

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.6.19
-**Last Updated:** 2025-08-18
+**Version:** 3.6.22
+**Last Updated:** 2025-08-19
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
@@ -428,9 +428,10 @@ python -m unittest discover -v
 python copernican.py --run-tests  # verbose unittest discovery
 ```
 
-Continuous integration verifies style and tests across Windows, macOS and
-Debian-based Linux using GitHub Actions. Each job runs inside a cached
-virtual environment for reproducibility and speed.
+Pull requests trigger a GitHub Actions workflow named ``Tests`` that runs
+pre-commit and the unit suite across Windows, macOS and Debian-based
+Linux. Each job executes inside a cached virtual environment for
+reproducibility and speed.
 
 Multiprocessing is used by several engines. The program enforces the `spawn`
 start method when it launches so that each worker process begins with a fresh

--- a/copernican_lib/console_output.py
+++ b/copernican_lib/console_output.py
@@ -26,9 +26,18 @@ def write(msg: str = "", *, end: str = "\n", error: bool = False) -> None:
     error : bool, optional
         When ``True`` the message is sent to ``stderr`` rather than
         ``stdout``.
+
+    The write is wrapped in a ``try`` block so terminals that cannot
+    represent certain Unicode characters still receive output. Unencodable
+    characters are replaced with ``?`` to avoid raising a
+    :class:`UnicodeEncodeError`.
     """
     stream = sys.stderr if error else sys.stdout
-    print(msg, end=end, file=stream)
+    try:
+        print(msg, end=end, file=stream)
+    except UnicodeEncodeError:
+        fallback = msg.encode("ascii", errors="replace").decode("ascii")
+        print(fallback, end=end, file=stream)
 
 
 def ask(prompt: str = "") -> str:


### PR DESCRIPTION
## Summary
- replace legacy CI with pull-request-only `Tests` workflow running lint and unit tests
- handle UnicodeEncodeError in console output by replacing unencodable characters
- document new workflow and bump version to 3.6.22

## Testing
- `pre-commit run --files copernican_lib/console_output.py .github/workflows/tests.yml README.md AGENTS.md CHANGELOG.md`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68a389d2917c832f85d3726bb8d7626a