### PR TITLE
Read latex mappings with UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.23
+- 2025-08-19: Read ``latex_mappings.yml`` using UTF-8 for cross-platform
+  Unicode safety (AI assistant)
+
 ## Version 3.6.22
 - 2025-08-19: Replace legacy CI with pull-request-only ``Tests`` workflow and
   document behaviour (AI assistant)

--- a/copernican_lib/latex_utils.py
+++ b/copernican_lib/latex_utils.py
@@ -10,9 +10,10 @@ import yaml
 
 # Load replacement dictionaries from ``latex_mappings.yml`` once at import.
 # YAML is more readable than JSON and avoids backslash escaping issues.
+# Explicit UTF-8 ensures consistent parsing across platforms.
 _mapping_path = Path(__file__).with_name("latex_mappings.yml")
 try:
-    with _mapping_path.open("r") as _fh:
+    with open(_mapping_path, encoding="utf-8") as _fh:
         _MAPPINGS: Dict[str, Dict[str, str]] = yaml.safe_load(_fh)
 except OSError as exc:  # pragma: no cover - only fails if repo is corrupted
     raise RuntimeError(f"Cannot read LaTeX mappings: {_mapping_path}") from exc


### PR DESCRIPTION
## Summary
- ensure LaTeX mapping YAML is opened with UTF-8 encoding for consistent Unicode parsing across platforms
- document change in changelog

## Testing
- `pre-commit run --files copernican_lib/latex_utils.py`
- `pre-commit run --files CHANGELOG.md`
- `python -m unittest tests/test_bossdr12_parser.py tests/test_core.py`


------
https://chatgpt.com/codex/tasks/task_e_68a428568c28832fb6ae7d3451908631