### PR TITLE
Retry virtual environment creation when activation script missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,9 @@ documentation.
 To install the suite as a package, run `pip install .` at the repository root.
 Use `pip install -e .` if you intend to develop the code.
 The start scripts delete any `build/` directory before and after
-`pip install .` to prevent stale build artifacts.
+`pip install .` to prevent stale build artifacts. They recreate `.venv`
+once when the activation script is missing before suggesting installation of
+`python3.11-venv`.
 
 Pull requests run a GitHub Actions workflow named ``Tests`` that executes
 pre-commit checks and the full unit suite on Ubuntu, macOS and Windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.24
+- 2025-08-19: start.sh retries virtual environment creation when the
+  activation script is missing and advises installing 'python3.11-venv'
+  if the second attempt fails (AI assistant)
+
 ## Version 3.6.23
 - 2025-08-19: Read ``latex_mappings.yml`` using UTF-8 for cross-platform
   Unicode safety (AI assistant)

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ parsers are discovered automatically under
    install tips such as `sudo apt install python3.11 python3.11-venv` on
    Debian, `brew install python@3.11` on macOS or `winget install -e --id
    Python.Python.3.11` on Windows before exiting.
-   If the virtual environment is incomplete the script suggests installing
-   `python3.11-venv`.
+   If the activation script is missing the launcher recreates `.venv` once
+   before advising the user to install `python3.11-venv`.
 2. Follow the interactive prompts to choose a model, preferred data sources
    and
    computation engine.

--- a/start.sh
+++ b/start.sh
@@ -46,18 +46,23 @@ fi
 
 # Create the virtual environment on first run.
 if [ ! -d ".venv" ]; then
-    # Allow venv creation to fail so we can emit a clearer message if the
-    # activation script is missing.
+    # Allow the initial creation to fail so we can retry if needed.
     "$PYTHON" -m venv .venv || true
 fi
 
 # Ensure the virtual environment was created successfully. On Debian-based
 # systems the 'python3.11-venv' package may be missing, leaving out the
-# activation script. Advise the user to install it and abort in that case.
+# activation script. If it is missing after the first try delete '.venv' and
+# recreate it once. Abort with guidance if the second attempt still lacks the
+# activation script.
 if [ ! -f ".venv/bin/activate" ]; then
-    echo "Virtual environment support is missing." >&2
-    echo "Install with 'sudo apt install python3.11-venv'." >&2
-    exit 1
+    rm -rf .venv
+    "$PYTHON" -m venv .venv || true
+    if [ ! -f ".venv/bin/activate" ]; then
+        echo "Virtual environment support is missing." >&2
+        echo "Install with 'sudo apt install python3.11-venv'." >&2
+        exit 1
+    fi
 fi
 
 # Activate the environment, upgrade pip, install the project and restart the


### PR DESCRIPTION
## Summary
- retry `.venv` creation once if the activation script is missing before advising installation of `python3.11-venv`
- document the new retry behavior in README and AGENTS guidelines
- record change in changelog

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md README.md start.sh`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68a4880f9dd8832fac449db6241e6cac