### PR TITLE
Retry Windows venv creation once and warn when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Version headers run newest to oldest, and within each version the newest
 entries come first):
 
 ## Version 3.6.24
+- 2025-08-19: start.bat verifies '.venv\Scripts\activate.bat' exists,
+  recreating the environment once and advising on missing 'venv' support
+  before exiting (AI assistant)
 - 2025-08-19: start.sh retries virtual environment creation when the
   activation script is missing and advises installing 'python3.11-venv'
   if the second attempt fails (AI assistant)

--- a/start.bat
+++ b/start.bat
@@ -42,6 +42,19 @@ if not exist .venv (
     %PYTHON_CMD% -m venv .venv
 )
 
+REM Ensure the activation script exists. Recreate once before suggesting that
+REM the 'venv' component is missing.
+if not exist .venv\Scripts\activate.bat (
+    rmdir /s /q .venv
+    %PYTHON_CMD% -m venv .venv
+    if not exist .venv\Scripts\activate.bat (
+        echo Virtual environment support is missing.
+        echo Install the Python 'venv' component and try again.
+        echo On Debian/Ubuntu: sudo apt install python3.11-venv
+        exit /b 1
+    )
+)
+
 call .venv\Scripts\activate.bat
 set PYTHON=python
 %PYTHON% -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- retry Windows virtual environment creation when the activation script is missing
- explain how to install Python's venv component when creation fails

## Testing
- `pre-commit run --files start.bat CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68a4962c5374832f94556219bf7d586b