### PR TITLE
Handle missing macOS virtual env activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.25
+- 2025-08-20: start.command recreates missing virtual environments and
+  advises reinstalling Python when activation scripts remain absent (AI
+  assistant)
+
 ## Version 3.6.24
 - 2025-08-19: start.bat verifies '.venv\Scripts\activate.bat' exists,
   recreating the environment once and advising on missing 'venv' support

--- a/start.command
+++ b/start.command
@@ -42,6 +42,21 @@ if [ ! -d ".venv" ]; then
     "$PYTHON" -m venv .venv
 fi
 
+# Retry virtual environment creation once when the activation script is
+# missing. A missing script usually means the Python installation lacks
+# the ``venv`` module. Recreating the environment gives the interpreter
+# another chance before advising the user to reinstall Python.
+if [ ! -f ".venv/bin/activate" ]; then
+    rm -rf .venv
+    "$PYTHON" -m venv .venv
+    if [ ! -f ".venv/bin/activate" ]; then
+        echo "Python 3.11 with working 'venv' support is required." >&2
+        echo "Reinstall it with 'brew install python@3.11'." >&2
+        echo "Get it at https://www.python.org/downloads/." >&2
+        exit 1
+    fi
+fi
+
 # Activate, update pip, install the project and restart the script. Delete
 # any 'build/' directory before and after 'pip install .'
 # to avoid stale build artifacts.


### PR DESCRIPTION
## Summary
- Retry `.venv` creation in `start.command` when the activation script is missing
- Advise reinstalling Python 3.11 if the activation script still isn't created
- Document the change in `CHANGELOG.md`

## Testing
- `pre-commit run --files start.command CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68a555ee3fc8832f9b4d075078f3ae69