### PR TITLE
Add faulthandler signal handlers for crash tracing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ using Matplotlib's standard text rendering. Dataset names retain their
 original spacing and the second line wraps after 190 characters when
 necessary.
 
+The program enables Python's ``faulthandler`` at startup and registers
+``SIGILL``, ``SIGSEGV`` and ``SIGFPE`` handlers. When triggered, they dump
+stack traces to both the console and the active log file before exiting.
+
 The default engine is `engines/cosmo_engine_comb.py`. All model plugins are
 validated
 through `copernican_lib/engine_interface.py` before being passed to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.26
+- 2025-08-21: Added crash signal handlers dumping stack traces to log and
+  console (AI assistant)
+
 ## Version 3.6.25
 - 2025-08-20: start.command recreates missing virtual environments and
   advises reinstalling Python when activation scripts remain absent (AI

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.6.22
-**Last Updated:** 2025-08-19
+**Version:** 3.6.26
+**Last Updated:** 2025-08-21
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
@@ -259,6 +259,9 @@ sanitised and cached under `models/cache/` for the duration of the session,
 avoiding repeated schema validation. For CMB analyses unlensed CAMB spectra
 are cached by rounded parameter tuples which keeps successive evaluations
 fast during optimisation loops.
+
+Fatal signals such as ``SIGILL``, ``SIGSEGV`` or ``SIGFPE`` trigger handlers
+that dump stack traces to the console and active log file before termination.
 
 ## Creating New Models
 All model details, including theory text and equations, must be stored in a

--- a/copernican.py
+++ b/copernican.py
@@ -25,6 +25,8 @@ import datetime
 import argparse
 import subprocess
 from pathlib import Path
+import faulthandler
+import signal
 
 from copernican_lib import console_output as console
 from copernican_lib.version import get_version
@@ -49,6 +51,9 @@ if sys.version_info < MIN_PYTHON:
     )
     exit_clean(1)
 
+# Enable low-level stack tracing so crashes reveal their origin.
+faulthandler.enable()
+
 # Delay heavy third-party imports until after the dependency check.
 # Doing so keeps startup quick and lets ``check_dependencies`` provide a
 # clean error message before the interpreter tries to import missing
@@ -71,6 +76,35 @@ data_loaders = None
 # logs and plot footers still carry a version-like identifier.
 COPERNICAN_VERSION = get_version()
 CURRENT_LOG_FILE = None
+
+
+def _handle_fatal_signal(signum: int, _frame: object) -> None:
+    """Dump a stack trace to the log and console then exit cleanly.
+
+    Critical signals such as ``SIGSEGV`` may indicate a corrupted process
+    state, so the handler writes a traceback for debugging before terminating
+    immediately using :func:`os._exit`.
+    """
+
+    sig_name = signal.Signals(signum).name
+    msg = f"Fatal signal {sig_name} received"
+    console.write(msg, error=True)
+    if CURRENT_LOG_FILE:
+        try:
+            with open(CURRENT_LOG_FILE, "a", encoding="utf-8") as fh:
+                fh.write(msg + "\n")
+                faulthandler.dump_traceback(file=fh, all_threads=True)
+        except Exception:
+            pass
+    faulthandler.dump_traceback(all_threads=True)
+    console.write("Exiting due to fatal signal.", error=True)
+    os._exit(1)
+
+
+for _name in ("SIGILL", "SIGSEGV", "SIGFPE"):
+    _sig = getattr(signal, _name, None)
+    if _sig is not None:
+        signal.signal(_sig, _handle_fatal_signal)
 
 
 def _delete_log_file(path: str) -> None:


### PR DESCRIPTION
## Summary
- enable Python faulthandler and hook SIGILL, SIGSEGV, and SIGFPE to dump stack traces to the console and active log file before exiting
- document crash signal handling in AGENTS and README
- log change in changelog

## Testing
- `pre-commit run --files copernican.py AGENTS.md README.md CHANGELOG.md`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68a6ec09720c832fb5ad6de71103e189