### PR TITLE
feat: log runtime environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,9 @@ necessary.
 The program enables Python's ``faulthandler`` at startup and registers
 ``SIGILL``, ``SIGSEGV`` and ``SIGFPE`` handlers. When triggered, they dump
 stack traces to both the console and the active log file before exiting.
+Immediately after logging initialises the suite records the Python version,
+operating system, CPU model and key package versions. A short summary is
+shown on the console while the log captures full details.
 
 The default engine is `engines/cosmo_engine_comb.py`. All model plugins are
 validated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.6.27
+- 2025-08-21: Logged Python version, OS, CPU and package versions after logging setup (AI assistant)
+
 ## Version 3.6.26
 - 2025-08-21: Added crash signal handlers dumping stack traces to log and
   console (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.6.26
+**Version:** 3.6.27
 **Last Updated:** 2025-08-21
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -253,8 +253,11 @@ portable across operating systems.
 
 ## Logging and Caching
 All console output and user prompts are captured in a timestamped log file in
-`./output/`. The logger shortens absolute paths so logs remain portable and
-records the final filenames used for plots and tables. Model YAML files are
+`./output/`. After initialisation the suite logs the Python version, OS, CPU
+model and key package versions. A short summary appears on the console while
+full details are stored in the log file. The logger shortens absolute paths so
+logs remain portable and records the final filenames used for plots and tables.
+Model YAML files are
 sanitised and cached under `models/cache/` for the duration of the session,
 avoiding repeated schema validation. For CMB analyses unlensed CAMB spectra
 are cached by rounded parameter tuples which keeps successive evaluations

--- a/copernican.py
+++ b/copernican.py
@@ -566,6 +566,8 @@ def main_workflow():
         )
         CURRENT_LOG_FILE = log_file
         logger = log_mod.get_logger()
+        # Record interpreter and package details for reproducibility
+        log_mod.log_environment_info()
         utils.set_random_seed(0)
         start_ts = time.strftime("%y%m%d_%H%M%S")
         run_start_dt = datetime.datetime.now()

--- a/copernican_lib/logger.py
+++ b/copernican_lib/logger.py
@@ -10,8 +10,10 @@ session without clutter or duplicated lines.
 """
 
 import builtins
+import importlib
 import logging
 import os
+import platform
 import sys
 
 from .utils import ensure_dir_exists, get_timestamp
@@ -132,6 +134,36 @@ def setup_logging(log_dir: str = ".", base_dir: str | None = None) -> str:
         _patch_builtins(base_dir)
 
     return log_filename
+
+
+def log_environment_info() -> None:
+    """Log Python, OS, CPU and key package versions.
+
+    Detailed information is written to the log file while a short
+    summary prints to the console. This aids in reproducing results
+    across different systems.
+    """
+    logger = logging.getLogger()
+    py_ver = platform.python_version()
+    os_info = platform.platform()
+    cpu = platform.processor() or "Unknown CPU"
+    pkgs = {}
+    for name in ("numpy", "scipy", "matplotlib"):
+        try:
+            mod = importlib.import_module(name)
+            pkgs[name] = getattr(mod, "__version__", "unknown")
+        except Exception:
+            pkgs[name] = "not installed"
+    logger.info("Environment details:")
+    logger.info(f"  Python: {py_ver}")
+    logger.info(f"  OS: {os_info}")
+    logger.info(f"  CPU: {cpu}")
+    for n, v in pkgs.items():
+        logger.info(f"  {n}: {v}")
+    summary = f"Python {py_ver}; {os_info}; CPU {cpu}; " + ", ".join(
+        f"{n} {v}" for n, v in pkgs.items()
+    )
+    print(f"Environment summary: {summary}")
 
 
 def get_logger():


### PR DESCRIPTION
## Summary
- log Python, OS, CPU and key package versions after initializing logging
- document runtime environment logging

## Testing
- `pre-commit run --files copernican_lib/logger.py copernican.py README.md CHANGELOG.md AGENTS.md`
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a74d9789a4832fb0072ed0a06a62d6