### PR TITLE
Add strict warning mode and forward warnings to logger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ Immediately after logging initialises the suite records the Python version,
 operating system, CPU model and key package versions. A short summary is
 shown on the console while the log captures full details.
 
+All Python warnings are forwarded to the central logger. Use
+``--strict-warnings`` to elevate warnings to errors during CI runs.
+
 The default engine is `engines/cosmo_engine_comb.py`. All model plugins are
 validated
 through `copernican_lib/engine_interface.py` before being passed to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,13 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.7.0
+- 2025-08-21: Forwarded Python warnings to logger and added strict warning flag
+  for CI reproducibility (AI assistant)
+
 ## Version 3.6.27
-- 2025-08-21: Logged Python version, OS, CPU and package versions after logging setup (AI assistant)
+- 2025-08-21: Logged Python version, OS, CPU and package versions
+  after logging setup (AI assistant)
 
 ## Version 3.6.26
 - 2025-08-21: Added crash signal handlers dumping stack traces to log and

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ parsers are discovered automatically under
 3. Execute `python3 copernican.py --run-tests` to run the verbose test
    suite, or run `python -m unittest discover -v` directly. The test
    runner reports informational messages, warnings and errors while
-   verifying the reference model and parsers.
+   verifying the reference model and parsers. Add `--strict-warnings`
+   to upgrade warnings to errors for reproducible CI runs.
 4. Plots and CSV results will appear in the `output/` folder when the run
    completes.
 
@@ -434,6 +435,9 @@ python -m unittest discover -v
 python copernican.py --run-tests  # verbose unittest discovery
 ```
 
+The optional `--strict-warnings` flag treats all warnings as errors during
+any run.
+
 Pull requests trigger a GitHub Actions workflow named ``Tests`` that runs
 pre-commit and the unit suite across Windows, macOS and Debian-based
 Linux. Each job executes inside a cached virtual environment for
@@ -488,7 +492,7 @@ altering `MAJOR.MINOR`.
     verbose functional test suite and verify that the LCDM model and data
     parsers work as expected. This flag performs unittest discovery over
     the `tests` package and streams informational messages, warnings and
-    errors.
+    errors. Combine with `--strict-warnings` to fail on any warning.
 3.  **Initialization**: The script starts and creates the `./output/`
     directory
     for all results.

--- a/copernican.py
+++ b/copernican.py
@@ -168,13 +168,27 @@ def run_startup_tests():
 
 
 def parse_args():
-    """Parse command line flags provided by the user."""
+    """Parse command line flags provided by the user.
+
+    Returns
+    -------
+    argparse.Namespace
+        ``run_tests`` executes the functional test suite and exits, while
+        ``strict_warnings`` upgrades all warnings to errors to ensure
+        deterministic CI behaviour.
+    """
+
     parser = argparse.ArgumentParser(description="Copernican Suite")
     # ``--run-tests`` triggers the functional test suite and then exits.
     parser.add_argument(
         "--run-tests",
         action="store_true",
         help="execute functional tests and exit",
+    )
+    parser.add_argument(
+        "--strict-warnings",
+        action="store_true",
+        help="treat warnings as errors for reproducible CI runs",
     )
     return parser.parse_args()
 
@@ -520,7 +534,7 @@ def main_workflow():
 
     # Import optional third-party packages after confirming they are installed
     global np, plt, mp, model_parser, model_coder, engine_interface, \
-        data_loaders, plotter, csv_writer, log_mod, logger
+        data_loaders, plotter, csv_writer, log_mod, logger, error_handler
     import numpy as np
     import matplotlib.pyplot as plt
     import multiprocessing as mp
@@ -531,6 +545,7 @@ def main_workflow():
         csv_writer,
         logger as log_mod,
         utils,
+        error_handler,
     )
 
     try:
@@ -566,6 +581,15 @@ def main_workflow():
         )
         CURRENT_LOG_FILE = log_file
         logger = log_mod.get_logger()
+        error_handler.configure_warnings(strict=args.strict_warnings)
+        if args.strict_warnings:
+            logger.info(
+                "Strict warnings mode enabled; treating warnings as errors"
+            )
+        else:
+            logger.info(
+                "Warnings will be logged but not treated as errors"
+            )
         # Record interpreter and package details for reproducibility
         log_mod.log_environment_info()
         utils.set_random_seed(0)

--- a/copernican_lib/error_handler.py
+++ b/copernican_lib/error_handler.py
@@ -1,11 +1,17 @@
-"""Simple logging helper used by model parsing code.
+"""Logging and warning helpers for Copernican components.
 
-This module contains a single function ``report_error`` which delegates
-error messages to Python's :mod:`logging` system.  It exists so that
-parsers can emit errors without caring about the global logger setup.
+Parsers use :func:`report_error` to emit messages without depending on the
+global logging configuration.  The new :func:`configure_warnings` routine
+forwards all :mod:`warnings` to the central logger and optionally upgrades
+them to errors for deterministic CI runs.  Centralising this behaviour keeps
+log handling consistent across the project.
 """
 
+from __future__ import annotations
+
 import logging
+import warnings
+from typing import Type
 
 
 def report_error(message: str) -> None:
@@ -14,3 +20,41 @@ def report_error(message: str) -> None:
     # that logging configuration stays centralised. Any error messages end up
     # in the same log file as the main application output.
     logging.getLogger().error(message)
+
+
+def configure_warnings(strict: bool = False) -> None:
+    """Forward warnings to the logger and optionally treat them as errors.
+
+    Parameters
+    ----------
+    strict:
+        When ``True`` all warnings raise exceptions via
+        ``warnings.filterwarnings("error")``.  This flag is designed for
+        reproducible continuous integration runs where unexpected warnings
+        should fail the build.
+    """
+
+    def _log_warning(
+        message: str,
+        category: Type[Warning],
+        filename: str,
+        lineno: int,
+        file: object | None = None,
+        line: str | None = None,
+    ) -> None:
+        """Log formatted warning details to the shared logger."""
+
+        logging.getLogger().warning(
+            "%s:%s: %s: %s",
+            filename,
+            lineno,
+            category.__name__,
+            message,
+        )
+
+    warnings.showwarning = _log_warning
+    if strict:
+        warnings.filterwarnings("error")
+
+
+__all__ = ["report_error", "configure_warnings"]


### PR DESCRIPTION
## Summary
- route all Python warnings through the central logger
- add `--strict-warnings` flag to treat warnings as errors
- document strict warning mode and update contributor guidelines

## Testing
- `pre-commit run --files copernican_lib/error_handler.py copernican.py README.md AGENTS.md CHANGELOG.md`
- `python -m unittest discover -v | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a75a2095c0832f9249cfe47d9f81b2