### PR TITLE
Add NumPy/SciPy sanity checks for CPU compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ shown on the console while the log captures full details.
 All Python warnings are forwarded to the central logger. Use
 ``--strict-warnings`` to elevate warnings to errors during CI runs.
 
+Before any heavy computation, a tiny NumPy/SciPy calculation checks that the
+installed binaries match the CPU. If this fails the log explains possible CPU
+feature mismatches and suggests reinstalling with suitable wheels.
+
 The default engine is `engines/cosmo_engine_comb.py`. All model plugins are
 validated
 through `copernican_lib/engine_interface.py` before being passed to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.8.0
+- 2025-08-21: Added NumPy/SciPy sanity checks before heavy computations to
+  diagnose CPU feature mismatches (AI assistant)
+
 ## Version 3.7.0
 - 2025-08-21: Forwarded Python warnings to logger and added strict warning flag
   for CI reproducibility (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.6.27
+**Version:** 3.8.0
 **Last Updated:** 2025-08-21
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -48,9 +48,10 @@ Users select models, datasets, and computational engines at runtime through a
 simple command line interface. Results are saved as plots and CSV files in the
 `./output/` directory.
 Under the hood the program follows a clear pipeline:
-1. **Dependency Check** – `copernican.py` scans for required packages and
-   automatically installs any missing ones using `pip`, verifying each
-import before continuing.
+1. **Dependency Check** – `copernican.py` scans for required packages,
+   installs missing ones and verifies each import. A tiny NumPy/SciPy
+   calculation then runs to catch CPU feature mismatches before heavy
+   computation begins.
 2. **Initialization** – the output directory is created and logging begins.
 3. **Configuration** – the user chooses a model and a computation engine
    from `./engines/`.  The default `cosmo_engine_comb.py` performs a

--- a/copernican.py
+++ b/copernican.py
@@ -518,11 +518,36 @@ def cleanup_cache(base_dir):
                     logger.error(f"Error removing cache file {path}: {e}")
 
 
+def _sanity_check_numpy_scipy(log):
+    """Run a tiny NumPy/SciPy calculation to verify binary compatibility.
+
+    Mismatched CPU features or corrupted installations can cause crashes when
+    heavy computations begin. A trivial dot product and determinant expose such
+    issues early so the program can advise reinstalling with suitable wheels.
+    """
+
+    try:
+        import numpy as _np
+        from scipy import linalg as _linalg
+
+        _np.dot(_np.ones(1), _np.ones(1))
+        _linalg.det([[1.0]])
+    except Exception as exc:  # pragma: no cover - depends on local install
+        log.error(
+            "Basic NumPy/SciPy check failed. This often points to CPU feature "
+            "mismatches or a corrupted install. Reinstall NumPy and SciPy with "
+            "wheels built for your machine.",
+            exc_info=exc,
+        )
+        raise
+
+
 def main_workflow():
     """Main workflow for the Copernican Suite."""
     # This routine coordinates the entire user interaction:
     #  * parse command-line flags
     #  * verify Python dependencies
+    #  * perform a NumPy/SciPy sanity check
     #  * load the reference ΛCDM model
     #  * repeatedly ask the user for models, data sources and engines
     #  * produce plots and CSV files with the results
@@ -592,6 +617,10 @@ def main_workflow():
             )
         # Record interpreter and package details for reproducibility
         log_mod.log_environment_info()
+        try:
+            _sanity_check_numpy_scipy(logger)
+        except Exception:
+            exit_clean(1)
         utils.set_random_seed(0)
         start_ts = time.strftime("%y%m%d_%H%M%S")
         run_start_dt = datetime.datetime.now()

--- a/copernican_lib/optim_utils.py
+++ b/copernican_lib/optim_utils.py
@@ -35,6 +35,10 @@ def minimize_with_progress(
 ) -> Tuple[Optional[object], int, float, List[float]]:
     """Run :func:`scipy.optimize.minimize` while tracking evaluations.
 
+    A tiny NumPy/SciPy operation is attempted first to ensure the compiled
+    extensions load correctly. Failures often stem from CPU feature
+    mismatches and the log advises reinstalling compatible wheels.
+
     Parameters
     ----------
     func : callable
@@ -66,6 +70,19 @@ def minimize_with_progress(
     """
 
     logger = logging.getLogger()
+    try:
+        np.dot(np.ones(1), np.ones(1))
+        from scipy import linalg as _linalg
+
+        _linalg.det([[1.0]])
+    except Exception as exc:  # pragma: no cover - depends on environment
+        logger.error(
+            "Basic NumPy/SciPy check failed. This may indicate CPU feature "
+            "mismatches or a corrupted install. Reinstall with wheels "
+            "built for your system.",
+            exc_info=exc,
+        )
+        return None, 0, float("inf"), list(x0)
     eval_count = {"count": 0}
     best_val = [np.inf]
     best_params = [list(x0)]


### PR DESCRIPTION
## Summary
- Verify NumPy and SciPy by running a tiny operation before heavy computations
- Log diagnostics advising reinstall with CPU-appropriate wheels when the check fails
- Document the new startup check and bump project version

## Testing
- `pre-commit run --files copernican.py copernican_lib/optim_utils.py AGENTS.md README.md CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68a767f48c88832fb6e2a13eebee244b