### PR TITLE
Drop JSON support from compound BAO dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.8.3
+- 2025-08-22: Dropped JSON input from the compound BAO parser and updated
+  documentation to reference YAML only (AI assistant)
+
 ## Version 3.8.2
 - 2025-08-21: Logged previously silent exceptions in `copernican.py`,
   `copernican_lib/utils.py` and `engines/cosmo_engine_comb.py` (AI assistant)

--- a/data/bao/compound/cosmo_parser_compound.py
+++ b/data/bao/compound/cosmo_parser_compound.py
@@ -31,8 +31,7 @@ def parse_bao_v1(data_dir, **kwargs):
     data_files = [
         f
         for f in os.listdir(data_dir)
-        if f.lower().endswith((".json", ".yml", ".yaml"))
-        and not f.startswith("metadata")
+        if f.lower().endswith((".yml", ".yaml")) and not f.startswith("metadata")
     ]
     if not data_files:
         logger.error(f"No BAO data file found in {data_dir}.")
@@ -40,9 +39,9 @@ def parse_bao_v1(data_dir, **kwargs):
     filepath = os.path.join(data_dir, sorted(data_files)[0])
     try:
         with open(filepath, "r") as f:
-            data_json = yaml.safe_load(f)
+            data_yaml = yaml.safe_load(f)
 
-        df = pd.DataFrame(data_json["data_points"])
+        df = pd.DataFrame(data_yaml["data_points"])
         required_cols = ["redshift", "observable_type", "value", "error"]
         if not all(col in df.columns for col in required_cols):
             logger.error(

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -76,11 +76,11 @@ diagonal uncertainties only when the matrix is absent or ill conditioned.
 ### Compound BAO Dataset
 *Source:* synthetic compilation for testing purposes.
 *Location:* `data/bao/compound/`.
-*Parser:* `cosmo_parser_compound.py` scans the directory for a YAML or JSON
-file and loads its `data_points` table into a `DataFrame`. Numeric columns are
-coerced to floats and rows missing required fields are discarded. No
-covariance matrix is supplied, so the engine assumes uncorrelated errors and
-applies a diagonal covariance during \(\chi^2\) evaluation.
+*Parser:* `cosmo_parser_compound.py` scans the directory for a YAML file and
+loads its `data_points` table into a `DataFrame`. Numeric columns are coerced
+to floats and rows missing required fields are discarded. No covariance matrix
+is supplied, so the engine assumes uncorrelated errors and applies a diagonal
+covariance during \(\chi^2\) evaluation.
 
 ## CMB Datasets
 


### PR DESCRIPTION
## Summary
- restrict compound BAO parser to YAML inputs and rename interim variables
- clarify docs: Compound BAO dataset uses only YAML files
- record removal of JSON support in changelog

## Testing
- `pre-commit run --files data/bao/compound/cosmo_parser_compound.py docs/data_overview.md CHANGELOG.md`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68a8a9a6f598832f959f0b4cac5a84a1