### PR TITLE
Harden SymPy expression compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Version 1.1.0
 - 2025-05-27: Added plotting and CSV (Apostol Apostolov)
+- 2025-08-22: Hardened SymPy expression handling to block unsafe code and
+               added security tests (OpenAI ChatGPT)
 
 ## Version 1.0.0
 - 2025-05-26: Debugged copernican.py script (AI assistant)

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -47,6 +47,32 @@ def _latex_to_sympy_str(expr: str) -> str:
     return latex_utils.latex_to_sympy(expr)
 
 
+_SAFE_GLOBALS = {"__builtins__": {}}
+_SAFE_GLOBALS.update({name: getattr(sp, name) for name in sp.__all__})
+
+
+def _safe_parse_expr(expr_str: str, local_dict: dict) -> sp.Expr:
+    """Safely parse ``expr_str`` into a SymPy expression.
+
+    The parser runs with an empty ``__builtins__`` dict so that tokens like
+    ``__import__`` cannot access Python's standard library. Expressions with
+    double underscores are rejected outright to avoid dunder exploits.
+    """
+
+    if "__" in expr_str:
+        raise ValueError(
+            "Double underscores are not permitted in expressions."
+        )
+
+    return parse_expr(
+        expr_str,
+        local_dict,
+        global_dict=_SAFE_GLOBALS,
+        transformations=standard_transformations
+        + (implicit_multiplication_application,),
+    )
+
+
 def _compile_sympy_expr(sym_expr, args):
     """Compile a SymPy expression into a callable that evaluates
     ``Integral`` nodes."""
@@ -58,8 +84,11 @@ def _compile_sympy_expr(sym_expr, args):
         printer = QuadPrinter({"strict": False})
         code = printer.doprint(sym_expr)
         lambda_src = f"lambda {', '.join(str(a) for a in args)}: {code}"
-        return eval(lambda_src, {"np": np, "quad": quad})
-    return sp.lambdify(args, sym_expr, "numpy")
+        return eval(
+            lambda_src,
+            {"np": np, "quad": quad, "__builtins__": {}},
+        )
+    return sp.lambdify(args, sym_expr, [{"__builtins__": {}}, "numpy"])
 
 
 def generate_callables(cache_path):
@@ -101,12 +130,7 @@ def generate_callables(cache_path):
     if hz_expr_str:
         try:
             parsed_hz = _latex_to_sympy_str(hz_expr_str)
-            hz_sym = parse_expr(
-                parsed_hz,
-                local_dict,
-                transformations=standard_transformations
-                + (implicit_multiplication_application,),
-            )
+            hz_sym = _safe_parse_expr(parsed_hz, local_dict)
             used_syms = {str(s) for s in hz_sym.free_symbols if s != z}
             param_names = {p["python_var"] for p in model_data["parameters"]}
             missing = used_syms - param_names
@@ -202,12 +226,7 @@ def generate_callables(cache_path):
             if rs_expr_str:
                 try:
                     parsed_rs = _latex_to_sympy_str(rs_expr_str)
-                    rs_sym = parse_expr(
-                        parsed_rs,
-                        local_dict,
-                        transformations=standard_transformations
-                        + (implicit_multiplication_application,),
-                    )
+                    rs_sym = _safe_parse_expr(parsed_rs, local_dict)
                     used = {str(s) for s in rs_sym.free_symbols} - {"z"}
                     missing_rs = used - param_names
                     if missing_rs:
@@ -303,12 +322,7 @@ def generate_callables(cache_path):
             # Textual equations are preserved but not parsed into functions
             continue
         try:
-            sym_expr = parse_expr(
-                expr,
-                local_dict,
-                transformations=standard_transformations
-                + (implicit_multiplication_application,),
-            )
+            sym_expr = _safe_parse_expr(expr, local_dict)
             # Convert SymPy expression to a callable, numerically evaluating
             # ``Integral`` constructs if present.
             fn = _compile_sympy_expr(sym_expr, (z, *param_syms))

--- a/tests/test_model_coder.py
+++ b/tests/test_model_coder.py
@@ -1,0 +1,28 @@
+"""Security tests for ``model_coder`` expression handling."""
+
+import unittest
+
+import sympy as sp
+
+from copernican_lib import model_coder
+
+
+class TestModelCoderSecurity(unittest.TestCase):
+    """Ensure potentially dangerous expressions are not executed."""
+
+    def test_compile_sympy_expr_blocks_import(self):
+        """``_compile_sympy_expr`` should deny access to ``__import__``."""
+        z = sp.symbols("z")
+        malicious = sp.Function("__import__")(sp.Symbol("os"))
+        fn = model_coder._compile_sympy_expr(malicious, (z,))
+        with self.assertRaises(NameError):
+            fn(0)
+
+    def test_safe_parse_expr_rejects_dunder(self):
+        """Expressions containing ``__`` should be rejected outright."""
+        with self.assertRaises(ValueError):
+            model_coder._safe_parse_expr("__import__('os')", {})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- Restrict SymPy parsing and lambdify to an empty `__builtins__` and block double-underscore tokens to avoid executing injected code.
- Add unit tests verifying that `__import__` and other dunder expressions are rejected.
- Document security hardening in `CHANGELOG.md`.

## Testing
- `pre-commit run --files copernican_lib/model_coder.py tests/test_model_coder.py CHANGELOG.md`
- `python -m unittest tests/test_model_coder.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8b2f858e0832fa8ac262b6ee29a6e