### PR TITLE
Add license references to dataset metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,10 @@ models/           - YAML model definitions with embedded theory text and
 engines/          - Computational backends (SciPy CPU by default)
 data/             - Observation files under ``data/<type>/<source>/``. Each
                     dataset directory includes a `metadata_*.yml` file with
-                    `dataset_name`, `description`, `citation`, the full
-                    `author` list and BibTeX keys such as `title`, `volume`,
-                    `journal` and `DOI`. Metadata is loaded exclusively by
+                    `dataset_name`, `description`, `citation`, `license`, the
+                    full `author` list and BibTeX keys such as `title`,
+                    `volume`, `journal` and `DOI`. Metadata is loaded
+                    exclusively by
                     `copernican_lib/data_loaders.py` after each parser runs.
   cmb/planck2018lite/ - Planck 2018 lite TT/TE/EE spectra and covariance
 output/           - Generated plots and CSV tables (created automatically)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.8.4
+- 2025-08-22: Added dataset license references and updated documentation
+  (AI assistant)
+
 ## Version 3.8.3
 - 2025-08-22: Updated README version to 3.8.3 (AI assistant)
 - 2025-08-22: Dropped JSON input from the compound BAO parser and updated

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.8.3
+**Version:** 3.8.4
 **Last Updated:** 2025-08-22
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -241,9 +241,10 @@ bold, while the dataset name on the second line retains its original spacing
 via MathText's ``\mathbf`` command.
 
 Metadata values are read from ``metadata_*.yml`` files stored next to each
-dataset. ``copernican_lib/data_loaders.py`` attaches this metadata to the
-DataFrame returned by each parser so both plot footers and CSV headers reflect
-the official dataset description and citation. Individual parsers never access
+dataset. These files include a ``license`` field pointing to usage terms.
+``copernican_lib/data_loaders.py`` attaches this metadata to the DataFrame
+returned by each parser so both plot footers and CSV headers reflect the
+official dataset description and citation. Individual parsers never access
 metadata files directly.
 
 During configuration each loader prints a summary indicating whether the

--- a/data/bao/bossdr12/metadata_bossdr12.yml
+++ b/data/bao/bossdr12/metadata_bossdr12.yml
@@ -1,8 +1,27 @@
 dataset_name: BOSS DR12 BAO Consensus
 dataset_id: boss_dr12_bao
-description: Consensus BAO distances for three redshift bins providing DM/rs, DH/rs and DV/rs with propagated block-diagonal covariance
+description: >-
+  Consensus BAO distances for three redshift bins providing DM/rs, DH/rs and
+  DV/rs with propagated block-diagonal covariance
 citation: Alam et al. - MNRAS 470 (2017) 2617-2652 - DOI: https://doi.org/10.1093/mnras/stx721
-author: Alam S., Ata M., Bailey S., Beutler F., Bizyaev D., Blazek J.A., Bolton A.S., Brownstein J.R., Burden A., Chuang C., Comparat J., Cuesta A.J., Dawson K.S., Eisenstein D.J., Escoffier S., Gil-Mar'in H., Grieb J.N., Hand N., Ho S., Kinemuchi K., Kirkby D., Kitaura F., Malanushenko E., Malanushenko V., Maraston C., McBride C.K., Nichol R.C., Olmstead M.D., Oravetz D., Padmanabhan N., Palanque-Delabrouille N., Pan K., Pellejero-Ibanez M., Percival W.J., Petitjean P., Prada F., Price-Whelan A.M., Reid B.A., Rodriguez-Torres S.A., Roe N.A., Ross A.J., Ross N.P., Rossi G., Rubino-Martin J.A., Saito S., Salazar-Albornoz S., Samushia L., Sanchez A.G., Satpathy S., Schlegel D.J., Schneider D.P., Scoccola C.G., Seo H., Sheldon E.S., Simmons A., Slosar A., Strauss M.A., Swanson M.E.C., Thomas D., Tinker J.L., Tojeiro R., Vargas Magana M., Vazquez J.A., Verde L., Wake D.A., Wang Y., Weinberg D.H., White M., Wood-Vasey W.M., Yeche C., Zehavi I., Zhai Z., Zhao G.
+license: >-
+  SDSS-III DR12 data are public and require acknowledgement; see
+  https://www.sdss.org/collaboration/citing-sdss/
+author: >-
+  Alam S., Ata M., Bailey S., Beutler F., Bizyaev D., Blazek J.A., Bolton
+  A.S., Brownstein J.R., Burden A., Chuang C., Comparat J., Cuesta A.J.,
+  Dawson K.S., Eisenstein D.J., Escoffier S., Gil-Mar'in H., Grieb J.N., Hand
+  N., Ho S., Kinemuchi K., Kirkby D., Kitaura F., Malanushenko E.,
+  Malanushenko V., Maraston C., McBride C.K., Nichol R.C., Olmstead M.D.,
+  Oravetz D., Padmanabhan N., Palanque-Delabrouille N., Pan K.,
+  Pellejero-Ibanez M., Percival W.J., Petitjean P., Prada F., Price-Whelan
+  A.M., Reid B.A., Rodriguez-Torres S.A., Roe N.A., Ross A.J., Ross N.P.,
+  Rossi G., Rubino-Martin J.A., Saito S., Salazar-Albornoz S., Samushia L.,
+  Sanchez A.G., Satpathy S., Schlegel D.J., Schneider D.P., Scoccola C.G.,
+  Seo H., Sheldon E.S., Simmons A., Slosar A., Strauss M.A., Swanson M.E.C.,
+  Thomas D., Tinker J.L., Tojeiro R., Vargas Magana M., Vazquez J.A., Verde
+  L., Wake D.A., Wang Y., Weinberg D.H., White M., Wood-Vasey W.M., Yeche C.,
+  Zehavi I., Zhai Z., Zhao G.
 title: The clustering of galaxies in the completed SDSS-III Baryon Oscillation Spectroscopic Survey: cosmological analysis of the DR12 galaxy sample
 article: Alam_2017
 volume: 470
@@ -16,4 +35,8 @@ publisher: Oxford University Press (OUP)
 year: 2017
 month: mar
 pages: 2617-2652
-notes: Published dM(rs_fid/rs) and Hz(rs/rs_fid) measurements are converted to D_M/rs and D_H/rs and combined with D_V/rs results. The dM/Hz and D_V/F_AP covariance matrices are assembled into a block-diagonal matrix, propagated through the transformation and inverted when well conditioned.
+notes: >-
+  Published dM(rs_fid/rs) and Hz(rs/rs_fid) measurements are converted to
+  D_M/rs and D_H/rs and combined with D_V/rs results. The dM/Hz and D_V/F_AP
+  covariance matrices are assembled into a block-diagonal matrix, propagated
+  through the transformation and inverted when well conditioned.

--- a/data/bao/compound/metadata_compound.yml
+++ b/data/bao/compound/metadata_compound.yml
@@ -2,14 +2,19 @@ dataset_name: Compound BAO dataset
 dataset_id: compound_bao_set
 description: Compilation of BAO distance measurements without a covariance matrix
 citation: Multiple Surveys (see metadata "authors")
-author: 6dFGS: Beutler et al. 2011. SDSS MGS: Ross et al. 2015. WiggleZ: Blake
-  et al. 2011. BOSS DR12 Consensus: Alam et al. 2017 (Table 5). eBOSS DR14 Quasar:
-  Benasque BAO DR14 QSO. eBOSS DR16 Quasar: Alam et al. 2021 (Table 3). eBOSS DR16
-  Lyman-α: du Mas des Bourboux et al. 2020 (Table 7). Additional: SDSS DR7 LRG z=0.35;
-  SDSS DR7 LRG z=0.2; BOSS DR11 LOWZ z=0.32 & CMASS z=0.57; BOSS DR11 Quasar-Lyα Cross
-  z=2.36; eBOSS DR14 Quasar-Lyα Cross z=2.35: Blomqvist et al. 2019; eBOSS DR14 Lyα
-  Auto z=2.34: de Sainte Agathe et al. 2019; eBOSS DR16 ELG z=0.845: Raichoor et al.
-  2020; DES Year 1 Angular BAO z=0.81: Leclercq et al. 2018.
+license: >-
+  Aggregates publicly released BAO measurements; consult individual surveys
+  for their usage policies.
+author: >-
+  6dFGS: Beutler et al. 2011. SDSS MGS: Ross et al. 2015. WiggleZ: Blake et
+  al. 2011. BOSS DR12 Consensus: Alam et al. 2017 (Table 5). eBOSS DR14
+  Quasar: Benasque BAO DR14 QSO. eBOSS DR16 Quasar: Alam et al. 2021 (Table
+  3). eBOSS DR16 Lyman-α: du Mas des Bourboux et al. 2020 (Table 7).
+  Additional: SDSS DR7 LRG z=0.35; SDSS DR7 LRG z=0.2; BOSS DR11 LOWZ
+  z=0.32 & CMASS z=0.57; BOSS DR11 Quasar-Lyα Cross z=2.36; eBOSS DR14
+  Quasar-Lyα Cross z=2.35: Blomqvist et al. 2019; eBOSS DR14 Lyα Auto
+  z=2.34: de Sainte Agathe et al. 2019; eBOSS DR16 ELG z=0.845: Raichoor et
+  al. 2020; DES Year 1 Angular BAO z=0.81: Leclercq et al. 2018.
 title: N/A
 article: N/A
 volume: N/A
@@ -23,4 +28,9 @@ publisher: N/A
 year: N/A
 month: N/A
 pages: N/A
-notes: Observable types: DV_over_rs (D_V(z)/r_s), DM_over_rs (D_M(z)/r_s), DH_over_rs (D_H(z)/r_s = c/(H(z) r_s)). All r_s values are the model's sound horizon at the drag epoch unless a fiducial r_s is specified (rs_fiducial_Mpc). No covariance matrix is available; uncertainties are treated as uncorrelated.
+notes: >-
+  Observable types: DV_over_rs (D_V(z)/r_s), DM_over_rs (D_M(z)/r_s),
+  DH_over_rs (D_H(z)/r_s = c/(H(z) r_s)). All r_s values are the model's
+  sound horizon at the drag epoch unless a fiducial r_s is specified
+  (rs_fiducial_Mpc). No covariance matrix is available; uncertainties are
+  treated as uncorrelated.

--- a/data/cmb/planck2018lite/metadata_planck2018lite.yml
+++ b/data/cmb/planck2018lite/metadata_planck2018lite.yml
@@ -1,8 +1,48 @@
 dataset_name: Planck 2018 Lite TT/TE/EE
 dataset_id: planck_2018_lite
-description: Temperature and polarization power spectra from the Planck 2018 lite release with full covariance matrix
+description: >-
+  Temperature and polarization power spectra from the Planck 2018 lite
+  release with full covariance matrix
 citation: Aghanim et al. - A&A 641 (2020) A1 - DOI: https://doi.org/10.1051/0004-6361/201833880
-author: Aghanim N., Akrami Y., Arroja F., Ashdown M., Aumont J., Baccigalupi C., Ballardini M., Banday A.J., Barreiro R.B., Bartolo N., Basak S., Battye R., Benabed K., Bernard J., Bersanelli M., Bielewicz P., Bock J.J., Bond J.R., Borrill J., Bouchet F.R., Boulanger F., Bucher M., Burigana C., Butler R.C., Calabrese E., Cardoso J., Carron J., Casaponsa B., Challinor A., Chiang H.C., Colombo L.P.L., Combet C., Contreras D., Crill B.P., Cuttaia F., de Bernardis P., de Zotti G., Delabrouille J., Delouis J., Desert F., Di Valentino E., Dickinson C., Diego J.M., Donzelli S., Dore O., Douspis M., Ducout A., Dupac X., Efstathiou G., Elsner F., Ensslin T.A., Eriksen H.K., Falgarone E., Fantaye Y., Fergusson J., Fernandez-Cobos R., Finelli F., Forastieri F., Frailis M., Franceschi E., Frolov A., Galeotta S., Galli S., Ganga K., Genova-Santos R.T., Gerbino M., Ghosh T., Gonzalez-Nuevo J., Gorski K.M., Gratton S., Gruppuso A., Gudmundsson J.E., Hamann J., Handley W., Hansen F.K., Helou G., Herranz D., Hildebrandt S.R., Hivon E., Huang Z., Jaffe A.H., Jones W.C., Karakci A., Keihanen E., Keskitalo R., Kiiveri K., Kim J., Kisner T.S., Knox L., Krachmalnicoff N., Kunz M., Kurki-Suonio H., Lagache G., Lamarre J., Langer M., Lasenby A., Lattanzi M., Lawrence C.R., Le Jeune M., Leahy J.P., Lesgourgues J., Levrier F., Lewis A., Liguori M., Lilje P.B., Lilley M., Lindholm V., Lopez-Caniego M., Lubin P.M., Ma Y., Macias-Perez J.F., Maggio G., Maino D., Mandolesi N., Mangilli A., Marcos-Caballero A., Maris M., Martin P.G., Martinelli M., Martinez-Gonzalez E., Matarrese S., Mauri N., McEwen J.D., Meerburg P.D., Meinhold P.R., Melchiorri A., Mennella A., Migliaccio M., Millea M., Mitra S., Miville-Deschenes M., Molinari D., Moneti A., Montier L., Morgante G., Moss A., Mottet S., Munchmeyer M., Natoli P., Norgaard-Nielsen H.U., Oxborrow C.A., Pagano L., Paoletti D., Partridge B., Patanchon G., Pearson T.J., Peel M., Peiris H.V., Perrotta F., Pettorino V., Piacentini F., Polastri L., Polenta G., Puget J., Rachen J.P., Reinecke M., Remazeilles M., Renault C., Renzi A., Rocha G., Rosset C., Roudier G., Rubino-Martin J.A., Ruiz-Granados B., Salvati L., Sandri M., Savelainen M., Scott D., Shellard E.P.S., Shiraishi M., Sirignano C., Sirri G., Spencer L.D., Sunyaev R., Suur-Uski A., Tauber J.A., Tavagnacco D., Tenti M., Terenzi L., Toffolatti L., Tomasi M., Trombetti T., Valiviita J., Van Tent B., Vibert L., Vielva P., Villa F., Vittorio N., Wandelt B.D., Wehus I.K., White M., White S.D.M., Zacchei A., Zonca A.
+license: >-
+  Planck 2018 data released under the ESA Planck Legacy Archive terms; see
+  https://www.cosmos.esa.int/web/planck/pla
+author: >-
+  Aghanim N., Akrami Y., Arroja F., Ashdown M., Aumont J., Baccigalupi C.,
+  Ballardini M., Banday A.J., Barreiro R.B., Bartolo N., Basak S., Battye R.,
+  Benabed K., Bernard J., Bersanelli M., Bielewicz P., Bock J.J., Bond J.R.,
+  Borrill J., Bouchet F.R., Boulanger F., Bucher M., Burigana C., Butler R.C.,
+  Calabrese E., Cardoso J., Carron J., Casaponsa B., Challinor A., Chiang
+  H.C., Colombo L.P.L., Combet C., Contreras D., Crill B.P., Cuttaia F., de
+  Bernardis P., de Zotti G., Delabrouille J., Delouis J., Desert F., Di
+  Valentino E., Dickinson C., Diego J.M., Donzelli S., Dore O., Douspis M.,
+  Ducout A., Dupac X., Efstathiou G., Elsner F., Ensslin T.A., Eriksen H.K.,
+  Falgarone E., Fantaye Y., Fergusson J., Fernandez-Cobos R., Finelli F.,
+  Forastieri F., Frailis M., Franceschi E., Frolov A., Galeotta S., Galli S.,
+  Ganga K., Genova-Santos R.T., Gerbino M., Ghosh T., Gonzalez-Nuevo J.,
+  Gorski K.M., Gratton S., Gruppuso A., Gudmundsson J.E., Hamann J., Handley
+  W., Hansen F.K., Helou G., Herranz D., Hildebrandt S.R., Hivon E., Huang Z.,
+  Jaffe A.H., Jones W.C., Karakci A., Keihanen E., Keskitalo R., Kiiveri K.,
+  Kim J., Kisner T.S., Knox L., Krachmalnicoff N., Kunz M., Kurki-Suonio H.,
+  Lagache G., Lamarre J., Langer M., Lasenby A., Lattanzi M., Lawrence C.R.,
+  Le Jeune M., Leahy J.P., Lesgourgues J., Levrier F., Lewis A., Liguori M.,
+  Lilje P.B., Lilley M., Lindholm V., Lopez-Caniego M., Lubin P.M., Ma Y.,
+  Macias-Perez J.F., Maggio G., Maino D., Mandolesi N., Mangilli A.,
+  Marcos-Caballero A., Maris M., Martin P.G., Martinelli M.,
+  Martinez-Gonzalez E., Matarrese S., Mauri N., McEwen J.D., Meerburg P.D.,
+  Meinhold P.R., Melchiorri A., Mennella A., Migliaccio M., Millea M., Mitra
+  S., Miville-Deschenes M., Molinari D., Moneti A., Montier L., Morgante G.,
+  Moss A., Mottet S., Munchmeyer M., Natoli P., Norgaard-Nielsen H.U.,
+  Oxborrow C.A., Pagano L., Paoletti D., Partridge B., Patanchon G., Pearson
+  T.J., Peel M., Peiris H.V., Perrotta F., Pettorino V., Piacentini F.,
+  Polastri L., Polenta G., Puget J., Rachen J.P., Reinecke M., Remazeilles M.,
+  Renault C., Renzi A., Rocha G., Rosset C., Roudier G., Rubino-Martin J.A.,
+  Ruiz-Granados B., Salvati L., Sandri M., Savelainen M., Scott D., Shellard
+  E.P.S., Shiraishi M., Sirignano C., Sirri G., Spencer L.D., Sunyaev R.,
+  Suur-Uski A., Tauber J.A., Tavagnacco D., Tenti M., Terenzi L., Toffolatti L.,
+  Tomasi M., Trombetti T., Valiviita J., Van Tent B., Vibert L., Vielva P.,
+  Villa F., Vittorio N., Wandelt B.D., Wehus I.K., White M., White S.D.M.,
+  Zacchei A., Zonca A.
 title: Planck2018 results: I. Overview and the cosmological legacy of Planck
 article: 2020
 volume: 641
@@ -16,4 +56,8 @@ publisher: EDP Sciences
 year: 2020
 month: sep
 pages: A1
-notes: TT, TE and EE angular power spectra are converted to D_l and aligned to the TT multipole grid. The covariance matrix is read from the binary release, transformed to D_l units and inverted when well conditioned. Diagonal errors are stored for plotting and as a fallback.
+notes: >-
+  TT, TE and EE angular power spectra are converted to D_l and aligned to
+  the TT multipole grid. The covariance matrix is read from the binary
+  release, transformed to D_l units and inverted when well conditioned.
+  Diagonal errors are stored for plotting and as a fallback.

--- a/data/gw/placeholder/metadata_gw_placeholder.yml
+++ b/data/gw/placeholder/metadata_gw_placeholder.yml
@@ -2,5 +2,6 @@ dataset_name: GW Placeholder
 dataset_id: gw_placeholder
 description: No gravitational wave dataset available yet
 citation: N/A
+license: Usage terms to be determined
 authors_all: N/A
 notes: Stub parser for future gravitational wave observations

--- a/data/sirens/placeholder/metadata_siren_placeholder.yml
+++ b/data/sirens/placeholder/metadata_siren_placeholder.yml
@@ -2,5 +2,6 @@ dataset_name: Standard Siren Placeholder
 dataset_id: siren_placeholder
 description: No standard siren dataset available yet
 citation: N/A
+license: Usage terms to be determined
 authors_all: N/A
 notes: Stub parser for future standard siren observations

--- a/data/sne/jla2014/metadata_jla2014.yml
+++ b/data/sne/jla2014/metadata_jla2014.yml
@@ -1,8 +1,25 @@
 dataset_name: Joint Light-curve Analysis 2014
 dataset_id: jla_2014
-description: Joint SDSS-II and SNLS supernova sample of 740 SNe Ia with distance moduli and full covariance matrix.
+description: >-
+  Joint SDSS-II and SNLS supernova sample of 740 SNe Ia with distance
+  moduli and full covariance matrix.
 citation: Betoule et al. - A&A 568 (2014) A22 - DOI: https://doi.org/10.1051/0004-6361/201423413
-author: Betoule M., Kessler R., Guy J., Mosher J., Hardin D., Biswas R., Astier P., El-Hage P., Konig M., Kuhlmann S., Marriner J., Pain R., Regnault N., Balland C., Bassett B.A., Brown P.J., Campbell H., Carlberg R.G., Cellier-Holzem F., Cinabro D., Conley A., D'Andrea C.B., DePoy D.L., Doi M., Ellis R.S., Fabbro S., Filippenko A.V., Foley R.J., Frieman J.A., Fouchez D., Galbany L., Goobar A., Gupta R.R., Hill G.J., Hlozek R., Hogan C.J., Hook I.M., Howell D.A., Jha S.W., Le Guillou L., Leloudas G., Lidman C., Marshall J.L., Moller A., Mourao A.M., Neveu J., Nichol R., Olmstead M.D., Palanque-Delabrouille N., Perlmutter S., Prieto J.L., Pritchet C.J., Richmond M., Riess A.G., Ruhlmann-Kleider V., Sako M., Schahmaneche K., Schneider D.P., Smith M., Sollerman J., Sullivan M., Walton N.A., Wheeler C.J.
+license: >-
+  JLA data release is public with required citation; see
+  https://supernovae.in2p3.fr/sdss_snls_jla/ReadMe.html
+author: >-
+  Betoule M., Kessler R., Guy J., Mosher J., Hardin D., Biswas R., Astier P.,
+  El-Hage P., Konig M., Kuhlmann S., Marriner J., Pain R., Regnault N.,
+  Balland C., Bassett B.A., Brown P.J., Campbell H., Carlberg R.G.,
+  Cellier-Holzem F., Cinabro D., Conley A., D'Andrea C.B., DePoy D.L., Doi M.,
+  Ellis R.S., Fabbro S., Filippenko A.V., Foley R.J., Frieman J.A., Fouchez D.,
+  Galbany L., Goobar A., Gupta R.R., Hill G.J., Hlozek R., Hogan C.J., Hook
+  I.M., Howell D.A., Jha S.W., Le Guillou L., Leloudas G., Lidman C., Marshall
+  J.L., Moller A., Mourao A.M., Neveu J., Nichol R., Olmstead M.D.,
+  Palanque-Delabrouille N., Perlmutter S., Prieto J.L., Pritchet C.J.,
+  Richmond M., Riess A.G., Ruhlmann-Kleider V., Sako M., Schahmaneche K.,
+  Schneider D.P., Smith M., Sollerman J., Sullivan M., Walton N.A., Wheeler
+  C.J.
 title: Improved cosmological constraints from a joint analysis of the SDSS-II and SNLS supernova samples
 article: Betoule_2014
 volume: 568
@@ -16,4 +33,9 @@ publisher: EDP Sciences
 year: 2014
 month: aug
 pages: A22
-notes: Light-curve parameters are converted to distance moduli using fixed SALT2 nuisance parameters. The systematic covariance from tablef4.fit is projected to distance-modulus space, combined with diagonal statistical errors and inverted. Supernovae are sorted by redshift and the inverse covariance is attached to the DataFrame.
+notes: >-
+  Light-curve parameters are converted to distance moduli using fixed SALT2
+  nuisance parameters. The systematic covariance from tablef4.fit is
+  projected to distance-modulus space, combined with diagonal statistical
+  errors and inverted. Supernovae are sorted by redshift and the inverse
+  covariance is attached to the DataFrame.

--- a/data/sne/pantheon/metadata_pantheon.yml
+++ b/data/sne/pantheon/metadata_pantheon.yml
@@ -1,8 +1,21 @@
 dataset_name: Pantheon+SH0ES 2022
 dataset_id: pantheon+sh0es_2022
-description: Combined sample of 1701 Type Ia supernova distance moduli with full statistical and systematic covariance matrix
+description: >-
+  Combined sample of 1701 Type Ia supernova distance moduli with full
+  statistical and systematic covariance matrix
 citation: Brout et al. - ApJ 938 (2022) 110 - DOI: https://doi.org/10.3847/1538-4357/ac8e04
-author: Brout D., Scolnic D., Popovic B., Riess A.G., Carr A., Zuntz J., Kessler R., Davis T.M., Hinton S., Jones D., Kenworthy W.D., Peterson E.R., Said K., Taylor G., Ali N., Armstrong P., Charvu P., Dwomoh A., Meldorf C., Palmese A., Qu H., Rose B.M., Sanchez B., Stubbs C.W., Vincenzi M., Wood C.M., Brown P.J., Chen R., Chambers K., Coulter D.A., Dai M., Dimitriadis G., Filippenko A.V., Foley R.J., Jha S.W., Kelsey L., Kirshner R.P., Moller A., Muir J., Nadathur S., Pan Y., Rest A., Rojas-Bravo C., Sako M., Siebert M.R., Smith M., Stahl B.E., Wiseman P.
+license: >-
+  Pantheon+SH0ES 2022 data are publicly released for research with required
+  citation; see https://pantheonplussh0es.github.io/
+author: >-
+  Brout D., Scolnic D., Popovic B., Riess A.G., Carr A., Zuntz J., Kessler R.,
+  Davis T.M., Hinton S., Jones D., Kenworthy W.D., Peterson E.R., Said K.,
+  Taylor G., Ali N., Armstrong P., Charvu P., Dwomoh A., Meldorf C., Palmese A.,
+  Qu H., Rose B.M., Sanchez B., Stubbs C.W., Vincenzi M., Wood C.M., Brown P.J.,
+  Chen R., Chambers K., Coulter D.A., Dai M., Dimitriadis G., Filippenko A.V.,
+  Foley R.J., Jha S.W., Kelsey L., Kirshner R.P., Moller A., Muir J., Nadathur
+  S., Pan Y., Rest A., Rojas-Bravo C., Sako M., Siebert M.R., Smith M., Stahl
+  B.E., Wiseman P.
 title: The Pantheon+ Analysis: Cosmological Constraints
 article: Brout_2022
 volume: 938
@@ -16,4 +29,9 @@ publisher: American Astronomical Society
 year: 2022
 month: oct
 pages: 110
-notes: Distance moduli are loaded alongside the full statistical and systematic covariance matrix. The parser identifies the data and covariance files automatically, sorts the sample by redshift and inverts the covariance. Duplicate entries represent alternate calibrations and are intentionally retained.
+notes: >-
+  Distance moduli are loaded alongside the full statistical and systematic
+  covariance matrix. The parser identifies the data and covariance files
+  automatically, sorts the sample by redshift and inverts the covariance.
+  Duplicate entries represent alternate calibrations and are intentionally
+  retained.

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -23,9 +23,9 @@ usable simply rename the folder and supply a valid parser and metadata file.
 
 Every dataset folder also provides a `metadata_*.yml` describing the
 source. Fields such as `dataset_name`, `dataset_id`, `description`,
-`citation`, the full `author` list and accompanying BibTeX information
-(for example `title`, `volume`, `journal` and `DOI`) are read by
-`copernican_lib/data_loaders.py` after the parser returns so individual
+`citation`, `license`, the full `author` list and accompanying BibTeX
+information (for example `title`, `volume`, `journal` and `DOI`) are read
+by `copernican_lib/data_loaders.py` after the parser returns so individual
 parsers remain metadata-agnostic. Parsed DataFrames expose the same
 information on their `.attrs` property, and `dataset_id` is used when
 constructing output filenames. See `dataset_metadata.md` for a full

--- a/docs/dataset_metadata.md
+++ b/docs/dataset_metadata.md
@@ -1,8 +1,8 @@
 # Dataset Metadata Fields
 
 Each dataset folder contains a `metadata_*.yml` file that describes the
-source. All fields are optional except for `dataset_name`, `dataset_id`
-and `description`.
+source. All fields are optional except for `dataset_name`, `dataset_id`,
+`description` and `license`.
 
 Example skeleton:
 
@@ -11,6 +11,7 @@ dataset_name: Example Dataset
 dataset_id: example_set
 description: Short human readable blurb
 citation: FirstAuthor et al. 2024 - Journal 12 (2024) 34-56 - DOI: 10.x/y
+license: Free to use with attribution
 ```
 
 - `dataset_name` -- Short human-readable identifier used in logs, plot
@@ -21,6 +22,7 @@ citation: FirstAuthor et al. 2024 - Journal 12 (2024) 34-56 - DOI: 10.x/y
 - `description` -- Brief explanation of the dataset origin.
 - `citation` -- Formatted as "FirstAuthor et al. - J. Vol (Year) Pages - DOI:
   URL".
+- `license` -- Usage terms or license under which the dataset is released.
 - `author` -- Full author list from the publication.
 - `title` -- Publication title.
 - `article` -- BibTeX citation key.


### PR DESCRIPTION
## Summary
- add license field and wrap long text across dataset metadata files
- document license metadata in README and docs

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md README.md data/bao/bossdr12/metadata_bossdr12.yml data/bao/compound/metadata_compound.yml data/cmb/planck2018lite/metadata_planck2018lite.yml data/gw/placeholder/metadata_gw_placeholder.yml data/sirens/placeholder/metadata_siren_placeholder.yml data/sne/jla2014/metadata_jla2014.yml data/sne/pantheon/metadata_pantheon.yml docs/data_overview.md docs/dataset_metadata.md`

------
https://chatgpt.com/codex/tasks/task_e_68a8b07c9b88832f9de2e64adb96dd4d