### PR TITLE
feat: confirm dependency install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,9 +97,11 @@ AST parser to avoid false positives from comments. The `start.*` launchers
 verify Python 3.11 or later before creating ``.venv``. If the interpreter is
 missing or outdated they print platform-specific installation commands and
 exit. Once the requirement is met the scripts run inside the repository's
-``.venv``. If any required package is missing, the program installs it
-automatically with `pip` and verifies the import before continuing. Running
-outside ``.venv`` prompts the user to restart via the appropriate launcher.
+``.venv``. If any required package is missing, the program asks before
+installing it with `pip` and verifies the import before continuing.
+Use `--yes` to bypass the prompt in non-interactive environments.
+Running outside ``.venv`` prompts the user to restart via the appropriate
+launcher.
 This lightweight approach works across Windows, macOS and Linux while allowing
 new engines to introduce additional dependencies without manual updates to the
 documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.0
+- 2025-08-22: Prompted before installing dependencies and added `--yes` flag
+  for CI automation (AI assistant)
+
 ## Version 3.8.4
 - 2025-08-22: Added dataset license references and updated documentation
   (AI assistant)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.8.4
+**Version:** 3.9.0
 **Last Updated:** 2025-08-22
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -438,7 +438,7 @@ python copernican.py --run-tests  # verbose unittest discovery
 ```
 
 The optional `--strict-warnings` flag treats all warnings as errors during
-any run.
+any run. Add `--yes` to install missing dependencies without prompting.
 
 Pull requests trigger a GitHub Actions workflow named ``Tests`` that runs
 pre-commit and the unit suite across Windows, macOS and Debian-based
@@ -489,7 +489,8 @@ altering `MAJOR.MINOR`.
 ## 4. Workflow Overview
 
 1.  **Dependency Check**: `copernican.py` scans for missing packages,
-    installs them automatically with `pip` and verifies the environment.
+    prompts before installing them with `pip` and verifies the environment.
+    Use `--yes` to skip the prompt in automated CI runs.
 2.  **Optional Tests**: Run `copernican.py --run-tests` to execute the
     verbose functional test suite and verify that the LCDM model and data
     parsers work as expected. This flag performs unittest discovery over

--- a/copernican.py
+++ b/copernican.py
@@ -223,7 +223,8 @@ def parse_args():
     argparse.Namespace
         ``run_tests`` executes the functional test suite and exits, while
         ``strict_warnings`` upgrades all warnings to errors to ensure
-        deterministic CI behaviour.
+        deterministic CI behaviour.  ``yes`` installs missing dependencies
+        without asking for confirmation, simplifying non-interactive CI runs.
     """
 
     parser = argparse.ArgumentParser(description="Copernican Suite")
@@ -237,6 +238,12 @@ def parse_args():
         "--strict-warnings",
         action="store_true",
         help="treat warnings as errors for reproducible CI runs",
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="install missing packages without prompting",
     )
     return parser.parse_args()
 
@@ -352,8 +359,16 @@ def _gather_required_packages():
     }
 
 
-def check_dependencies():
-    """Ensure required packages are installed inside the local ``.venv``.
+def check_dependencies(auto_confirm: bool = False) -> None:
+    """Ensure required packages exist inside the local ``.venv``.
+
+    Parameters
+    ----------
+    auto_confirm : bool, optional
+        When ``True`` any missing packages are installed without prompting
+        the user.  This is intended for non-interactive environments such as
+        continuous integration systems.  When ``False`` the user is asked to
+        confirm installation before ``pip`` is invoked.
 
     The suite bundles a virtual environment under ``.venv`` that is activated
     by the ``start.*`` launchers.  This check confirms the interpreter is
@@ -391,6 +406,14 @@ def check_dependencies():
         console.write(
             f"Missing packages detected: {', '.join(missing)}"
         )
+        if not auto_confirm:
+            reply = console.ask("Install missing packages? [y/N] ")
+            if reply.lower() not in {"y", "yes"}:
+                console.write(
+                    "Dependency installation aborted by user.",
+                    error=True,
+                )
+                exit_clean(1)
         try:
             subprocess.run(
                 [sys.executable, "-m", "pip", "install", *missing],
@@ -558,7 +581,7 @@ def main_workflow():
     #  * repeatedly ask the user for models, data sources and engines
     #  * produce plots and CSV files with the results
     args = parse_args()
-    check_dependencies()
+    check_dependencies(auto_confirm=args.yes)
     if args.run_tests:
         success = run_startup_tests()
         exit_clean(0 if success else 1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,5 +53,41 @@ class SelectSourceDisplayTestCase(unittest.TestCase):
         self.assertNotIn("dummy_id", out)
 
 
+class DependencyPromptTestCase(unittest.TestCase):
+    """Test dependency installer confirmation and CI override."""
+
+    @mock.patch("copernican.Path")
+    def test_installs_after_confirmation(self, path_mock):
+        path_mock.return_value.resolve.return_value.name = ".venv"
+        with (
+            mock.patch(
+                "copernican._gather_required_packages", return_value=["demo"]
+            ),
+            mock.patch("importlib.util.find_spec", return_value=None),
+            mock.patch("copernican.console.ask", return_value="y") as ask_mock,
+            mock.patch("subprocess.run") as run_mock,
+            mock.patch("importlib.import_module"),
+        ):
+            copernican.check_dependencies()
+            ask_mock.assert_called_once()
+            run_mock.assert_called_once()
+
+    @mock.patch("copernican.Path")
+    def test_auto_confirm_skips_prompt(self, path_mock):
+        path_mock.return_value.resolve.return_value.name = ".venv"
+        with (
+            mock.patch(
+                "copernican._gather_required_packages", return_value=["demo"]
+            ),
+            mock.patch("importlib.util.find_spec", return_value=None),
+            mock.patch("copernican.console.ask") as ask_mock,
+            mock.patch("subprocess.run") as run_mock,
+            mock.patch("importlib.import_module"),
+        ):
+            copernican.check_dependencies(auto_confirm=True)
+            ask_mock.assert_not_called()
+            run_mock.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- prompt users before installing missing packages and allow `--yes` override
- document new flag in README and AGENTS
- test manual confirmation and CI auto-confirm flows

## Testing
- `pre-commit run --files copernican.py README.md AGENTS.md CHANGELOG.md tests/test_cli.py`
- `python -m unittest tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8b74f27e8832fb5ad2e7e4cb73ff9