### PR TITLE
Finalize placeholder dataset licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.2
+- 2025-08-22: Updated licenses for GW and siren placeholders (AI assistant)
+
 ## Version 3.9.1
 - 2025-08-22: Replaced ``eval`` in CAMB parameter parsing with a safe
   AST-based evaluator and added malicious expression tests (AI assistant)

--- a/data/gw/placeholder/metadata_gw_placeholder.yml
+++ b/data/gw/placeholder/metadata_gw_placeholder.yml
@@ -2,6 +2,8 @@ dataset_name: GW Placeholder
 dataset_id: gw_placeholder
 description: No gravitational wave dataset available yet
 citation: N/A
-license: Usage terms to be determined
+license: >-
+  CC0 1.0 Universal (CC0 1.0) Public Domain Dedication.
+  https://creativecommons.org/publicdomain/zero/1.0/
 authors_all: N/A
 notes: Stub parser for future gravitational wave observations

--- a/data/sirens/placeholder/metadata_siren_placeholder.yml
+++ b/data/sirens/placeholder/metadata_siren_placeholder.yml
@@ -2,6 +2,8 @@ dataset_name: Standard Siren Placeholder
 dataset_id: siren_placeholder
 description: No standard siren dataset available yet
 citation: N/A
-license: Usage terms to be determined
+license: >-
+  CC0 1.0 Universal (CC0 1.0) Public Domain Dedication.
+  https://creativecommons.org/publicdomain/zero/1.0/
 authors_all: N/A
 notes: Stub parser for future standard siren observations


### PR DESCRIPTION
## Summary
- Finalized the license terms for placeholder gravitational-wave and standard-siren metadata using a CC0 public-domain dedication.
- Logged the dataset license updates in the changelog with a new version entry.

## Testing
- `pre-commit run --files data/sirens/placeholder/metadata_siren_placeholder.yml data/gw/placeholder/metadata_gw_placeholder.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a8e8efd880832fae6e4c729712e719