### PR TITLE
Format metadata text fields with folded YAML blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Version headers run newest to oldest, and within each version the newest
 entries come first):
 
 ## Version 3.9.2
+- 2025-08-22: Wrapped metadata citations with YAML folded blocks and line
+  breaks (AI assistant)
 - 2025-08-22: Updated licenses for GW and siren placeholders (AI assistant)
 
 ## Version 3.9.1

--- a/data/bao/bossdr12/metadata_bossdr12.yml
+++ b/data/bao/bossdr12/metadata_bossdr12.yml
@@ -3,26 +3,30 @@ dataset_id: boss_dr12_bao
 description: >-
   Consensus BAO distances for three redshift bins providing DM/rs, DH/rs and
   DV/rs with propagated block-diagonal covariance
-citation: Alam et al. - MNRAS 470 (2017) 2617-2652 - DOI: https://doi.org/10.1093/mnras/stx721
+citation: >-
+  Alam et al. - MNRAS 470 (2017) 2617-2652 - DOI:
+  https://doi.org/10.1093/mnras/stx721
 license: >-
   SDSS-III DR12 data are public and require acknowledgement; see
   https://www.sdss.org/collaboration/citing-sdss/
 author: >-
   Alam S., Ata M., Bailey S., Beutler F., Bizyaev D., Blazek J.A., Bolton
   A.S., Brownstein J.R., Burden A., Chuang C., Comparat J., Cuesta A.J.,
-  Dawson K.S., Eisenstein D.J., Escoffier S., Gil-Mar'in H., Grieb J.N., Hand
-  N., Ho S., Kinemuchi K., Kirkby D., Kitaura F., Malanushenko E.,
+  Dawson K.S., Eisenstein D.J., Escoffier S., Gil-Mar'in H., Grieb J.N.,
+  Hand N., Ho S., Kinemuchi K., Kirkby D., Kitaura F., Malanushenko E.,
   Malanushenko V., Maraston C., McBride C.K., Nichol R.C., Olmstead M.D.,
   Oravetz D., Padmanabhan N., Palanque-Delabrouille N., Pan K.,
-  Pellejero-Ibanez M., Percival W.J., Petitjean P., Prada F., Price-Whelan
-  A.M., Reid B.A., Rodriguez-Torres S.A., Roe N.A., Ross A.J., Ross N.P.,
-  Rossi G., Rubino-Martin J.A., Saito S., Salazar-Albornoz S., Samushia L.,
-  Sanchez A.G., Satpathy S., Schlegel D.J., Schneider D.P., Scoccola C.G.,
-  Seo H., Sheldon E.S., Simmons A., Slosar A., Strauss M.A., Swanson M.E.C.,
-  Thomas D., Tinker J.L., Tojeiro R., Vargas Magana M., Vazquez J.A., Verde
-  L., Wake D.A., Wang Y., Weinberg D.H., White M., Wood-Vasey W.M., Yeche C.,
-  Zehavi I., Zhai Z., Zhao G.
-title: The clustering of galaxies in the completed SDSS-III Baryon Oscillation Spectroscopic Survey: cosmological analysis of the DR12 galaxy sample
+  Pellejero-Ibanez M., Percival W.J., Petitjean P., Prada F.,
+  Price-Whelan A.M., Reid B.A., Rodriguez-Torres S.A., Roe N.A., Ross A.J.,
+  Ross N.P., Rossi G., Rubino-Martin J.A., Saito S., Salazar-Albornoz S.,
+  Samushia L., Sanchez A.G., Satpathy S., Schlegel D.J., Schneider D.P.,
+  Scoccola C.G., Seo H., Sheldon E.S., Simmons A., Slosar A., Strauss M.A.,
+  Swanson M.E.C., Thomas D., Tinker J.L., Tojeiro R., Vargas Magana M.,
+  Vazquez J.A., Verde L., Wake D.A., Wang Y., Weinberg D.H., White M.,
+  Wood-Vasey W.M., Yeche C., Zehavi I., Zhai Z., Zhao G.
+title: >-
+  The clustering of galaxies in the completed SDSS-III Baryon Oscillation
+  Spectroscopic Survey: cosmological analysis of the DR12 galaxy sample
 article: Alam_2017
 volume: 470
 ISSN: 1365-2966

--- a/data/bao/compound/metadata_compound.yml
+++ b/data/bao/compound/metadata_compound.yml
@@ -1,7 +1,9 @@
 dataset_name: Compound BAO dataset
 dataset_id: compound_bao_set
-description: Compilation of BAO distance measurements without a covariance matrix
-citation: Multiple Surveys (see metadata "authors")
+description: >-
+  Compilation of BAO distance measurements without a covariance matrix
+citation: >-
+  Multiple Surveys (see metadata "authors")
 license: >-
   Aggregates publicly released BAO measurements; consult individual surveys
   for their usage policies.

--- a/data/cmb/planck2018lite/metadata_planck2018lite.yml
+++ b/data/cmb/planck2018lite/metadata_planck2018lite.yml
@@ -3,7 +3,9 @@ dataset_id: planck_2018_lite
 description: >-
   Temperature and polarization power spectra from the Planck 2018 lite
   release with full covariance matrix
-citation: Aghanim et al. - A&A 641 (2020) A1 - DOI: https://doi.org/10.1051/0004-6361/201833880
+citation: >-
+  Aghanim et al. - A&A 641 (2020) A1 - DOI:
+  https://doi.org/10.1051/0004-6361/201833880
 license: >-
   Planck 2018 data released under the ESA Planck Legacy Archive terms; see
   https://www.cosmos.esa.int/web/planck/pla
@@ -39,11 +41,13 @@ author: >-
   Renault C., Renzi A., Rocha G., Rosset C., Roudier G., Rubino-Martin J.A.,
   Ruiz-Granados B., Salvati L., Sandri M., Savelainen M., Scott D., Shellard
   E.P.S., Shiraishi M., Sirignano C., Sirri G., Spencer L.D., Sunyaev R.,
-  Suur-Uski A., Tauber J.A., Tavagnacco D., Tenti M., Terenzi L., Toffolatti L.,
+  Suur-Uski A., Tauber J.A., Tavagnacco D., Tenti M., Terenzi L.,
+  Toffolatti L.,
   Tomasi M., Trombetti T., Valiviita J., Van Tent B., Vibert L., Vielva P.,
   Villa F., Vittorio N., Wandelt B.D., Wehus I.K., White M., White S.D.M.,
   Zacchei A., Zonca A.
-title: Planck2018 results: I. Overview and the cosmological legacy of Planck
+title: >-
+  Planck2018 results: I. Overview and the cosmological legacy of Planck
 article: 2020
 volume: 641
 ISSN: 1432-0746

--- a/data/sne/jla2014/metadata_jla2014.yml
+++ b/data/sne/jla2014/metadata_jla2014.yml
@@ -3,24 +3,28 @@ dataset_id: jla_2014
 description: >-
   Joint SDSS-II and SNLS supernova sample of 740 SNe Ia with distance
   moduli and full covariance matrix.
-citation: Betoule et al. - A&A 568 (2014) A22 - DOI: https://doi.org/10.1051/0004-6361/201423413
+citation: >-
+  Betoule et al. - A&A 568 (2014) A22 - DOI:
+  https://doi.org/10.1051/0004-6361/201423413
 license: >-
   JLA data release is public with required citation; see
   https://supernovae.in2p3.fr/sdss_snls_jla/ReadMe.html
 author: >-
-  Betoule M., Kessler R., Guy J., Mosher J., Hardin D., Biswas R., Astier P.,
-  El-Hage P., Konig M., Kuhlmann S., Marriner J., Pain R., Regnault N.,
+  Betoule M., Kessler R., Guy J., Mosher J., Hardin D., Biswas R., Astier
+  P., El-Hage P., Konig M., Kuhlmann S., Marriner J., Pain R., Regnault N.,
   Balland C., Bassett B.A., Brown P.J., Campbell H., Carlberg R.G.,
-  Cellier-Holzem F., Cinabro D., Conley A., D'Andrea C.B., DePoy D.L., Doi M.,
-  Ellis R.S., Fabbro S., Filippenko A.V., Foley R.J., Frieman J.A., Fouchez D.,
-  Galbany L., Goobar A., Gupta R.R., Hill G.J., Hlozek R., Hogan C.J., Hook
-  I.M., Howell D.A., Jha S.W., Le Guillou L., Leloudas G., Lidman C., Marshall
-  J.L., Moller A., Mourao A.M., Neveu J., Nichol R., Olmstead M.D.,
-  Palanque-Delabrouille N., Perlmutter S., Prieto J.L., Pritchet C.J.,
+  Cellier-Holzem F., Cinabro D., Conley A., D'Andrea C.B., DePoy D.L., Doi
+  M., Ellis R.S., Fabbro S., Filippenko A.V., Foley R.J., Frieman J.A.,
+  Fouchez D., Galbany L., Goobar A., Gupta R.R., Hill G.J., Hlozek R., Hogan
+  C.J., Hook I.M., Howell D.A., Jha S.W., Le Guillou L., Leloudas G., Lidman
+  C., Marshall J.L., Moller A., Mourao A.M., Neveu J., Nichol R., Olmstead
+  M.D., Palanque-Delabrouille N., Perlmutter S., Prieto J.L., Pritchet C.J.,
   Richmond M., Riess A.G., Ruhlmann-Kleider V., Sako M., Schahmaneche K.,
   Schneider D.P., Smith M., Sollerman J., Sullivan M., Walton N.A., Wheeler
   C.J.
-title: Improved cosmological constraints from a joint analysis of the SDSS-II and SNLS supernova samples
+title: >-
+  Improved cosmological constraints from a joint analysis of the SDSS-II and
+  SNLS supernova samples
 article: Betoule_2014
 volume: 568
 ISSN: 1432-0746

--- a/data/sne/pantheon/metadata_pantheon.yml
+++ b/data/sne/pantheon/metadata_pantheon.yml
@@ -3,20 +3,23 @@ dataset_id: pantheon+sh0es_2022
 description: >-
   Combined sample of 1701 Type Ia supernova distance moduli with full
   statistical and systematic covariance matrix
-citation: Brout et al. - ApJ 938 (2022) 110 - DOI: https://doi.org/10.3847/1538-4357/ac8e04
+citation: >-
+  Brout et al. - ApJ 938 (2022) 110 - DOI:
+  https://doi.org/10.3847/1538-4357/ac8e04
 license: >-
   Pantheon+SH0ES 2022 data are publicly released for research with required
   citation; see https://pantheonplussh0es.github.io/
 author: >-
-  Brout D., Scolnic D., Popovic B., Riess A.G., Carr A., Zuntz J., Kessler R.,
-  Davis T.M., Hinton S., Jones D., Kenworthy W.D., Peterson E.R., Said K.,
-  Taylor G., Ali N., Armstrong P., Charvu P., Dwomoh A., Meldorf C., Palmese A.,
-  Qu H., Rose B.M., Sanchez B., Stubbs C.W., Vincenzi M., Wood C.M., Brown P.J.,
-  Chen R., Chambers K., Coulter D.A., Dai M., Dimitriadis G., Filippenko A.V.,
-  Foley R.J., Jha S.W., Kelsey L., Kirshner R.P., Moller A., Muir J., Nadathur
-  S., Pan Y., Rest A., Rojas-Bravo C., Sako M., Siebert M.R., Smith M., Stahl
-  B.E., Wiseman P.
-title: The Pantheon+ Analysis: Cosmological Constraints
+  Brout D., Scolnic D., Popovic B., Riess A.G., Carr A., Zuntz J., Kessler
+  R., Davis T.M., Hinton S., Jones D., Kenworthy W.D., Peterson E.R., Said
+  K., Taylor G., Ali N., Armstrong P., Charvu P., Dwomoh A., Meldorf C.,
+  Palmese A., Qu H., Rose B.M., Sanchez B., Stubbs C.W., Vincenzi M., Wood
+  C.M., Brown P.J., Chen R., Chambers K., Coulter D.A., Dai M., Dimitriadis
+  G., Filippenko A.V., Foley R.J., Jha S.W., Kelsey L., Kirshner R.P., Moller
+  A., Muir J., Nadathur S., Pan Y., Rest A., Rojas-Bravo C., Sako M., Siebert
+  M.R., Smith M., Stahl B.E., Wiseman P.
+title: >-
+  The Pantheon+ Analysis: Cosmological Constraints
 article: Brout_2022
 volume: 938
 ISSN: 1538-4357


### PR DESCRIPTION
## Summary
- wrap metadata citations, authors, and titles with folded YAML blocks and line breaks
- document metadata formatting cleanup in changelog

## Testing
- `python -m yaml data/bao/bossdr12/metadata_bossdr12.yml` *(fails: No module named yaml.__main__)*
- `python - <<'PY'\nimport yaml\nfor path in ['data/bao/bossdr12/metadata_bossdr12.yml','data/bao/compound/metadata_compound.yml','data/cmb/planck2018lite/metadata_planck2018lite.yml','data/sne/jla2014/metadata_jla2014.yml','data/sne/pantheon/metadata_pantheon.yml']:\n    with open(path) as f: yaml.safe_load(f)\n    print(path, 'OK')\nPY`
- `pre-commit run --files CHANGELOG.md data/bao/bossdr12/metadata_bossdr12.yml data/bao/compound/metadata_compound.yml data/cmb/planck2018lite/metadata_planck2018lite.yml data/sne/jla2014/metadata_jla2014.yml data/sne/pantheon/metadata_pantheon.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a8ed7a398c832f8c7d9b4f7fa25c91