### PR TITLE
Use strict YAML loader for metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.3
+- 2025-08-23: Replaced ad-hoc metadata parser with strict YAML loader and
+  added tests rejecting invalid YAML (AI assistant)
+
 ## Version 3.9.2
 - 2025-08-23: Updated README version and Last Updated date (AI assistant)
 - 2025-08-22: Wrapped metadata citations with YAML folded blocks and line

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.9.2
+**Version:** 3.9.3
 **Last Updated:** 2025-08-23
 
 The Copernican Suite is a Python toolkit for testing cosmological models

--- a/copernican_lib/utils.py
+++ b/copernican_lib/utils.py
@@ -85,13 +85,12 @@ def ensure_dir_exists(directory):
 def load_metadata_from_dir(data_dir: str) -> dict:
     """Return dataset metadata from ``data_dir`` if available.
 
-    The loader looks for a file starting with ``metadata`` and ending in
-    ``.yml`` or ``.yaml``. JSON files were supported in earlier versions but
-    have been removed to keep the format consistent across the project.
-    Some legacy metadata files contain unquoted values with embedded colons,
-    e.g. URLs. ``yaml.safe_load`` rejects such scalars so a simple
-    line-by-line fallback parser is used when the strict loader fails.
+    The loader searches for a file starting with ``metadata`` and ending in
+    ``.yml`` or ``.yaml``. Metadata must be valid YAML; parse errors are
+    surfaced to the caller so that malformed files do not silently pass
+    through.
     """
+    logger = logging.getLogger(__name__)
     try:
         # fmt: off
         meta_files = [
@@ -101,30 +100,20 @@ def load_metadata_from_dir(data_dir: str) -> dict:
             and f.lower().endswith((".yml", ".yaml"))
         ]
         # fmt: on
-        if meta_files:
-            path = os.path.join(data_dir, sorted(meta_files)[0])
-            try:
-                with open(path, "r") as fh:
-                    return yaml.safe_load(fh)
-            except Exception:
-                # Fallback: parse ``key: value`` pairs manually so that
-                # unquoted URLs or other colon-containing values do not break
-                # metadata loading.
-                meta = {}
-                with open(path, "r") as fh:
-                    for line in fh:
-                        if ":" in line:
-                            key, val = line.strip().split(":", 1)
-                            meta[key.strip()] = val.strip()
-                return meta
-    except Exception as exc:
-        # Report the failure instead of silently returning an empty dict.
-        logging.getLogger(__name__).exception(
-            "copernican_lib/utils.py: failed to load metadata from %s: %s",
-            data_dir,
-            exc,
-        )
-    return {}
+    except OSError as exc:
+        logger.warning("Failed to list metadata in %s: %s", data_dir, exc)
+        raise
+
+    if not meta_files:
+        return {}
+
+    path = os.path.join(data_dir, sorted(meta_files)[0])
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("Failed to load metadata from %s: %s", path, exc)
+        raise
 
 
 def set_random_seed(seed: int = 0) -> None:

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -9,6 +9,7 @@ import pandas as pd
 import yaml
 
 from copernican_lib import data_loaders
+from copernican_lib.utils import load_metadata_from_dir
 
 
 class DataLoaderRegistryTestCase(unittest.TestCase):
@@ -72,6 +73,15 @@ class DataLoaderRegistryTestCase(unittest.TestCase):
         output = "".join(captured)
         self.assertIn("Dummy SNe", output)
         self.assertNotIn("dummy_sne", output)
+
+    def test_invalid_metadata_raises_yaml_error(self):
+        """Invalid YAML metadata should raise ``YAMLError``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = os.path.join(tmp, "metadata_bad.yml")
+            with open(bad, "w", encoding="utf-8") as fh:
+                fh.write("dataset_name: bad\nitems: [1, 2\n")
+            with self.assertRaises(yaml.YAMLError):
+                load_metadata_from_dir(tmp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace line-based metadata parsing with strict YAML loader that warns and raises on errors
- add regression test ensuring invalid YAML metadata is rejected
- bump README version and update changelog

## Testing
- `pre-commit run --files copernican_lib/utils.py tests/test_data_loaders.py README.md CHANGELOG.md`
- `python -m unittest tests/test_data_loaders.py`


------
https://chatgpt.com/codex/tasks/task_e_68a977055408832fabc1afecd97aaed0