### PR TITLE
Add license notices to start scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Version headers run newest to oldest, and within each version the newest
 entries come first):
 
 ## Version 3.9.4
+- 2025-08-23: Prepended license notices to start scripts (AI assistant)
 - 2025-08-23: Locked runtime dependencies and enforced hash-verified
   installation (AI assistant)
 

--- a/start.bat
+++ b/start.bat
@@ -1,3 +1,6 @@
+@REM Copyright (c) 2025 Copernican Suite developers.
+@REM See LICENSE.md in the repository root for details.
+
 @echo off
 REM Start the Copernican Suite on Windows.
 REM

--- a/start.command
+++ b/start.command
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 # Start the Copernican Suite on macOS.
 #
 # The script finds a Python 3 interpreter, prepares a virtual environment and

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 # Start the Copernican Suite on Unix-like systems.
 #
 # The script locates a Python 3 interpreter, creates a local virtual


### PR DESCRIPTION
## Summary
- reference LICENSE.md in start.sh, start.command, and start.bat
- log start script license headers in changelog

## Testing
- `pre-commit run --files start.sh start.command start.bat`


------
https://chatgpt.com/codex/tasks/task_e_68a98421fbac832fa641792434bdbf87