### PR TITLE
docs: refresh documentation and dependency instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,15 +98,18 @@ verify Python 3.11 or later before creating ``.venv``. If the interpreter is
 missing or outdated they print platform-specific installation commands and
 exit. Once the requirement is met the scripts run inside the repository's
 ``.venv``. If any required package is missing, the program asks before
-installing it with `pip` and verifies the import before continuing.
-Use `--yes` to bypass the prompt in non-interactive environments.
-Running outside ``.venv`` prompts the user to restart via the appropriate
-launcher.
-This lightweight approach works across Windows, macOS and Linux while allowing
-new engines to introduce additional dependencies without manual updates to the
-documentation.
-To install the suite as a package, run `pip install .` at the repository root.
-Use `pip install -e .` if you intend to develop the code.
+installing it by running `pip install --require-hashes -r requirements.lock`
+and verifies the import before continuing. Use `--yes` to bypass the prompt in
+non-interactive environments. Running outside ``.venv`` prompts the user to
+restart via the appropriate launcher. This lightweight approach works across
+Windows, macOS and Linux while allowing new engines to introduce additional
+dependencies without manual updates to the documentation.
+
+`requirements.lock` pins exact versions and SHA256 hashes for all runtime
+packages. Any dependency changes must update this file and
+`THIRD_PARTY_LICENSES.md` to keep license records current. To install the
+suite as a package, run `pip install .` at the repository root. Use
+`pip install -e .` if you intend to develop the code.
 The start scripts delete any `build/` directory before and after
 `pip install .` to prevent stale build artifacts. They recreate `.venv`
 once when the activation script is missing before suggesting installation of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ entries come first):
 - 2025-08-23: Prepended license notices to start scripts (AI assistant)
 - 2025-08-23: Locked runtime dependencies and enforced hash-verified
   installation (AI assistant)
+- 2025-08-23: Expanded documentation and updated dependency instructions
+  (AI assistant)
 
 ## Version 3.9.3
 - 2025-08-23: Replaced ad-hoc metadata parser with strict YAML loader and

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.9.3
+**Version:** 3.9.4
 **Last Updated:** 2025-08-23
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -115,13 +115,16 @@ platform-specific commands like `sudo apt install python3.11
 python3.11-venv` on Debian, `brew install python@3.11` on macOS or
 `winget install -e --id Python.Python.3.11` on Windows before exiting.
 They also verify that `.venv/bin/activate` exists and hint to install
-`python3.11-venv` when it does not.
-Inside the virtual environment this project relies on `numpy`, `scipy`,
-`matplotlib`, `pandas`, `sympy`, `jsonschema` and `camb==1.6.2`.
-If any packages are missing the program installs them automatically with
-`pip` and verifies the imports. Running outside `.venv` instructs you to
-launch via `start.*`. Future engines may also depend on `numba` or GPU
-libraries.
+`python3.11-venv` when it does not. Inside the virtual environment this
+project relies on `numpy`, `scipy`, `matplotlib`, `pandas`, `sympy`,
+`jsonschema` and `camb==1.6.2`.
+
+Versions and SHA256 hashes for all runtime dependencies are pinned in
+`requirements.lock`. When a package is missing the program asks before
+running `pip install --require-hashes -r requirements.lock` and verifies
+each import. Use `--yes` to skip the prompt in automated environments.
+Running outside `.venv` instructs you to launch via `start.*`. Future
+engines may also depend on `numba` or GPU libraries.
 
 ## Building & Installation
 Windows users should open `start.bat`, macOS users should run

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -23,8 +23,13 @@ Run the launcher in the project root:
 - `start.sh` on Linux
 
 The script verifies Python 3.11+, then creates or reuses `.venv`, upgrades
-`pip` and installs packages.
-Re-run it after pulling updates to refresh the environment.
+`pip` and installs packages from `requirements.lock` using
+`pip install --require-hashes -r requirements.lock`. Re-run it after pulling
+updates to refresh the environment.
+
+`requirements.lock` pins exact versions and SHA256 hashes for all runtime
+dependencies. Adding or updating a package requires editing this file and the
+license summary in `THIRD_PARTY_LICENSES.md`.
 
 ## Build optional distributions
 
@@ -53,7 +58,7 @@ should complete within a few seconds.
 - **No module named pip**: run `python -m ensurepip --upgrade` and relaunch
   launcher.
 - **Packages not updating**: run `pip install -U pip` followed by
-  `pip install -U -r requirements.txt`.
+  `pip install --require-hashes -r requirements.lock`.
 - **Permission denied**: avoid `sudo pip`; use a writable directory or the
   provided `.venv`.
 - **Virtual environment missing**: ensure a launcher was used or activate with


### PR DESCRIPTION
## Summary
- bump README to version 3.9.4 and describe hash-locked dependency installation via `requirements.lock`
- expand AGENTS and packaging guide with instructions for hashed dependency installs and updating third-party licenses
- document updates in the changelog

## Testing
- `pre-commit run --files README.md AGENTS.md docs/packaging.md CHANGELOG.md`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68a8ad9e2c6c832fb16c55012b9a4cb0