### PR TITLE
Use AST-based compilation for model integrals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.5
+- 2025-08-23: Replaced ``eval`` in model compilation with AST-based execution
+  and expanded tests for integral handling (AI assistant)
+
 ## Version 3.9.4
 - 2025-08-23: Prepended license notices to start scripts (AI assistant)
 - 2025-08-23: Locked runtime dependencies and enforced hash-verified

--- a/copernican_lib/model_coder.py
+++ b/copernican_lib/model_coder.py
@@ -8,6 +8,7 @@ converts equations to SymPy expressions and then compiles them into fast
 NumPy functions suitable for evaluation within the engines.
 """
 
+import ast
 import logging
 from pathlib import Path
 
@@ -77,20 +78,31 @@ def _safe_parse_expr(expr_str: str, local_dict: dict) -> sp.Expr:
 
 
 def _compile_sympy_expr(sym_expr, args):
-    """Compile a SymPy expression into a callable that evaluates
-    ``Integral`` nodes."""
+    """Return a callable for ``sym_expr`` that evaluates ``Integral`` nodes.
+
+    ``sym_expr`` is converted to a function using an AST-based compilation
+    step. This avoids the use of :func:`eval` while still allowing generated
+    code to run quickly. The executed environment exposes only ``numpy`` and
+    ``scipy.integrate.quad`` and disables builtins to guard against malicious
+    expressions.
+    """
+
     # SymPy can convert expressions directly to Python functions, but it does
-    # not evaluate ``Integral`` objects by default. When an integral is present
-    # we expand it into a call to ``scipy.integrate.quad`` so the resulting
-    # callable is fully numerical.
+    # not evaluate ``Integral`` objects by default. When an integral is
+    # present we expand it into a call to ``scipy.integrate.quad`` so the
+    # resulting callable is fully numerical.
     if sym_expr.atoms(sp.Integral):
         printer = QuadPrinter({"strict": False})
         code = printer.doprint(sym_expr)
-        lambda_src = f"lambda {', '.join(str(a) for a in args)}: {code}"
-        return eval(
-            lambda_src,
-            {"np": np, "quad": quad, "__builtins__": {}},
-        )
+        func_name = "_generated_func"
+        args_str = ", ".join(str(a) for a in args)
+        src = f"def {func_name}({args_str}):\n    return {code}"
+        module = ast.parse(src, mode="exec")
+        compiled = compile(module, filename="<model>", mode="exec")
+        env = {"np": np, "quad": quad, "__builtins__": {}}
+        exec(compiled, env)
+        return env[func_name]
+
     return sp.lambdify(args, sym_expr, [{"__builtins__": {}}, "numpy"])
 
 

--- a/tests/test_model_coder.py
+++ b/tests/test_model_coder.py
@@ -23,6 +23,14 @@ class TestModelCoderSecurity(unittest.TestCase):
         with self.assertRaises(ValueError):
             model_coder._safe_parse_expr("__import__('os')", {})
 
+    def test_compile_sympy_expr_integral_execution(self):
+        """``_compile_sympy_expr`` should handle integrals safely."""
+        z = sp.symbols("z")
+        expr = sp.Integral(z, (z, 0, 1))  # integral of z from 0 to 1 = 0.5
+        fn = model_coder._compile_sympy_expr(expr, (z,))
+        self.assertAlmostEqual(fn(0), 0.5)
+        self.assertEqual(fn.__globals__.get("__builtins__"), {})
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- Replace `eval` usage in `_compile_sympy_expr` with AST-based compilation executed in a restricted environment.
- Add regression test covering integral compilation and builtins isolation.
- Document change in changelog.

## Testing
- `pre-commit run --files copernican_lib/model_coder.py tests/test_model_coder.py CHANGELOG.md`
- `pytest tests/test_model_coder.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9b17717f4832f92051c9a0233d221