### PR TITLE
Verify parser modules against trusted hashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@ Support for additional observations such as gravitational waves and standard
 sirens is
 being prepared. Users interact with `copernican.py`, choose a model from
 `./models/`, pick a computational engine from `./engines/` and choose data
-sources. Parsers reside alongside their data. Results are saved under
-`./output/`. Each plot carries a centered footer with three lines: the
+sources. Parsers reside alongside their data but are imported only when their
+SHA256 digest matches a vetted list to block untrusted files. Results are saved
+under `./output/`. Each plot carries a centered footer with three lines: the
 model comparison, dataset details and the citation. The first and third
 lines are bold, while the dataset name on the second line is bolded
 using Matplotlib's standard text rendering. Dataset names retain their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.7
+- 2025-08-23: Normalized parser path separators so trusted hashes work on all
+  platforms (AI assistant)
+
+## Version 3.9.6
+- 2025-08-23: Verified parser modules against trusted hashes and skipped
+  untrusted files (AI assistant)
+
 ## Version 3.9.5
 - 2025-08-23: Replaced ``eval`` in model compilation with AST-based execution
   and expanded tests for integral handling (AI assistant)

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Under the hood the program follows a clear pipeline:
   additional fit parameters so CMB spectra can be matched precisely. Data
 parsers are discovered automatically under
   `data/<type>/<source>` and models are loaded from `cosmo_model_*.yml`.
-  Folders named `placeholder` are ignored so unfinished datasets do not appear
-  in the selection menus.
+  Only parser modules whose SHA256 digest matches a vetted list are imported,
+  ensuring untrusted files are ignored. Folders named `placeholder` are
+  ignored so unfinished datasets do not appear in the selection menus.
 4. **Parameter Fitting** – depending on the chosen engine either a pure
    SNe fit is performed or a combined optimisation over all datasets.  For
    the combined engine this optimisation begins with the SNe refinement

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -11,6 +11,7 @@ themselves through decorators provided here.  At runtime
 returns uniformly formatted :class:`pandas.DataFrame` objects with metadata
 stored on ``.attrs``.
 """
+import hashlib
 import importlib
 import logging
 import os
@@ -146,17 +147,57 @@ def register_siren_parser(name=None, description="", data_dir=None):
     return decorator
 
 
+TRUSTED_PARSER_HASHES = {
+    # ``relative_path`` -> ``sha256``
+    "sne/pantheon/cosmo_parser_pantheon.py": (
+        "5fd4f60499129dc4a0468712bc29364f717bc7fa3442021bb7691cf6fc98233d"
+    ),
+    "sne/jla2014/cosmo_parser_jla2014.py": (
+        "27b553519fa4545153c675f82141be2e2ed35a69b91ce5d72b0add794fb25339"
+    ),
+    "bao/bossdr12/cosmo_parser_bossdr12.py": (
+        "4de5b07156d65e4e075810745c6b61cf8b7f10f0e4c575be9d6d16ebbfcf37b8"
+    ),
+    "bao/compound/cosmo_parser_compound.py": (
+        "0faa58a29b2c809054d48130cce78adeebafd8d92b0bb40616b2bcc88c782712"
+    ),
+    "cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py": (
+        "ccd9f8173b38ea9d8fcf458ea638086efd2ac8cfb300a4b9ece84342fa69f296"
+    ),
+    "gw/placeholder/cosmo_parser_gw_placeholder.py": (
+        "10d0159cdd879a74324c852be92e877308b949ff0375c9e9609da3a95c0fe3e2"
+    ),
+    "sirens/placeholder/cosmo_parser_sirens_placeholder.py": (
+        "816f2624ff8452ae7fd41c138fcc73b5a5272117d931aae342c9eee6246d3f58"
+    ),
+}
+
+
+def _file_sha256(path: str) -> str:
+    """Return the SHA256 digest for ``path``."""
+    hasher = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
 # --- Dynamic Discovery of Parser Modules ---
-def _discover_parsers():
+def _discover_parsers(base_dir: str | None = None):
     """Import parser modules and populate registries with dataset metadata.
 
-    The scan walks ``data/`` recursively, ignoring ``placeholder`` folders
-    so unfinished datasets stay hidden.  Parser modules are imported on the
-    fly, allowing them to register with the decorators above.  Metadata is
-    read here to keep the parser implementations small and focused solely on
-    table parsing.
+    The scan walks ``data/`` recursively, ignoring ``placeholder`` folders so
+    unfinished datasets stay hidden.  Each candidate parser is verified against
+    ``TRUSTED_PARSER_HASHES`` before import to guard against tampering.  Only
+    trusted modules are executed, keeping the discovery step resilient to
+    untrusted files shipped alongside the data tables.
+    Metadata is read here to keep the parser implementations small and focused
+    solely on table parsing.
     """
-    base_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
+    if base_dir is None:
+        base_dir = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "data"
+        )
     registry_map = {
         "sne": SNE_PARSERS,
         "bao": BAO_PARSERS,
@@ -190,16 +231,43 @@ def _discover_parsers():
                 if fname.startswith("cosmo_parser_") and fname.endswith(".py"):
                     module_name = f"data.{dtype}.{source}.{fname[:-3]}"
                     file_path = os.path.join(src_dir, fname)
+                    rel_path = os.path.relpath(file_path, base_dir)
+                    # Normalise path separators
+                    # for cross-platform hash lookup.
+                    rel_path = rel_path.replace("\\", "/")
+                    expected_hash = TRUSTED_PARSER_HASHES.get(rel_path)
+                    if expected_hash is None:
+                        logging.getLogger().warning(
+                            "Skipping untrusted parser %s", file_path
+                        )
+                        continue
+                    actual_hash = _file_sha256(file_path)
+                    if actual_hash != expected_hash:
+                        logging.getLogger().error(
+                            "Hash mismatch for parser %s; expected %s but "
+                            "got %s",
+                            file_path,
+                            expected_hash,
+                            actual_hash,
+                        )
+                        continue
                     spec = importlib.util.spec_from_file_location(
                         module_name,
                         file_path,
                     )
-                    module = importlib.util.module_from_spec(spec)
-                    try:
-                        spec.loader.exec_module(module)
-                    except Exception as e:
+                    if spec and spec.loader:
+                        module = importlib.util.module_from_spec(spec)
+                        try:
+                            spec.loader.exec_module(module)
+                        except Exception as e:
+                            logging.getLogger().error(
+                                "Failed loading parser module %s: %s",
+                                file_path,
+                                e,
+                            )
+                    else:
                         logging.getLogger().error(
-                            f"Failed loading parser module {file_path}: {e}",
+                            "Missing loader for parser module %s", file_path
                         )
                     registry = registry_map[dtype]
                     key = None

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -52,6 +52,91 @@ class DataLoaderRegistryTestCase(unittest.TestCase):
         finally:
             data_loaders.SNE_PARSERS = prev
 
+    def test_hash_mismatch_skips_parser(self):
+        """Hash mismatches prevent parser import."""
+        prev_parsers = data_loaders.SNE_PARSERS.copy()
+        prev_hashes = data_loaders.TRUSTED_PARSER_HASHES.copy()
+        try:
+            with tempfile.TemporaryDirectory() as base:
+                sne_dir = os.path.join(base, "sne", "rogue2")
+                os.makedirs(sne_dir)
+                meta = {
+                    "dataset_name": "Rogue2 SNe",
+                    "dataset_id": "rogue2_sne",
+                }
+                with open(
+                    os.path.join(sne_dir, "metadata_dummy.yml"),
+                    "w",
+                    encoding="utf-8",
+                ) as fh:
+                    yaml.safe_dump(meta, fh)
+                parser_path = os.path.join(sne_dir, "cosmo_parser_rogue2.py")
+                code = (
+                    "from copernican_lib.data_loaders "
+                    "import register_sne_parser\n"
+                    "@register_sne_parser(name='rogue2_sne', data_dir=r'"
+                    + sne_dir
+                    + "')\n"
+                    "def load(_dir, **_kwargs):\n"
+                    "    return None\n"
+                )
+                with open(parser_path, "w", encoding="utf-8") as fh:
+                    fh.write(code)
+                rel_path = os.path.relpath(parser_path, base)
+                data_loaders.TRUSTED_PARSER_HASHES[rel_path] = "0" * 64
+                data_loaders.SNE_PARSERS = {}
+                data_loaders._discover_parsers(base_dir=base)
+                self.assertNotIn("rogue2_sne", data_loaders.SNE_PARSERS)
+        finally:
+            data_loaders.SNE_PARSERS = prev_parsers
+            data_loaders.TRUSTED_PARSER_HASHES = prev_hashes
+
+    def test_windows_separators_are_normalized(self):
+        """Trusted modules load even when ``relpath`` returns backslashes."""
+        prev_parsers = data_loaders.SNE_PARSERS.copy()
+        prev_hashes = data_loaders.TRUSTED_PARSER_HASHES.copy()
+        try:
+            with tempfile.TemporaryDirectory() as base:
+                sne_dir = os.path.join(base, "sne", "trusted")
+                os.makedirs(sne_dir)
+                meta = {
+                    "dataset_name": "Trusted SNe",
+                    "dataset_id": "trusted_sne",
+                }
+                with open(
+                    os.path.join(sne_dir, "metadata_dummy.yml"),
+                    "w",
+                    encoding="utf-8",
+                ) as fh:
+                    yaml.safe_dump(meta, fh)
+                parser_path = os.path.join(sne_dir, "cosmo_parser_trusted.py")
+                code = (
+                    "from copernican_lib.data_loaders "
+                    "import register_sne_parser\n"
+                    "@register_sne_parser(name='trusted_sne', data_dir=r'"
+                    + sne_dir
+                    + "')\n"
+                    "def load(_dir, **_kwargs):\n"
+                    "    return None\n"
+                )
+                with open(parser_path, "w", encoding="utf-8") as fh:
+                    fh.write(code)
+                rel_key = os.path.relpath(parser_path, base).replace("\\", "/")
+                digest = data_loaders._file_sha256(parser_path)
+                data_loaders.TRUSTED_PARSER_HASHES[rel_key] = digest
+                data_loaders.SNE_PARSERS = {}
+                orig_relpath = os.path.relpath
+
+                def fake_relpath(path, start):
+                    return orig_relpath(path, start).replace("/", "\\")
+
+                with mock.patch("os.path.relpath", side_effect=fake_relpath):
+                    data_loaders._discover_parsers(base_dir=base)
+                self.assertIn("trusted_sne", data_loaders.SNE_PARSERS)
+        finally:
+            data_loaders.SNE_PARSERS = prev_parsers
+            data_loaders.TRUSTED_PARSER_HASHES = prev_hashes
+
     @mock.patch("copernican_lib.data_loaders.console.ask", return_value="1")
     def test_select_source_uses_dataset_name(self, ask_mock):
         """Interactive selection should display names and return the id."""
@@ -82,6 +167,41 @@ class DataLoaderRegistryTestCase(unittest.TestCase):
                 fh.write("dataset_name: bad\nitems: [1, 2\n")
             with self.assertRaises(yaml.YAMLError):
                 load_metadata_from_dir(tmp)
+
+    def test_untrusted_parser_is_skipped(self):
+        """Modules not whitelisted should never be imported."""
+        prev = data_loaders.SNE_PARSERS.copy()
+        try:
+            with tempfile.TemporaryDirectory() as base:
+                sne_dir = os.path.join(base, "sne", "rogue")
+                os.makedirs(sne_dir)
+                meta = {
+                    "dataset_name": "Rogue SNe",
+                    "dataset_id": "rogue_sne",
+                }
+                with open(
+                    os.path.join(sne_dir, "metadata_dummy.yml"),
+                    "w",
+                    encoding="utf-8",
+                ) as fh:
+                    yaml.safe_dump(meta, fh)
+                parser_path = os.path.join(sne_dir, "cosmo_parser_rogue.py")
+                code = (
+                    "from copernican_lib.data_loaders "
+                    "import register_sne_parser\n"
+                    "@register_sne_parser(name='rogue_sne', data_dir=r'"
+                    + sne_dir
+                    + "')\n"
+                    "def load(_dir, **_kwargs):\n"
+                    "    return None\n"
+                )
+                with open(parser_path, "w", encoding="utf-8") as fh:
+                    fh.write(code)
+                data_loaders.SNE_PARSERS = {}
+                data_loaders._discover_parsers(base_dir=base)
+                self.assertNotIn("rogue_sne", data_loaders.SNE_PARSERS)
+        finally:
+            data_loaders.SNE_PARSERS = prev
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Validate parser modules against a whitelist of SHA256 digests before import to block tampered files
- Normalize parser path separators so trusted hashes resolve on all platforms and add a test for Windows-style paths
- Document trusted parser requirement and note in changelog

## Testing
- `pre-commit run --files copernican_lib/data_loaders.py tests/test_data_loaders.py CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68a9b349f154832f846560c621784ed6