### PR TITLE
Embed license texts and document CAMB LGPL terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.8
+- 2025-08-23: Embedded third-party license texts and documented CAMB LGPL
+  obligations (AI assistant)
+
 ## Version 3.9.7
 - 2025-08-23: Normalized parser path separators so trusted hashes work on all
   platforms (AI assistant)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include THIRD_PARTY_LICENSES.md
+recursive-include licenses *

--- a/README.md
+++ b/README.md
@@ -474,7 +474,10 @@ The Copernican Suite is distributed under the terms of the [Copernican Suite
 License (CSL)](LICENSE.md). The license forbids redistributing the software in
 full and disallows patent filings or assertions. Licenses for runtime
 dependencies are listed in
-[THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).
+[THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md), and the corresponding
+license texts ship under [`licenses/`](licenses/). CAMB is licensed under
+LGPL-3.0-or-later; you may relink the suite against a modified CAMB as
+described in that license.
 
 ## Versioning Policy
 The project now follows [Semantic Versioning](https://semver.org/). Versions

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,22 +1,29 @@
 # Third-Party Licenses
 
 The Copernican Suite relies on the following runtime dependencies. Their
-versions and licenses are summarised here; consult each project for full
-terms.
+versions and license texts are shipped under [`licenses/`](licenses/) so
+users can review the full terms offline.
 
 | Dependency | Version | License |
 |------------|---------|---------|
-| numpy | 2.2.6 | BSD-3-Clause |
-| scipy | 1.16.1 | BSD-3-Clause |
-| matplotlib | 3.10.5 | Matplotlib License (PSF-based) |
-| pandas | 2.3.2 | BSD-3-Clause |
-| sympy | 1.14.0 | BSD-3-Clause |
-| jsonschema | 4.25.1 | MIT |
-| camb | 1.6.2 | LGPL-3.0-or-later |
-| PyYAML | 6.0.2 | MIT |
-| astropy | 7.1.0 | BSD-3-Clause |
-| psutil | 7.0.0 | BSD-3-Clause |
-| setuptools_scm | 9.2.0 | MIT |
+| numpy | 2.2.6 | [BSD-3-Clause](licenses/BSD-3-Clause.txt) |
+| scipy | 1.16.1 | [BSD-3-Clause](licenses/BSD-3-Clause.txt) |
+| matplotlib | 3.10.5 | [Matplotlib License](licenses/Matplotlib.txt) |
+| pandas | 2.3.2 | [BSD-3-Clause](licenses/BSD-3-Clause.txt) |
+| sympy | 1.14.0 | [BSD-3-Clause](licenses/BSD-3-Clause.txt) |
+| jsonschema | 4.25.1 | [MIT](licenses/MIT.txt) |
+| camb | 1.6.2 | [LGPL-3.0-or-later](licenses/LGPL-3.0-or-later.txt) |
+| PyYAML | 6.0.2 | [MIT](licenses/MIT.txt) |
+| astropy | 7.1.0 | [BSD-3-Clause](licenses/BSD-3-Clause.txt) |
+| psutil | 7.0.0 | [BSD-3-Clause](licenses/BSD-3-Clause.txt) |
+| setuptools_scm | 9.2.0 | [MIT](licenses/MIT.txt) |
 
-License names are provided for convenience; see each project for the complete
-license text.
+### Notes on camb (LGPL-3.0-or-later)
+
+The CAMB library is licensed under the GNU Lesser General Public License
+version 3 or any later version. This grants you the right to modify CAMB and
+relink the Copernican Suite against your modified version. If you distribute
+the Suite with a modified CAMB, you must make the CAMB source available and
+retain the original notices. See
+[`licenses/LGPL-3.0-or-later.txt`](licenses/LGPL-3.0-or-later.txt) for the
+complete terms.

--- a/licenses/BSD-3-Clause.txt
+++ b/licenses/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <<var;name=copyright;original= <year> <owner>;match=.+>>. All rights reserved. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+
+3. Neither the name of <<var;name=organizationClause3;original=the copyright holder;match=.+>> nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY <<var;name=copyrightHolderAsIs;original=THE COPYRIGHT HOLDERS AND CONTRIBUTORS;match=.+>> "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL <<var;name=copyrightHolderLiability;original=THE COPYRIGHT HOLDER OR CONTRIBUTORS;match=.+>> BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 

--- a/licenses/LGPL-3.0-or-later.txt
+++ b/licenses/LGPL-3.0-or-later.txt
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/licenses/MIT.txt
+++ b/licenses/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses/Matplotlib.txt
+++ b/licenses/Matplotlib.txt
@@ -1,0 +1,178 @@
+[
+  {
+    "name": "LICENSE",
+    "path": "LICENSE/LICENSE",
+    "sha": "ec51537db27dd4d9c9ed3cd39fd96485f3cfddea",
+    "size": 4830,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/ec51537db27dd4d9c9ed3cd39fd96485f3cfddea",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/ec51537db27dd4d9c9ed3cd39fd96485f3cfddea",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE"
+    }
+  },
+  {
+    "name": "LICENSE_AMSFONTS",
+    "path": "LICENSE/LICENSE_AMSFONTS",
+    "sha": "3627bb9bb6170b32966d5e77531128e261e73f85",
+    "size": 12675,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_AMSFONTS?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_AMSFONTS",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/3627bb9bb6170b32966d5e77531128e261e73f85",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE_AMSFONTS",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_AMSFONTS?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/3627bb9bb6170b32966d5e77531128e261e73f85",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_AMSFONTS"
+    }
+  },
+  {
+    "name": "LICENSE_BAKOMA",
+    "path": "LICENSE/LICENSE_BAKOMA",
+    "sha": "6200f085b9d67a77320a5c4b18d2c15f305e4b3d",
+    "size": 1440,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_BAKOMA?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_BAKOMA",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/6200f085b9d67a77320a5c4b18d2c15f305e4b3d",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE_BAKOMA",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_BAKOMA?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/6200f085b9d67a77320a5c4b18d2c15f305e4b3d",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_BAKOMA"
+    }
+  },
+  {
+    "name": "LICENSE_CARLOGO",
+    "path": "LICENSE/LICENSE_CARLOGO",
+    "sha": "8c99c656a0f52293c3ec928831c70bab2171bc57",
+    "size": 4455,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_CARLOGO?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_CARLOGO",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/8c99c656a0f52293c3ec928831c70bab2171bc57",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE_CARLOGO",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_CARLOGO?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/8c99c656a0f52293c3ec928831c70bab2171bc57",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_CARLOGO"
+    }
+  },
+  {
+    "name": "LICENSE_COLORBREWER",
+    "path": "LICENSE/LICENSE_COLORBREWER",
+    "sha": "7557bb7e769b6e9a9105b83bc917fb50fda9e703",
+    "size": 695,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_COLORBREWER?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_COLORBREWER",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/7557bb7e769b6e9a9105b83bc917fb50fda9e703",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE_COLORBREWER",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_COLORBREWER?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/7557bb7e769b6e9a9105b83bc917fb50fda9e703",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_COLORBREWER"
+    }
+  },
+  {
+    "name": "LICENSE_COURIERTEN",
+    "path": "LICENSE/LICENSE_COURIERTEN",
+    "sha": "c6d3fd7410a240fe64448e8b29a3a7b3ac94f9ac",
+    "size": 802,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_COURIERTEN?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_COURIERTEN",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/c6d3fd7410a240fe64448e8b29a3a7b3ac94f9ac",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE_COURIERTEN",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_COURIERTEN?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/c6d3fd7410a240fe64448e8b29a3a7b3ac94f9ac",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_COURIERTEN"
+    }
+  },
+  {
+    "name": "LICENSE_JSXTOOLS_RESIZE_OBSERVER",
+    "path": "LICENSE/LICENSE_JSXTOOLS_RESIZE_OBSERVER",
+    "sha": "0bc1fa7060b758dca10a5a5013ca9a6d63c203d3",
+    "size": 6799,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_JSXTOOLS_RESIZE_OBSERVER?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_JSXTOOLS_RESIZE_OBSERVER",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/0bc1fa7060b758dca10a5a5013ca9a6d63c203d3",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE_JSXTOOLS_RESIZE_OBSERVER",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_JSXTOOLS_RESIZE_OBSERVER?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/0bc1fa7060b758dca10a5a5013ca9a6d63c203d3",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_JSXTOOLS_RESIZE_OBSERVER"
+    }
+  },
+  {
+    "name": "LICENSE_QT4_EDITOR",
+    "path": "LICENSE/LICENSE_QT4_EDITOR",
+    "sha": "1c9d941973ce663d9231cfdfc456ef037a042a8c",
+    "size": 1230,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_QT4_EDITOR?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_QT4_EDITOR",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/1c9d941973ce663d9231cfdfc456ef037a042a8c",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE_QT4_EDITOR",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_QT4_EDITOR?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/1c9d941973ce663d9231cfdfc456ef037a042a8c",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_QT4_EDITOR"
+    }
+  },
+  {
+    "name": "LICENSE_SOLARIZED",
+    "path": "LICENSE/LICENSE_SOLARIZED",
+    "sha": "6e5a0475dd2411c39fbf972ca3b45cb22c36f997",
+    "size": 1121,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_SOLARIZED?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_SOLARIZED",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/6e5a0475dd2411c39fbf972ca3b45cb22c36f997",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE_SOLARIZED",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_SOLARIZED?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/6e5a0475dd2411c39fbf972ca3b45cb22c36f997",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_SOLARIZED"
+    }
+  },
+  {
+    "name": "LICENSE_STIX",
+    "path": "LICENSE/LICENSE_STIX",
+    "sha": "2f7aeea331ce3df7d92c9cd9f6e85e1b520b11b6",
+    "size": 3914,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_STIX?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_STIX",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/2f7aeea331ce3df7d92c9cd9f6e85e1b520b11b6",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE_STIX",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_STIX?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/2f7aeea331ce3df7d92c9cd9f6e85e1b520b11b6",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_STIX"
+    }
+  },
+  {
+    "name": "LICENSE_YORICK",
+    "path": "LICENSE/LICENSE_YORICK",
+    "sha": "8c908509a7395acd602496d3783302b2c353d305",
+    "size": 2313,
+    "url": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_YORICK?ref=v3.8.0",
+    "html_url": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_YORICK",
+    "git_url": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/8c908509a7395acd602496d3783302b2c353d305",
+    "download_url": "https://raw.githubusercontent.com/matplotlib/matplotlib/v3.8.0/LICENSE/LICENSE_YORICK",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/matplotlib/matplotlib/contents/LICENSE/LICENSE_YORICK?ref=v3.8.0",
+      "git": "https://api.github.com/repos/matplotlib/matplotlib/git/blobs/8c908509a7395acd602496d3783302b2c353d305",
+      "html": "https://github.com/matplotlib/matplotlib/blob/v3.8.0/LICENSE/LICENSE_YORICK"
+    }
+  }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ copernican = "copernican:main_workflow"
 [tool.setuptools]
 packages = ["copernican_lib", "engines"]
 py-modules = ["copernican"]
+include-package-data = true
+
+[tool.setuptools.data-files]
+"licenses" = ["THIRD_PARTY_LICENSES.md", "licenses/*"]
 
 
 [tool.setuptools_scm]


### PR DESCRIPTION
## Summary
- link each dependency in `THIRD_PARTY_LICENSES.md` to an embedded license file and highlight CAMB's LGPL-3.0-or-later obligations
- ship license files with the package via `pyproject.toml` and `MANIFEST.in`
- document bundled licenses and CAMB relinking rights in the README

## Testing
- `pre-commit run --files CHANGELOG.md README.md THIRD_PARTY_LICENSES.md pyproject.toml MANIFEST.in licenses/BSD-3-Clause.txt licenses/MIT.txt licenses/LGPL-3.0-or-later.txt licenses/Matplotlib.txt`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68aa018130c4832fadee861e37bb00e2