### PR TITLE
Install hashed dependencies before package setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,10 @@ dependencies without manual updates to the documentation.
 packages. Any dependency changes must update this file and
 `THIRD_PARTY_LICENSES.md` to keep license records current. To install the
 suite as a package, run `pip install .` at the repository root. Use
-`pip install -e .` if you intend to develop the code.
-The start scripts delete any `build/` directory before and after
-`pip install .` to prevent stale build artifacts. They recreate `.venv`
+`pip install -e .` if you intend to develop the code. The start scripts
+install pinned dependencies from `requirements.lock` using hash verification
+before running `pip install .`. They delete any `build/` directory before and
+after `pip install .` to prevent stale build artifacts. They recreate `.venv`
 once when the activation script is missing before suggesting installation of
 `python3.11-venv`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.9
+- 2025-08-23: start.sh installs dependencies with hash verification before
+  package installation (AI assistant)
+
 ## Version 3.9.8
 - 2025-08-23: Added CITATION.cff and referenced it from README (AI assistant)
 - 2025-08-23: Embedded third-party license texts and documented CAMB LGPL

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.9.4
+**Version:** 3.9.9
 **Last Updated:** 2025-08-23
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -89,15 +89,15 @@ parsers are discovered automatically under
 1. Run the platform-specific `start` script. macOS users should run
    `./start.command`, Windows users open `start.bat`, and Linux users can
    execute `./start.sh`. The launcher verifies Python 3.11+ before
-   creating a `.venv`, upgrading `pip` and installing the project
-   automatically. It deletes any `build/` directory before and after
-   `pip install .` to avoid stale artifacts. If the interpreter is missing
-   or too old it prints
-   install tips such as `sudo apt install python3.11 python3.11-venv` on
-   Debian, `brew install python@3.11` on macOS or `winget install -e --id
-   Python.Python.3.11` on Windows before exiting.
-   If the activation script is missing the launcher recreates `.venv` once
-   before advising the user to install `python3.11-venv`.
+   creating a `.venv`, upgrading `pip`, installing locked dependencies with
+   hash verification and installing the project automatically. It deletes
+   any `build/` directory before and after `pip install .` to avoid stale
+   artifacts. If the interpreter is missing or too old it prints install
+   tips such as `sudo apt install python3.11 python3.11-venv` on Debian,
+   `brew install python@3.11` on macOS or `winget install -e --id
+   Python.Python.3.11` on Windows before exiting. If the activation script
+   is missing the launcher recreates `.venv` once before advising the user
+   to install `python3.11-venv`.
 2. Follow the interactive prompts to choose a model, preferred data sources
    and
    computation engine.

--- a/start.sh
+++ b/start.sh
@@ -68,11 +68,14 @@ if [ ! -f ".venv/bin/activate" ]; then
     fi
 fi
 
-# Activate the environment, upgrade pip, install the project and restart the
-# script. Delete any 'build/' directory before and after 'pip install .'
-# to avoid stale build artifacts.
+# Activate the environment, upgrade pip, install dependencies with hash
+# verification, install the project and restart the script. Delete any
+# 'build/' directory before and after 'pip install .' to avoid stale build
+# artifacts.
 source .venv/bin/activate
 python -m pip install --upgrade pip
+# Install pinned dependencies to ensure reproducible environments.
+python -m pip install --require-hashes -r requirements.lock
 rm -rf build
 python -m pip install .
 rm -rf build


### PR DESCRIPTION
## Summary
- ensure `start.sh` installs pinned dependencies from `requirements.lock` with hash verification before installing the project
- document hashed dependency installation in README and developer guide
- log change in changelog

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md README.md start.sh`
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_68aa067baf14832f97821679b9a08092