### PR TITLE
Pin dependency versions and document lockfile sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,8 @@ Windows, macOS and Linux while allowing new engines to introduce additional
 dependencies without manual updates to the documentation.
 
 `requirements.lock` pins exact versions and SHA256 hashes for all runtime
-packages. Any dependency changes must update this file and
+packages, and `[project].dependencies` in `pyproject.toml` mirrors these pins.
+Any dependency change must regenerate both files and update
 `THIRD_PARTY_LICENSES.md` to keep license records current. To install the
 suite as a package, run `pip install .` at the repository root. Use
 `pip install -e .` if you intend to develop the code. The start scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.10
+- 2025-08-23: Pinned pyproject dependencies to requirements.lock and
+  documented joint regeneration (AI assistant)
+
 ## Version 3.9.9
 - 2025-08-23: start.sh installs dependencies with hash verification before
   package installation (AI assistant)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Versions and SHA256 hashes for all runtime dependencies are pinned in
 `requirements.lock`. When a package is missing the program asks before
 running `pip install --require-hashes -r requirements.lock` and verifies
 each import. Use `--yes` to skip the prompt in automated environments.
+The same versions appear under `[project].dependencies` in `pyproject.toml`.
+Regenerate both files together whenever dependencies change.
 Running outside `.venv` instructs you to launch via `start.*`. Future
 engines may also depend on `numba` or GPU libraries.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,17 +10,18 @@ authors = [{name = "Copernican Developers"}]
 license = {file = "LICENSE.md"}
 requires-python = ">=3.11"
 dependencies = [
-    "numpy",
-    "scipy",
-    "matplotlib",
-    "pandas",
-    "sympy",
-    "jsonschema",
+    # Keep versions in sync with requirements.lock.
+    "numpy==2.2.6",
+    "scipy==1.16.1",
+    "matplotlib==3.10.5",
+    "pandas==2.3.2",
+    "sympy==1.14.0",
+    "jsonschema==4.25.1",
     "camb==1.6.2", # pin to ensure Python 3.11 wheels
-    "PyYAML",
-    "astropy",
-    "psutil",
-    "setuptools_scm",
+    "PyYAML==6.0.2",
+    "astropy==7.1.0",
+    "psutil==7.0.0",
+    "setuptools_scm==9.2.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- pin `[project].dependencies` to the exact versions listed in `requirements.lock`
- note in the guide and README that `pyproject.toml` and `requirements.lock` must be regenerated together when dependencies change
- record change in the changelog

## Testing
- `pre-commit run --files pyproject.toml AGENTS.md README.md CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68aa2c477190832fb4218349d153bbb9