### PR TITLE
Enable linting for dataset parsers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,22 +4,18 @@ repos:
     hooks:
       - id: black
         args: [--line-length, "79"]
-        exclude: ^data/
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
         args: [--profile, black, --line-length, "79"]
-        exclude: ^data/
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --line-length, "79"]
-        exclude: ^data/
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:
       - id: flake8
         args: [--max-line-length=79]
-        exclude: ^data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.11
+- 2025-08-23: Linted dataset parsers and removed data exclusion from
+  pre-commit (AI assistant)
+
 ## Version 3.9.10
 - 2025-08-23: Pinned pyproject dependencies to requirements.lock and
   documented joint regeneration (AI assistant)
@@ -66,7 +70,8 @@ entries come first):
   AST-based evaluator and added malicious expression tests (AI assistant)
 
 ## Version 3.9.0
-- 2025-08-22: Documented third-party licenses and linked from README (AI assistant)
+- 2025-08-22: Documented third-party licenses and linked from README
+  (AI assistant)
 - 2025-08-22: Added LICENSE.md references to module headers (AI assistant)
 - 2025-08-22: Prompted before installing dependencies and added `--yes` flag
   for CI automation (AI assistant)

--- a/data/bao/compound/cosmo_parser_compound.py
+++ b/data/bao/compound/cosmo_parser_compound.py
@@ -34,7 +34,8 @@ def parse_bao_v1(data_dir, **kwargs):
     data_files = [
         f
         for f in os.listdir(data_dir)
-        if f.lower().endswith((".yml", ".yaml")) and not f.startswith("metadata")
+        if f.lower().endswith((".yml", ".yaml"))
+        and not f.startswith("metadata")
     ]
     if not data_files:
         logger.error(f"No BAO data file found in {data_dir}.")

--- a/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
+++ b/data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py
@@ -83,15 +83,22 @@ def parse_planck2018lite(data_dir, **kwargs):
                 return None
             header_le = np.frombuffer(hdr_bytes, dtype="<i4")[0]
             header_be = np.frombuffer(hdr_bytes, dtype=">i4")[0]
-            if header_le > 0 and int(np.sqrt(header_le / 8)) ** 2 * 8 == header_le:
+            if (
+                header_le > 0
+                and int(np.sqrt(header_le / 8)) ** 2 * 8 == header_le
+            ):
                 endian = "<"
                 header = header_le
-            elif header_be > 0 and int(np.sqrt(header_be / 8)) ** 2 * 8 == header_be:
+            elif (
+                header_be > 0
+                and int(np.sqrt(header_be / 8)) ** 2 * 8 == header_be
+            ):
                 endian = ">"
                 header = header_be
             else:
                 logger.error(
-                    "Planck2018lite covariance matrix header mismatch or " "size error."
+                    "Planck2018lite covariance matrix header mismatch or "
+                    "size error."
                 )
                 return None
             n_full = int(np.sqrt(header / 8))
@@ -122,7 +129,8 @@ def parse_planck2018lite(data_dir, **kwargs):
             # Check for NaNs or infinities after inversion
             if not np.all(np.isfinite(cov_inv)):
                 raise ValueError(
-                    "Inverted Planck2018lite covariance contains non-finite " "values."
+                    "Inverted Planck2018lite covariance contains non-finite "
+                    "values."
                 )
 
             cond_num = np.linalg.cond(cov_matrix)

--- a/data/gw/placeholder/cosmo_parser_gw_placeholder.py
+++ b/data/gw/placeholder/cosmo_parser_gw_placeholder.py
@@ -18,6 +18,7 @@ def parse_gw_placeholder(data_dir, **kwargs):
     # the rest of the framework to run even though no real data is parsed yet.
     logger = logging.getLogger()
     logger.info(
-        f"GW parser placeholder invoked in {data_dir}. " "Feature not implemented."
+        "GW parser placeholder invoked in %s. " "Feature not implemented.",
+        data_dir,
     )
     return None

--- a/data/sne/pantheon/cosmo_parser_pantheon.py
+++ b/data/sne/pantheon/cosmo_parser_pantheon.py
@@ -28,7 +28,9 @@ def parse_pantheon_plus(data_dir, **kwargs):
         logger.error("Pantheon+ directory must contain .dat and .cov files")
         return None
     if len(dat_files) > 1 or len(cov_files) > 1:
-        logger.warning("Multiple data/covariance files found; using first match")
+        logger.warning(
+            "Multiple data/covariance files found; using first match"
+        )
     filepath = os.path.join(data_dir, sorted(dat_files)[0])
     cov_filepath = os.path.join(data_dir, sorted(cov_files)[0])
 
@@ -67,7 +69,9 @@ def parse_pantheon_plus(data_dir, **kwargs):
         if "Name" not in data_df:
             data_df["Name"] = temp_df.get(
                 "CID",
-                pd.Series([f"SN_PPlus_mucov_{i}" for i in range(len(temp_df))]),
+                pd.Series(
+                    [f"SN_PPlus_mucov_{i}" for i in range(len(temp_df))]
+                ),
             )
         data_df["Name"] = data_df["Name"].astype(str).str.strip()
 
@@ -81,7 +85,8 @@ def parse_pantheon_plus(data_dir, **kwargs):
             for col in essential_cols
         ):
             logger.error(
-                "One or more essential columns missing/all NaN in Pantheon+ " "data."
+                "One or more essential columns missing/all NaN in Pantheon+ "
+                "data."
             )
             return None
 
@@ -133,7 +138,9 @@ def parse_pantheon_plus(data_dir, **kwargs):
                 "Chi2 will fallback to diagonal errors."
             )
             output_df.attrs["covariance_matrix_inv"] = None
-            output_df.attrs["diag_errors_for_plot"] = output_df["e_mu_obs"].values
+            output_df.attrs["diag_errors_for_plot"] = output_df[
+                "e_mu_obs"
+            ].values
         # Metadata such as dataset name and citation is attached later by the
         # loader. Only the numerical data and covariance information are
         # handled here.


### PR DESCRIPTION
## Summary
- remove `^data/` exclusions so dataset parsers run through pre-commit hooks
- wrap dataset parser lines at 79 characters for readability

## Testing
- `pre-commit run --files .pre-commit-config.yaml CHANGELOG.md data/bao/compound/cosmo_parser_compound.py data/gw/placeholder/cosmo_parser_gw_placeholder.py data/cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py data/sne/pantheon/cosmo_parser_pantheon.py`
- `pre-commit run --files CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68aa2dfe299c832faff6c25b6d714e42