### PR TITLE
feat: tighten start script error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.13
+- 2025-08-23: start.sh exits on unset variables for stricter error handling (AI assistant)
+
 ## Version 3.9.12
 - 2025-08-23: Added security test ensuring rogue parsers are ignored (AI assistant)
 

--- a/start.sh
+++ b/start.sh
@@ -8,7 +8,9 @@
 # environment if needed, installs the project and re-executes itself inside
 # that environment. Subsequent runs reuse the cached dependencies.
 
-set -e
+# Abort on errors and on references to unset variables to guard against
+# mistyped names.
+set -eu
 # Resolve absolute path to this script before changing directories.
 SCRIPT="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 cd "$(dirname "$0")"


### PR DESCRIPTION
## Summary
- abort start.sh on unset variables for stricter error handling
- document new behavior in changelog

## Testing
- `pre-commit run --files start.sh CHANGELOG.md`
- `VIRTUAL_ENV=test ./start.sh -h`
- `VIRTUAL_ENV=test ./start.command -h`
- `bash -n start.sh`
- `bash -n start.command`
- `./start.bat` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68aa30a5fee4832fb549038649ade87c