### PR TITLE
docs: enforce documentation refresh policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,9 +203,10 @@ these rules:
 3. **Keep comments synchronized with the actual code.** Whenever behaviour
    changes, update all nearby comments immediately so future contributors can
    rely on them.
-4. **Update documentation**, including this `AGENTS.md` and `README.md`,
-   whenever behaviour or structure changes. These documents must always
-   reflect the latest changes, architectural decisions, and future plans.
+4. **Update documentation**, including this `AGENTS.md`, `README.md` and the
+   `docs/` directory, whenever behaviour or structure changes. Each task must
+   expand the documentation's scope and size, refresh version strings and
+   update all `Last Updated` fields.
 5. **Keep these laws synchronized across `README.md` and `AGENTS.md`.**
    Amendments to any rule require an explicit human request.
 6. **Bump the project version according to Semantic Versioning whenever
@@ -227,6 +228,9 @@ these rules:
 13. **Do not redistribute the Copernican Suite in full or assert patent
     claims; the license forbids these actions.**
 14. **Keep individual lines under 79 characters to maintain readability.**
+15. **Treat documentation refresh as integral to every task.** No change is
+    complete until all relevant texts reflect the update and version numbers
+    remain in sync.
 
 Failure to follow these guidelines will compromise the Copernican Suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.14
+- 2025-08-23: Established documentation refresh policy and aligned version
+               numbers across metadata (OpenAI ChatGPT)
+
 ## Version 3.9.13
 - 2025-08-23: start.sh exits on unset variables for stricter error handling (AI assistant)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "Copernican Suite"
-version: "3.9.4"
+version: "3.9.14"
 date-released: 2025-08-23
 authors:
   - name: "Copernican Developers"
@@ -10,5 +10,5 @@ preferred-citation:
   authors:
     - name: "Copernican Developers"
   title: "Copernican Suite"
-  version: "3.9.4"
+  version: "3.9.14"
   date-released: 2025-08-23

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.9.9
+**Version:** 3.9.14
 **Last Updated:** 2025-08-23
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -35,6 +35,7 @@ Citation details are provided in [CITATION.cff](CITATION.cff).
 16. [Versioning Policy](#versioning-policy)
 17. [API Overview](docs/api_overview.md)
 18. [Packaging Guide](docs/packaging.md)
+19. [Documentation Policy](docs/documentation_policy.md)
 
 ---
 
@@ -559,9 +560,10 @@ algorithms.
 changes, update all nearby comments immediately so future contributors can
 rely
 on them.
-> 4. **Update documentation**, including this `AGENTS.md` and `README.md`,
-whenever behaviour or structure changes. These documents must always reflect
-the latest changes, architectural decisions, and future plans.
+> 4. **Update documentation**, including this `AGENTS.md`, `README.md` and the
+`docs/` directory, whenever behaviour or structure changes. Each task must
+expand the documentation's scope and size, refresh version strings and update
+all `Last Updated` fields.
 > 5. **Keep these laws synchronized across `README.md` and `AGENTS.md`.**
 Amendments to any rule require an explicit human request.
 > 6. **Bump the project version according to Semantic Versioning whenever
@@ -583,6 +585,9 @@ Black, Isort, Ruff and Flake8 checks.**
 > 13. **Do not redistribute the Copernican Suite in full or assert patent
 claims; the license forbids these actions.**
 > 14. **Keep individual lines under 79 characters to maintain readability.**
+> 15. **Treat documentation refresh as integral to every task.** No change is
+complete until all relevant texts reflect the update and version numbers
+remain in sync.
 >
 > Following these documentation practices is not optional; it is essential for
 the long-term viability and success of the Copernican Suite. Failure to follow

--- a/docs/documentation_policy.md
+++ b/docs/documentation_policy.md
@@ -1,0 +1,17 @@
+# Documentation Policy
+
+**Version:** 1.0
+**Last Updated:** 2025-08-23
+
+The Copernican Suite treats documentation as a first-class component of the
+project. Every development task must include a documentation refresh that does
+more than fix typos.
+
+## Required Steps
+- Update `README.md`, `AGENTS.md` and any affected files under `docs/`.
+- Expand the scope or depth of documentation so it grows alongside the code.
+- Synchronise version strings and `Last Updated` fields across all documents.
+- Record the changes in `CHANGELOG.md`.
+
+Adhering to this policy keeps the suite's knowledge base accurate and protects
+our intellectual property by clearly documenting provenance and intent.


### PR DESCRIPTION
## Summary
- define documentation refresh as a core development requirement and add a dedicated policy doc
- sync version metadata across README and CITATION
- log the new policy in CHANGELOG

## Testing
- `pre-commit run --files AGENTS.md README.md CITATION.cff CHANGELOG.md docs/documentation_policy.md`
- `python -m unittest discover -v` *(fails: No CMB parser registered for 'planck_2018_lite'; BAO parser 'compound_bao_set' missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b094704c832f884b5a7a6d3e70cb