### PR TITLE
Clarify development laws link and heading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,9 +213,8 @@ these rules:
    changes introduce new features, fixes or breaking changes.**
 7. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in
    any file.**
-8. **Re-read the "Development laws and protocols for human and AI
-   contributors" section in `README.md` at the start of every development
-   session.**
+8. **Re-read the "AI-driven and human development laws and protocols" section
+   in `README.md` at the start of every development session.**
 9. **Document every module, function and class with clear "what" and "why"
    explanations.** Comments and docstrings should describe not only the
    behaviour but also the rationale behind it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Version headers run newest to oldest, and within each version the newest
 entries come first):
 
 ## Version 3.9.14
+- 2025-08-23: Clarified development laws section link and heading
+               (OpenAI ChatGPT)
 - 2025-08-23: Established documentation refresh policy and aligned version
                numbers across metadata (OpenAI ChatGPT)
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Citation details are provided in [CITATION.cff](CITATION.cff).
 11. [Logging and Caching](#logging-and-caching)
 12. [Creating New Models](#creating-new-models)
 13. [Developer Guide](#developer-guide)
-14. [AI-driven and human development laws and protocols](#ai-driven-and-
-    human-development-laws-and-protocols)
+14. [AI-driven and human development laws and protocols](#ai-driven-and-human-development-laws-and-protocols)
 15. [License](#license)
 16. [Versioning Policy](#versioning-policy)
 17. [API Overview](docs/api_overview.md)
@@ -538,7 +537,7 @@ altering `MAJOR.MINOR`.
 
 See `CHANGELOG.md` for complete version history.
 
-## 6. Development laws and protocols for human and AI contributors
+## 6. AI-driven and human development laws and protocols
 
 > **To any AI or human developer, including my future self, that modifies this
 codebase:**
@@ -570,9 +569,8 @@ Amendments to any rule require an explicit human request.
 changes introduce new features, fixes or breaking changes.**
 > 7. **Never insert Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in
 any file.**
-> 8. **Re-read the "Development laws and protocols for human and AI
-contributors" section in `README.md` at the start of every development
-session.**
+> 8. **Re-read the "AI-driven and human development laws and protocols" section
+in `README.md` at the start of every development session.**
 > 9. **Document every module, function and class with clear "what" and "why"
 explanations.** Comments and docstrings should describe not only the behaviour
 but also the rationale behind it.


### PR DESCRIPTION
## Summary
- Consolidate Table of Contents entry for development laws and align its anchor with the renamed section heading
- Rename section to "AI-driven and human development laws and protocols" and update references across README and AGENTS
- Log documentation adjustments in CHANGELOG

## Testing
- `pre-commit run --files README.md AGENTS.md CHANGELOG.md`
- `python -m unittest discover -v` *(fails: Hash mismatch for parser, missing parser registrations)*

------
https://chatgpt.com/codex/tasks/task_e_68aa36d7b1a0832f8ebde8b68cb75242