### PR TITLE
Fix BAO parser registration and update parser hashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ lines are bold, while the dataset name on the second line is bolded
 using Matplotlib's standard text rendering. Dataset names retain their
 original spacing and the second line wraps after 190 characters when
 necessary.
+Parsers must register under the `dataset_id` stated in their metadata so
+the loaders can locate them directly without discovery.
 
 The program enables Python's ``faulthandler`` at startup and registers
 ``SIGILL``, ``SIGSEGV`` and ``SIGFPE`` handlers. When triggered, they dump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.16
+- 2025-08-24: Fixed BAO compound parser registration to honour dataset_id
+               (OpenAI ChatGPT)
+
 ## Version 3.9.15
 - 2025-08-23: Nested developer guide sections and required tests to pass
                before commits (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.9.15
-**Last Updated:** 2025-08-23
+**Version:** 3.9.16
+**Last Updated:** 2025-08-24
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -150,7 +150,7 @@ def register_siren_parser(name=None, description="", data_dir=None):
 TRUSTED_PARSER_HASHES = {
     # ``relative_path`` -> ``sha256``
     "sne/pantheon/cosmo_parser_pantheon.py": (
-        "5fd4f60499129dc4a0468712bc29364f717bc7fa3442021bb7691cf6fc98233d"
+        "a15cfd8cec9104e62aebeb03fc72b148d8da76b33e90ede4537eddbe3310d0a6"
     ),
     "sne/jla2014/cosmo_parser_jla2014.py": (
         "27b553519fa4545153c675f82141be2e2ed35a69b91ce5d72b0add794fb25339"
@@ -159,10 +159,10 @@ TRUSTED_PARSER_HASHES = {
         "4de5b07156d65e4e075810745c6b61cf8b7f10f0e4c575be9d6d16ebbfcf37b8"
     ),
     "bao/compound/cosmo_parser_compound.py": (
-        "0faa58a29b2c809054d48130cce78adeebafd8d92b0bb40616b2bcc88c782712"
+        "a203b6f5efe3742c4cb2253d1f96691c7af769af1718f9526a73069afd3cf126"
     ),
     "cmb/planck2018lite/cosmo_parser_cmb_planck2018lite.py": (
-        "ccd9f8173b38ea9d8fcf458ea638086efd2ac8cfb300a4b9ece84342fa69f296"
+        "3017407d77779873a0eb145d9f8f420c0ea83da33431fab70ecfd8b5ee6a23de"
     ),
     "gw/placeholder/cosmo_parser_gw_placeholder.py": (
         "10d0159cdd879a74324c852be92e877308b949ff0375c9e9609da3a95c0fe3e2"

--- a/data/bao/compound/cosmo_parser_compound.py
+++ b/data/bao/compound/cosmo_parser_compound.py
@@ -27,7 +27,9 @@ from copernican_lib.data_loaders import register_bao_parser
 DATA_DIR = os.path.dirname(__file__)
 
 
-@register_bao_parser(data_dir=DATA_DIR)
+# Explicitly register under the metadata ``dataset_id`` so that
+# ``load_bao_data('compound_bao_set')`` locates this parser.
+@register_bao_parser(name="compound_bao_set", data_dir=DATA_DIR)
 def parse_bao_v1(data_dir, **kwargs):
     """Parse a BAO dataset defined in a small YAML table."""
     logger = logging.getLogger()

--- a/docs/bao_compound_dataset_format.md
+++ b/docs/bao_compound_dataset_format.md
@@ -1,4 +1,5 @@
 # BAO Compound Dataset Format
+**Last Updated:** 2025-08-24
 
 This document describes the YAML format used for the **compound** BAO dataset
 shipped with the Copernican Suite. The folder lives under `data/bao/compound/`
@@ -13,6 +14,10 @@ reads this metadata after parsing so the parser itself remains trivial. The
 compound dataset lets developers exercise the BAO pipeline without downloading
 large public releases. A covariance matrix is intentionally omitted;
 uncertainties are treated as uncorrelated.
+
+The accompanying parser registers itself under the dataset ID
+`compound_bao_set` so ``load_bao_data('compound_bao_set')`` locates it
+directly without discovery.
 
 Example `compound.yml`:
 ```yaml


### PR DESCRIPTION
## Summary
- register compound BAO parser with its dataset ID and refresh trusted hashes
- document dataset ID registration requirement and bump version to 3.9.16

## Testing
- `pre-commit run --files data/bao/compound/cosmo_parser_compound.py README.md docs/bao_compound_dataset_format.md AGENTS.md CHANGELOG.md copernican_lib/data_loaders.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aad6d18a68832f8890e2871675ad1d