### PR TITLE
Ensure start scripts install with hash-locked dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.18
+- 2025-08-24: start.bat and start.command install hashed dependencies and
+              isolate project install with --no-deps (OpenAI ChatGPT)
+
 ## Version 3.9.17
 - 2025-08-24: Normalised parser hash computation for cross-platform
                verification and refreshed trusted hashes (OpenAI ChatGPT)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "Copernican Suite"
-version: "3.9.15"
-date-released: 2025-08-23
+version: "3.9.18"
+date-released: 2025-08-24
 authors:
   - name: "Copernican Developers"
 preferred-citation:
@@ -10,5 +10,5 @@ preferred-citation:
   authors:
     - name: "Copernican Developers"
   title: "Copernican Suite"
-  version: "3.9.15"
-  date-released: 2025-08-23
+  version: "3.9.18"
+  date-released: 2025-08-24

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.9.17
+**Version:** 3.9.18
 **Last Updated:** 2025-08-24
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -92,9 +92,10 @@ parsers are discovered automatically under
    `./start.command`, Windows users open `start.bat`, and Linux users can
    execute `./start.sh`. The launcher verifies Python 3.11+ before
    creating a `.venv`, upgrading `pip`, installing locked dependencies with
-   hash verification and installing the project automatically. It deletes
-   any `build/` directory before and after `pip install .` to avoid stale
-   artifacts. If the interpreter is missing or too old it prints install
+   hash verification and then installing the project in isolation with
+   `pip install --no-deps .`. It deletes any `build/` directory before and
+   after installation to avoid stale artifacts. If the interpreter is
+   missing or too old it prints install
    tips such as `sudo apt install python3.11 python3.11-venv` on Debian,
    `brew install python@3.11` on macOS or `winget install -e --id
    Python.Python.3.11` on Windows before exiting. If the activation script

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -23,9 +23,9 @@ Run the launcher in the project root:
 - `start.sh` on Linux
 
 The script verifies Python 3.11+, then creates or reuses `.venv`, upgrades
-`pip` and installs packages from `requirements.lock` using
-`pip install --require-hashes -r requirements.lock`. Re-run it after pulling
-updates to refresh the environment.
+`pip`, installs packages from `requirements.lock` with hash verification and
+installs the project itself with `pip install --no-deps .`. Re-run it after
+pulling updates to refresh the environment.
 
 `requirements.lock` pins exact versions and SHA256 hashes for all runtime
 dependencies. Adding or updating a package requires editing this file and the

--- a/start.bat
+++ b/start.bat
@@ -61,10 +61,12 @@ if not exist .venv\Scripts\activate.bat (
 call .venv\Scripts\activate.bat
 set PYTHON=python
 %PYTHON% -m pip install --upgrade pip
-REM Remove any 'build' directory before and after 'pip install .'
+REM Install pinned dependencies with hash verification.
+%PYTHON% -m pip install --require-hashes -r requirements.lock
+REM Remove any 'build' directory before and after installing the project
 REM to avoid stale build artifacts.
 if exist build rmdir /s /q build
-%PYTHON% -m pip install .
+%PYTHON% -m pip install --no-deps .
 if exist build rmdir /s /q build
 
 call "%~f0" %*

--- a/start.command
+++ b/start.command
@@ -60,13 +60,18 @@ if [ ! -f ".venv/bin/activate" ]; then
     fi
 fi
 
-# Activate, update pip, install the project and restart the script. Delete
-# any 'build/' directory before and after 'pip install .'
-# to avoid stale build artifacts.
+# Activate, update pip, install dependencies with hash verification,
+# then install the project without dependencies and restart the script.
+# Delete any 'build/' directory before and after installing the project to
+# avoid stale build artifacts.
 source .venv/bin/activate
 python -m pip install --upgrade pip
+# Install pinned dependencies to ensure reproducible environments.
+python -m pip install --require-hashes -r requirements.lock
+# Remove any 'build/' directory before and after installing the project
+# to avoid stale build artifacts.
 rm -rf build
-python -m pip install .
+python -m pip install --no-deps .
 rm -rf build
 exec "$SCRIPT" "$@"
 


### PR DESCRIPTION
## Summary
- Enforce hash-locked dependency install and isolated project install in Windows and macOS launchers
- Document new `--no-deps` installation flow
- Bump version to 3.9.18

## Testing
- `pre-commit run --files start.bat start.command README.md docs/packaging.md CHANGELOG.md CITATION.cff`
- `python -m unittest tests.test_core -v`

------
https://chatgpt.com/codex/tasks/task_e_68ab4fd67e08832fa50bdbe26b63f99d