### PR TITLE
start.command: exit on unset variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.19
+- 2025-08-24: start.command exits on unset variables for stricter error
+              handling (OpenAI ChatGPT)
+
 ## Version 3.9.18
 - 2025-08-24: start.bat and start.command install hashed dependencies and
               isolate project install with --no-deps (OpenAI ChatGPT)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "Copernican Suite"
-version: "3.9.18"
+version: "3.9.19"
 date-released: 2025-08-24
 authors:
   - name: "Copernican Developers"
@@ -10,5 +10,5 @@ preferred-citation:
   authors:
     - name: "Copernican Developers"
   title: "Copernican Suite"
-  version: "3.9.18"
+  version: "3.9.19"
   date-released: 2025-08-24

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.9.18
+**Version:** 3.9.19
 **Last Updated:** 2025-08-24
 
 The Copernican Suite is a Python toolkit for testing cosmological models

--- a/start.command
+++ b/start.command
@@ -8,7 +8,9 @@
 # re-executes itself inside that environment so later runs reuse the cached
 # installation.
 
-set -e
+# Abort on errors and on references to unset variables to guard against
+# mistyped names.
+set -eu
 SCRIPT="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
## Summary
- fail fast in start.command on errors and unset variables to match start.sh
- bump version to 3.9.19 and document change

## Testing
- `VIRTUAL_ENV=1 ./start.sh --help`
- `VIRTUAL_ENV=1 ./start.command --help`
- `VIRTUAL_ENV='' PATH='/tmp/minpath' ./start.sh --help` *(fails: Python 3.11 is not installed)*
- `VIRTUAL_ENV='' PATH='/tmp/minpath' ./start.command --help` *(fails: Python 3.11 is not installed)*
- `pre-commit run --files start.command CHANGELOG.md README.md CITATION.cff`


------
https://chatgpt.com/codex/tasks/task_e_68ab51711690832fb97be34200f6820b