### PR TITLE
Ensure start scripts skip dependency install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,10 +116,10 @@ Any dependency change must regenerate both files and update
 suite as a package, run `pip install .` at the repository root. Use
 `pip install -e .` if you intend to develop the code. The start scripts
 install pinned dependencies from `requirements.lock` using hash verification
-before running `pip install .`. They delete any `build/` directory before and
-after `pip install .` to prevent stale build artifacts. They recreate `.venv`
-once when the activation script is missing before suggesting installation of
-`python3.11-venv`.
+before running `pip install --no-deps .`. They delete any `build/` directory
+before and after installing the project to prevent stale build artifacts.
+They recreate `.venv` once when the activation script is missing before
+suggesting installation of `python3.11-venv`.
 
 Pull requests run a GitHub Actions workflow named ``Tests`` that executes
 pre-commit checks and the full unit suite on Ubuntu, macOS and Windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.20
+- 2025-08-25: start.sh installs project with --no-deps to avoid implicit
+              dependency resolution (OpenAI ChatGPT)
+
 ## Version 3.9.19
 - 2025-08-24: start.command exits on unset variables for stricter error
               handling (OpenAI ChatGPT)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "Copernican Suite"
-version: "3.9.19"
-date-released: 2025-08-24
+version: "3.9.20"
+date-released: 2025-08-25
 authors:
   - name: "Copernican Developers"
 preferred-citation:
@@ -10,5 +10,5 @@ preferred-citation:
   authors:
     - name: "Copernican Developers"
   title: "Copernican Suite"
-  version: "3.9.19"
-  date-released: 2025-08-24
+  version: "3.9.20"
+  date-released: 2025-08-25

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.9.19
-**Last Updated:** 2025-08-24
+**Version:** 3.9.20
+**Last Updated:** 2025-08-25
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and

--- a/start.sh
+++ b/start.sh
@@ -71,14 +71,14 @@ if [ ! -f ".venv/bin/activate" ]; then
 fi
 
 # Activate the environment, upgrade pip, install dependencies with hash
-# verification, install the project and restart the script. Delete any
-# 'build/' directory before and after 'pip install .' to avoid stale build
-# artifacts.
+# verification, then install the project without dependencies and restart
+# the script. Delete any 'build/' directory before and after installing the
+# project to avoid stale build artifacts.
 source .venv/bin/activate
 python -m pip install --upgrade pip
 # Install pinned dependencies to ensure reproducible environments.
 python -m pip install --require-hashes -r requirements.lock
 rm -rf build
-python -m pip install .
+python -m pip install --no-deps .
 rm -rf build
 exec "$SCRIPT" "$@"


### PR DESCRIPTION
## Summary
- keep start.sh from reinstalling dependencies by using `pip install --no-deps .`
- document that launchers install the project without resolving dependencies
- bump version to 3.9.20

## Testing
- `pre-commit run --files start.sh AGENTS.md README.md CITATION.cff CHANGELOG.md`
- `python -m pip install --no-deps .`
- `python - <<'PY'\nimport copernican;\ntry:\n    copernican.check_dependencies(auto_confirm=True)\n    print('check_dependencies succeeded')\nexcept Exception as e:\n    print('check_dependencies failed:', e)\nPY` *(fails: Operation cancelled by user while building numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1dd122ac832fad05defcc8df2b80