### PR TITLE
Add license notices to test modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.21
+- 2025-08-25: Prepended license notice to test modules (OpenAI ChatGPT)
+
 ## Version 3.9.20
 - 2025-08-25: start.sh installs project with --no-deps to avoid implicit
               dependency resolution (OpenAI ChatGPT)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 """Test package for the Copernican Suite."""
 
 import logging

--- a/tests/test_bao_covariance.py
+++ b/tests/test_bao_covariance.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 import importlib.util
 import unittest
 from pathlib import Path

--- a/tests/test_bossdr12_parser.py
+++ b/tests/test_bossdr12_parser.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 """Validate the BOSS DR12 BAO parser.
 
 This test confirms that the parser combines the two covariance matrices into

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 """Tests for command-line helpers in ``copernican.py``."""
 
 import importlib

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 """Basic functional tests for the Copernican Suite."""
 
 import importlib.util

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 """Tests for ``copernican_lib.data_loaders`` registration helpers."""
 
 import os

--- a/tests/test_engine_interface.py
+++ b/tests/test_engine_interface.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 """Tests for ``copernican_lib.engine_interface`` helpers."""
 
 import unittest

--- a/tests/test_model_coder.py
+++ b/tests/test_model_coder.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 """Security tests for ``model_coder`` expression handling."""
 
 import unittest

--- a/tests/test_parser_discovery.py
+++ b/tests/test_parser_discovery.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
 """Security tests for parser discovery.
 
 Only parser modules whose hashes are registered should be imported.


### PR DESCRIPTION
## Summary
- add standard copyright and license notice to all test modules
- document license header addition in changelog

## Testing
- `pre-commit run --files tests/__init__.py tests/test_bao_covariance.py tests/test_bossdr12_parser.py tests/test_cli.py tests/test_core.py tests/test_data_loaders.py tests/test_engine_interface.py tests/test_model_coder.py tests/test_parser_discovery.py CHANGELOG.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ee10d58832fafa1c2e6bbfe16ba