### PR TITLE
Add complexity limits to get_camb_params evaluation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,10 @@ evaluation counters now live in ``copernican_lib/optim_utils.py`` and are
 imported
 by the engines instead of being reimplemented inside each backend.
 
+The ``_eval_safe`` helper in ``engine_interface`` caps recursion depth and
+AST node count when parsing expressions for ``get_camb_params`` to block
+runaway evaluation on malicious or overly complex inputs.
+
 ## 3. Dependency Installation
 `copernican.py` scans all project files for imported modules using Python's
 AST parser to avoid false positives from comments. The `start.*` launchers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.22
+- 2025-08-26: Capped expression complexity in get_camb_params and added
+              stress tests (OpenAI ChatGPT)
+
 ## Version 3.9.21
 - 2025-08-25: Prepended license notice to test modules (OpenAI ChatGPT)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 **Version:** 3.9.20
-**Last Updated:** 2025-08-25
+**Last Updated:** 2025-08-26
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
@@ -391,7 +391,9 @@ that the CMB spectrum can be adjusted independently. The engines themselves
 call
 CAMB using this mapping; the plugin no longer provides a fallback
 `compute_cmb_spectrum` implementation. When `valid_for_cmb` is `false` the
-suite skips the CMB evaluation stage for that model.
+suite skips the CMB evaluation stage for that model. Expressions are parsed
+by a restricted interpreter that aborts when recursion depth or AST node
+count limits are exceeded to block runaway evaluation.
 CMB data parsers attach a `param_names` attribute to the returned DataFrame
 listing the CAMB parameter order—including `omnuh2` when relevant. The engine
 combines this list with `get_camb_params` to evaluate the power spectrum and

--- a/copernican_lib/engine_interface.py
+++ b/copernican_lib/engine_interface.py
@@ -150,7 +150,8 @@ def build_plugin(model_data, func_dict):
             Raises
             ------
             ValueError
-                If ``expr`` contains disallowed syntax or identifiers.
+                If ``expr`` contains disallowed syntax or exceeds
+                complexity limits.
             """
 
             try:
@@ -158,9 +159,17 @@ def build_plugin(model_data, func_dict):
             except SyntaxError as exc:  # pragma: no cover - SyntaxError rare
                 raise ValueError(f"invalid expression '{expr}'") from exc
 
-            def _eval(node: ast.AST) -> float:
+            # Limit expression complexity to avoid pathological evaluations.
+            MAX_NODES = 100
+            MAX_DEPTH = 20
+            if sum(1 for _ in ast.walk(node)) > MAX_NODES:
+                raise ValueError("expression too complex")
+
+            def _eval(node: ast.AST, depth: int = 0) -> float:
+                if depth > MAX_DEPTH:
+                    raise ValueError("expression too complex")
                 if isinstance(node, ast.Expression):
-                    return _eval(node.body)
+                    return _eval(node.body, depth + 1)
                 if isinstance(node, ast.Constant):
                     if isinstance(node.value, (int, float)):
                         return float(node.value)
@@ -169,12 +178,15 @@ def build_plugin(model_data, func_dict):
                     op = BIN_OPS.get(type(node.op))
                     if op is None:
                         raise ValueError("operator not allowed")
-                    return op(_eval(node.left), _eval(node.right))
+                    return op(
+                        _eval(node.left, depth + 1),
+                        _eval(node.right, depth + 1),
+                    )
                 if isinstance(node, ast.UnaryOp):
                     op = UNARY_OPS.get(type(node.op))
                     if op is None:
                         raise ValueError("operator not allowed")
-                    return op(_eval(node.operand))
+                    return op(_eval(node.operand, depth + 1))
                 if isinstance(node, ast.Name):
                     if node.id in env:
                         return env[node.id]
@@ -191,7 +203,7 @@ def build_plugin(model_data, func_dict):
                         )
                     if node.keywords:
                         raise ValueError("keyword arguments not supported")
-                    args = [_eval(arg) for arg in node.args]
+                    args = [_eval(arg, depth + 1) for arg in node.args]
                     return float(func(*args))
                 raise ValueError("expression not allowed")
 

--- a/tests/test_engine_interface.py
+++ b/tests/test_engine_interface.py
@@ -58,6 +58,20 @@ class EngineInterfaceTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.plugin.get_camb_params([70.0])
 
+    def test_get_camb_params_rejects_recursion_depth(self):
+        """Deeply nested calls exceed the evaluator's recursion limit."""
+        expr = "exp(" * 30 + "1" + ")" * 30
+        self.plugin.CMB_PARAM_MAP["deep"] = expr
+        with self.assertRaises(ValueError):
+            self.plugin.get_camb_params([70.0])
+
+    def test_get_camb_params_rejects_node_blowup(self):
+        """Expressions with too many nodes trigger a ``ValueError``."""
+        expr = "+".join(["1"] * 200)
+        self.plugin.CMB_PARAM_MAP["wide"] = expr
+        with self.assertRaises(ValueError):
+            self.plugin.get_camb_params([70.0])
+
     def test_equation_sanitization(self):
         """Equations are sanitized into Matplotlib-friendly form."""
         self.assertEqual(self.plugin.MODEL_EQUATIONS_LATEX_SN[0], "$E=mc^2$")


### PR DESCRIPTION
## Summary
- Guard `_eval_safe` against runaway expressions by capping AST node count and recursion depth
- Document the new evaluator limits and update Last Updated fields
- Test that deeply nested or wide expressions fail gracefully

## Testing
- `pre-commit run --files AGENTS.md README.md CHANGELOG.md copernican_lib/engine_interface.py tests/test_engine_interface.py`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68ac32d5da24832f850be34f9365d6b3