### PR TITLE
Harden parser discovery against symlink escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.23
+- 2025-08-25: Hardened parser discovery against symlink escapes and expanded
+              security tests (OpenAI ChatGPT)
+
 ## Version 3.9.22
 - 2025-08-26: Capped expression complexity in get_camb_params and added
               stress tests (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.9.20
-**Last Updated:** 2025-08-26
+**Version:** 3.9.23
+**Last Updated:** 2025-08-25
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
@@ -65,8 +65,10 @@ Under the hood the program follows a clear pipeline:
 parsers are discovered automatically under
   `data/<type>/<source>` and models are loaded from `cosmo_model_*.yml`.
   Only parser modules whose SHA256 digest matches a vetted list are imported,
-  ensuring untrusted files are ignored. Folders named `placeholder` are
-  ignored so unfinished datasets do not appear in the selection menus.
+  ensuring untrusted files are ignored. Symbolic links are rejected and any
+  path that resolves outside the repository is skipped. Folders named
+  `placeholder` are ignored so unfinished datasets do not appear in the
+  selection menus.
 4. **Parameter Fitting** – depending on the chosen engine either a pure
    SNe fit is performed or a combined optimisation over all datasets.  For
    the combined engine this optimisation begins with the SNe refinement

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -193,7 +193,9 @@ def _discover_parsers(base_dir: str | None = None):
     """Import parser modules and populate registries with dataset metadata.
 
     The scan walks ``data/`` recursively, ignoring ``placeholder`` folders so
-    unfinished datasets stay hidden.  Each candidate parser is verified against
+    unfinished datasets stay hidden.  Candidate paths are resolved with
+    ``os.path.realpath`` and rejected if they are symlinks or if the resolved
+    location escapes ``base_dir``.  Each parser is then verified against
     ``TRUSTED_PARSER_HASHES`` before import to guard against tampering.  Only
     trusted modules are executed, keeping the discovery step resilient to
     untrusted files shipped alongside the data tables.
@@ -204,6 +206,10 @@ def _discover_parsers(base_dir: str | None = None):
         base_dir = os.path.join(
             os.path.dirname(os.path.dirname(__file__)), "data"
         )
+    # Resolve the discovery root to an absolute path so subsequent checks can
+    # verify that candidate entries never escape the repository via symlinks
+    # or ".." components.
+    base_dir = os.path.realpath(base_dir)
     registry_map = {
         "sne": SNE_PARSERS,
         "bao": BAO_PARSERS,
@@ -213,6 +219,12 @@ def _discover_parsers(base_dir: str | None = None):
     }
     for dtype in ("sne", "bao", "cmb", "gw", "sirens"):
         type_dir = os.path.join(base_dir, dtype)
+        # Skip symlinks or paths that resolve outside the data directory.
+        if os.path.islink(type_dir):
+            continue
+        type_dir = os.path.realpath(type_dir)
+        if os.path.commonpath([base_dir, type_dir]) != base_dir:
+            continue
         if not os.path.isdir(type_dir):
             continue
         for source in os.listdir(type_dir):
@@ -221,6 +233,11 @@ def _discover_parsers(base_dir: str | None = None):
             if source.lower() == "placeholder":
                 continue
             src_dir = os.path.join(type_dir, source)
+            if os.path.islink(src_dir):
+                continue
+            src_dir = os.path.realpath(src_dir)
+            if os.path.commonpath([base_dir, src_dir]) != base_dir:
+                continue
             if not os.path.isdir(src_dir):
                 continue
             meta = load_metadata_from_dir(src_dir)
@@ -237,9 +254,13 @@ def _discover_parsers(base_dir: str | None = None):
                 if fname.startswith("cosmo_parser_") and fname.endswith(".py"):
                     module_name = f"data.{dtype}.{source}.{fname[:-3]}"
                     file_path = os.path.join(src_dir, fname)
+                    if os.path.islink(file_path):
+                        continue
+                    file_path = os.path.realpath(file_path)
+                    if os.path.commonpath([base_dir, file_path]) != base_dir:
+                        continue
                     rel_path = os.path.relpath(file_path, base_dir)
-                    # Normalise path separators
-                    # for cross-platform hash lookup.
+                    # Normalise path separators for cross-platform hash lookup.
                     rel_path = rel_path.replace("\\", "/")
                     expected_hash = TRUSTED_PARSER_HASHES.get(rel_path)
                     if expected_hash is None:

--- a/tests/test_parser_discovery.py
+++ b/tests/test_parser_discovery.py
@@ -84,6 +84,55 @@ class ParserDiscoverySecurityTestCase(unittest.TestCase):
             data_loaders.TRUSTED_PARSER_HASHES = prev_hashes
             os.environ.pop("MAL_SENTINEL", None)
 
+    def test_symlinked_paths_are_skipped(self) -> None:
+        """Symlinked directories and parsers must never be imported."""
+        prev_parsers = data_loaders.SNE_PARSERS.copy()
+        prev_hashes = data_loaders.TRUSTED_PARSER_HASHES.copy()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                base = Path(tmp)
+                outside = base.parent / "outside"
+                outside.mkdir()
+                meta = {"dataset_name": "Link SNe", "dataset_id": "link"}
+                with open(
+                    outside / "metadata_dummy.yml", "w", encoding="utf-8"
+                ) as fh:
+                    yaml.safe_dump(meta, fh)
+                bad_parser = outside / "cosmo_parser_bad.py"
+                sentinel = outside / "symlink_imported.txt"
+                code = (
+                    "import os\n"
+                    "with open(os.environ['LINK_SENTINEL'], 'w', "
+                    "encoding='utf-8') as fh:\n"
+                    "    fh.write('imported')\n"
+                )
+                bad_parser.write_text(code, encoding="utf-8")
+                os.environ["LINK_SENTINEL"] = str(sentinel)
+
+                sne_dir = base / "sne"
+                sne_dir.mkdir()
+                # Symlinked dataset directory pointing outside ``base``.
+                (sne_dir / "linked_dir").symlink_to(
+                    outside, target_is_directory=True
+                )
+                # Real dataset with symlinked parser file.
+                real_dir = sne_dir / "real"
+                real_dir.mkdir()
+                with open(
+                    real_dir / "metadata_dummy.yml", "w", encoding="utf-8"
+                ) as fh:
+                    yaml.safe_dump(meta, fh)
+                (real_dir / "cosmo_parser_real.py").symlink_to(bad_parser)
+
+                data_loaders.SNE_PARSERS = {}
+                data_loaders._discover_parsers(base_dir=tmp)
+                self.assertFalse(sentinel.exists())
+                self.assertEqual(data_loaders.SNE_PARSERS, {})
+        finally:
+            data_loaders.SNE_PARSERS = prev_parsers
+            data_loaders.TRUSTED_PARSER_HASHES = prev_hashes
+            os.environ.pop("LINK_SENTINEL", None)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- Resolve and validate parser paths with `os.path.realpath` to skip symlinks and prevent repository escapes
- Expand parser discovery security tests with symlink-based attempts
- Document stricter parser scanning and bump version

## Testing
- `pre-commit run --files CHANGELOG.md README.md copernican_lib/data_loaders.py tests/test_parser_discovery.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68ac57f00000832f96a39e9cb90476e4