### PR TITLE
Handle unset virtual env in start script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.24
+- 2025-08-25: start.sh guards against unset VIRTUAL_ENV to prevent
+              startup errors (OpenAI ChatGPT)
+
 ## Version 3.9.23
 - 2025-08-25: Hardened parser discovery against symlink escapes and expanded
               security tests (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.9.23
+**Version:** 3.9.24
 **Last Updated:** 2025-08-25
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -95,9 +95,9 @@ parsers are discovered automatically under
    execute `./start.sh`. The launcher verifies Python 3.11+ before
    creating a `.venv`, upgrading `pip`, installing locked dependencies with
    hash verification and then installing the project in isolation with
-   `pip install --no-deps .`. It deletes any `build/` directory before and
-   after installation to avoid stale artifacts. If the interpreter is
-   missing or too old it prints install
+   `pip install --no-deps .`. It skips errors when `VIRTUAL_ENV` is unset,
+   deletes any `build/` directory before and after installation to avoid
+   stale artifacts. If the interpreter is missing or too old it prints install
    tips such as `sudo apt install python3.11 python3.11-venv` on Debian,
    `brew install python@3.11` on macOS or `winget install -e --id
    Python.Python.3.11` on Windows before exiting. If the activation script

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -24,7 +24,8 @@ Run the launcher in the project root:
 
 The script verifies Python 3.11+, then creates or reuses `.venv`, upgrades
 `pip`, installs packages from `requirements.lock` with hash verification and
-installs the project itself with `pip install --no-deps .`. Re-run it after
+installs the project itself with `pip install --no-deps .`. It ignores an
+unset `VIRTUAL_ENV` to avoid shell errors on first launch. Re-run it after
 pulling updates to refresh the environment.
 
 `requirements.lock` pins exact versions and SHA256 hashes for all runtime

--- a/start.sh
+++ b/start.sh
@@ -16,7 +16,9 @@ SCRIPT="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 cd "$(dirname "$0")"
 
 # If we are already inside the virtual environment simply launch the suite.
-if [ -n "$VIRTUAL_ENV" ]; then
+# Use parameter expansion to avoid an "unbound variable" error when
+# "VIRTUAL_ENV" is unset and "set -u" is active.
+if [ -n "${VIRTUAL_ENV:-}" ]; then
     exec python copernican.py "$@"
 fi
 


### PR DESCRIPTION
## Summary
- avoid unbound variable in start.sh when VIRTUAL_ENV is undefined
- document improved launcher behavior and bump version to 3.9.24

## Testing
- `pre-commit run --files CHANGELOG.md README.md docs/packaging.md start.sh`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68acd3507d88832fbd22d23a7e74288c