### PR TITLE
Expose progress output on stdout and deduplicate environment info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,9 @@ The program enables Python's ``faulthandler`` at startup and registers
 stack traces to both the console and the active log file before exiting.
 Immediately after logging initialises the suite records the Python version,
 operating system, CPU model and key package versions. A short summary is
-shown on the console while the log captures full details.
+shown on the console while the log captures full details. Progress messages
+print to ``stdout`` and flush on every update so lengthy optimisations still
+display activity on Linux terminals.
 
 All Python warnings are forwarded to the central logger. Use
 ``--strict-warnings`` to elevate warnings to errors during CI runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.26
+- 2025-08-25: Routed optimisation progress to ``stdout`` so runs no longer
+              appear to hang on Linux (OpenAI ChatGPT)
+
+## Version 3.9.25
+- 2025-08-25: Flushed console output to prevent apparent hangs on Linux and
+              restricted detailed environment information to the log file
+              (OpenAI ChatGPT)
+
 ## Version 3.9.24
 - 2025-08-25: start.sh guards against unset VIRTUAL_ENV to prevent
               startup errors (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.9.24
+**Version:** 3.9.26
 **Last Updated:** 2025-08-25
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -273,6 +273,8 @@ All console output and user prompts are captured in a timestamped log file in
 model and key package versions. A short summary appears on the console while
 full details are stored in the log file. The logger shortens absolute paths so
 logs remain portable and records the final filenames used for plots and tables.
+Progress indicators print to ``stdout`` and flush on every update so long
+optimisations do not appear stalled on Linux terminals.
 Model YAML files are
 sanitised and cached under `models/cache/` for the duration of the session,
 avoiding repeated schema validation. For CMB analyses unlensed CAMB spectra

--- a/copernican_lib/console_output.py
+++ b/copernican_lib/console_output.py
@@ -18,7 +18,9 @@ def write(msg: str = "", *, end: str = "\n", error: bool = False) -> None:
     Routing all prints through this function ensures the patched
     ``print``/``input`` hooks in :mod:`copernican_lib.logger` can record
     every message exactly once.  Direct calls to ``print`` should be
-    avoided inside the project so that logs remain faithful.
+    avoided inside the project so that logs remain faithful. The stream
+    is always flushed so progress lines using carriage returns remain
+    visible on all platforms.
 
     Parameters
     ----------
@@ -37,10 +39,10 @@ def write(msg: str = "", *, end: str = "\n", error: bool = False) -> None:
     """
     stream = sys.stderr if error else sys.stdout
     try:
-        print(msg, end=end, file=stream)
+        print(msg, end=end, file=stream, flush=True)
     except UnicodeEncodeError:
         fallback = msg.encode("ascii", errors="replace").decode("ascii")
-        print(fallback, end=end, file=stream)
+        print(fallback, end=end, file=stream, flush=True)
 
 
 def ask(prompt: str = "") -> str:

--- a/copernican_lib/logger.py
+++ b/copernican_lib/logger.py
@@ -157,12 +157,13 @@ def log_environment_info() -> None:
             pkgs[name] = getattr(mod, "__version__", "unknown")
         except Exception:
             pkgs[name] = "not installed"
-    logger.info("Environment details:")
-    logger.info(f"  Python: {py_ver}")
-    logger.info(f"  OS: {os_info}")
-    logger.info(f"  CPU: {cpu}")
+    log_kwargs = {"extra": {"console_capture": True}}
+    logger.info("Environment details:", **log_kwargs)
+    logger.info(f"  Python: {py_ver}", **log_kwargs)
+    logger.info(f"  OS: {os_info}", **log_kwargs)
+    logger.info(f"  CPU: {cpu}", **log_kwargs)
     for n, v in pkgs.items():
-        logger.info(f"  {n}: {v}")
+        logger.info(f"  {n}: {v}", **log_kwargs)
     summary = f"Python {py_ver}; {os_info}; CPU {cpu}; " + ", ".join(
         f"{n} {v}" for n, v in pkgs.items()
     )

--- a/copernican_lib/optim_utils.py
+++ b/copernican_lib/optim_utils.py
@@ -110,7 +110,7 @@ def minimize_with_progress(
             f"  {label} Evals: {eval_count['count']:<5} | Best Chi2: "
             f"{best_val[0]:.4f} | Speed: {rate:<15}",
             end="\r",
-            error=True,
+            error=False,
         )
         return val if np.isfinite(val) else 1e12
 
@@ -131,7 +131,7 @@ def minimize_with_progress(
         )
     finally:
         # Clear the progress line so subsequent prints start on a clean line
-        console.write(" " * 80, end="\r", error=True)
+        console.write(" " * 80, end="\r", error=False)
         logger.info(
             "%s optimization finished. Total evals: %s.",
             label,

--- a/docs/documentation_policy.md
+++ b/docs/documentation_policy.md
@@ -1,7 +1,7 @@
 # Documentation Policy
 
 **Version:** 1.0
-**Last Updated:** 2025-08-23
+**Last Updated:** 2025-08-25
 
 The Copernican Suite treats documentation as a first-class component of the
 project. Every development task must include a documentation refresh that does
@@ -12,6 +12,8 @@ more than fix typos.
 - Expand the scope or depth of documentation so it grows alongside the code.
 - Synchronise version strings and `Last Updated` fields across all documents.
 - Record the changes in `CHANGELOG.md`.
+- Document user-facing console behaviour changes, including logging output and
+  progress indicators, so users understand new interactions.
 
 Adhering to this policy keeps the suite's knowledge base accurate and protects
 our intellectual property by clearly documenting provenance and intent.


### PR DESCRIPTION
## Summary
- log environment details only to file while printing a concise summary
- flush and route optimisation progress to stdout so Linux runs no longer appear to hang
- document stdout progress behaviour and update version/changelog

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md README.md copernican_lib/optim_utils.py`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68acdda6bbec832f84263b914011ccc5