### PR TITLE
Fix mac launcher VIRTUAL_ENV check and document start script parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,13 @@ these rules:
     complete until all relevant texts reflect the update and version numbers
     remain in sync.
 16. **Commit changes only after all tests pass on every supported platform.**
+17. **Treat `start.command`, `start.bat` and `start.sh` equally.** When one
+    launcher is fixed, assess the other two for the same issue and update
+    them as needed. Investigate how code changes affect the start scripts and
+    adjust them accordingly.
+18. **Follow current compliance and security requirements for all work.** The
+    suite processes user-provided files, so every change must meet the latest
+    security guidelines and consider their impact on the `start.*` scripts.
 
 Failure to follow these guidelines will compromise the Copernican Suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.27
+- 2025-08-26: start.command handles unset VIRTUAL_ENV (OpenAI ChatGPT)
+- 2025-08-26: documented start script parity law (OpenAI ChatGPT)
+- 2025-08-26: added strict security compliance law (OpenAI ChatGPT)
+
 ## Version 3.9.26
 - 2025-08-25: Routed optimisation progress to ``stdout`` so runs no longer
               appear to hang on Linux (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.9.26
-**Last Updated:** 2025-08-25
+**Version:** 3.9.27
+**Last Updated:** 2025-08-26
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
@@ -566,6 +566,13 @@ accurately** convey their purpose without unnecessary length.
 > complete until all relevant texts reflect the update and version numbers
 > remain in sync.
 > 16. **Commit changes only after all tests pass on every supported platform.**
+> 17. **Treat `start.command`, `start.bat` and `start.sh` equally.** When one
+> launcher is fixed, examine the others for the same issue and update them as
+> needed. Consider how code changes impact these launchers and modify them when
+> required.
+> 18. **Follow current compliance and security requirements for all work.** The
+> suite processes user-provided files, so every change must meet the latest
+> security guidelines and account for their effect on the `start.*` scripts.
 >
 > Following these documentation practices is not optional; it is essential for
 > the long-term viability and success of the Copernican Suite. Failure to

--- a/start.bat
+++ b/start.bat
@@ -10,7 +10,8 @@ REM re-executes itself inside that environment so later runs reuse it.
 setlocal
 cd %~dp0
 
-if not "%VIRTUAL_ENV%"=="" goto run
+REM Skip setup when already inside the virtual environment.
+if defined VIRTUAL_ENV goto run
 
 REM Locate python.exe or the py launcher.
 where python >NUL 2>NUL

--- a/start.command
+++ b/start.command
@@ -15,7 +15,9 @@ SCRIPT="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 cd "$(dirname "$0")"
 
 # Relaunch from inside the virtual environment when already activated.
-if [ -n "$VIRTUAL_ENV" ]; then
+# Use parameter expansion to avoid an "unbound variable" error when
+# "VIRTUAL_ENV" is unset and "set -u" is active.
+if [ -n "${VIRTUAL_ENV:-}" ]; then
     exec python copernican.py "$@"
 fi
 


### PR DESCRIPTION
## Summary
- prevent macOS `start.command` from failing when `VIRTUAL_ENV` is unset
- align Windows launcher with explicit virtual environment check
- add development laws for start script parity and strict security compliance

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md README.md start.bat start.command`

------
https://chatgpt.com/codex/tasks/task_e_68ad7dde7c24832fa7cf092dfdd2f5e0