### PR TITLE
Throttle optimization progress updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.28
+- 2025-08-26: Throttled optimisation progress updates and added tests
+              (OpenAI ChatGPT)
+
 ## Version 3.9.27
 - 2025-08-26: start.command handles unset VIRTUAL_ENV (OpenAI ChatGPT)
 - 2025-08-26: documented start script parity law (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.9.27
+**Version:** 3.9.28
 **Last Updated:** 2025-08-26
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -469,7 +469,9 @@ the
 main process; child processes simply read the sanitized cache.
 All engines import progress helpers from `copernican_lib/optim_utils.py` so
 that
-evaluation counting and reporting remain consistent across backends.
+evaluation counting and reporting remain consistent across backends. The
+helpers update the console at most once every ten evaluations or half a
+second to keep progress readable.
 
 New models are described entirely by YAML. Copy an existing file from
 `models/`

--- a/copernican_lib/optim_utils.py
+++ b/copernican_lib/optim_utils.py
@@ -59,6 +59,13 @@ def minimize_with_progress(
     label : str, optional
         Human readable label shown in the live progress display.
 
+    Notes
+    -----
+    Progress updates are throttled so the console is not flooded with
+    output.  The status line refreshes only after ten new evaluations or
+    when at least half a second has elapsed since the previous update,
+    whichever comes first.
+
     Returns
     -------
     result : OptimizeResult or ``None``
@@ -90,9 +97,14 @@ def minimize_with_progress(
     best_val = [np.inf]
     best_params = [list(x0)]
     start_time = time.time()
+    last_update = start_time
+    last_eval = 0
 
     def wrapped(p, *wrapped_args):
         """Internal function that records progress."""
+
+        nonlocal last_update, last_eval
+
         eval_count["count"] += 1
         val = func(p, *wrapped_args)
         if not np.isfinite(val):
@@ -100,18 +112,29 @@ def minimize_with_progress(
         if val < best_val[0]:
             best_val[0] = float(val)
             best_params[0] = list(p)
-        elapsed = time.time() - start_time
-        rate = (
-            f"{eval_count['count'] / elapsed:.1f} evals/s"
-            if elapsed > 1e-6
-            else "--- evals/s"
-        )
-        console.write(
-            f"  {label} Evals: {eval_count['count']:<5} | Best Chi2: "
-            f"{best_val[0]:.4f} | Speed: {rate:<15}",
-            end="\r",
-            error=False,
-        )
+
+        now = time.time()
+        need_update = False
+        if eval_count["count"] - last_eval >= 10:
+            need_update = True
+        if now - last_update >= 0.5:
+            need_update = True
+        if need_update:
+            elapsed = now - start_time
+            rate = (
+                f"{eval_count['count'] / elapsed:.1f} evals/s"
+                if elapsed > 1e-6
+                else "--- evals/s"
+            )
+            console.write(
+                f"  {label} Evals: {eval_count['count']:<5} | Best Chi2: "
+                f"{best_val[0]:.4f} | Speed: {rate:<15}",
+                end="\r",
+                error=False,
+            )
+            last_update = now
+            last_eval = eval_count["count"]
+
         return val if np.isfinite(val) else 1e12
 
     result = None

--- a/tests/test_optim_utils.py
+++ b/tests/test_optim_utils.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
+"""Tests for :mod:`copernican_lib.optim_utils`."""
+
+import unittest
+from itertools import repeat
+from unittest.mock import patch
+
+from copernican_lib import optim_utils
+
+
+class ProgressThrottleTestCase(unittest.TestCase):
+    """Ensure progress updates are rate limited."""
+
+    def test_eval_based_throttle(self) -> None:
+        """Output only after every tenth evaluation when time stands still."""
+
+        calls: list[str] = []
+
+        def fake_write(
+            msg: str = "", *, end: str = "\n", error: bool = False
+        ) -> None:
+            calls.append(msg)
+
+        def fake_minimize(
+            fun, x0, args=(), method=None, bounds=None, options=None
+        ):
+            for _ in range(25):
+                fun(x0, *args)
+            return object()
+
+        with (
+            patch("copernican_lib.optim_utils.console.write", new=fake_write),
+            patch("copernican_lib.optim_utils.minimize", new=fake_minimize),
+            patch(
+                "copernican_lib.optim_utils.time.time",
+                side_effect=repeat(0.0),
+            ),
+        ):
+            optim_utils.minimize_with_progress(
+                lambda p: 1.0, [0.0], [(-1.0, 1.0)]
+            )
+
+        progress = [c for c in calls if "Evals:" in c]
+        self.assertEqual(len(progress), 2)
+
+    def test_time_based_throttle(self) -> None:
+        """Output after half a second even with few evaluations."""
+
+        calls: list[str] = []
+
+        def fake_write(
+            msg: str = "", *, end: str = "\n", error: bool = False
+        ) -> None:
+            calls.append(msg)
+
+        def fake_minimize(
+            fun, x0, args=(), method=None, bounds=None, options=None
+        ):
+            for _ in range(5):
+                fun(x0, *args)
+            return object()
+
+        current = {"t": 0.0}
+
+        def fake_time() -> float:
+            t = current["t"]
+            current["t"] += 0.6
+            return t
+
+        with (
+            patch("copernican_lib.optim_utils.console.write", new=fake_write),
+            patch("copernican_lib.optim_utils.minimize", new=fake_minimize),
+            patch(
+                "copernican_lib.optim_utils.time.time", side_effect=fake_time
+            ),
+        ):
+            optim_utils.minimize_with_progress(
+                lambda p: 1.0, [0.0], [(-1.0, 1.0)]
+            )
+
+        progress = [c for c in calls if "Evals:" in c]
+        self.assertEqual(len(progress), 5)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution guard
+    unittest.main()


### PR DESCRIPTION
## Summary
- throttle optimization progress display to update after 10 evals or 0.5s
- document throttling behavior and integrate tests
- note progress throttling in README and bump version

## Testing
- `pre-commit run --files CHANGELOG.md README.md copernican_lib/optim_utils.py tests/test_optim_utils.py`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68ae33e5eed0832faf253fd51f4dc4e4