### PR TITLE
Externalize BAO plugin validation to callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.29
+- 2025-08-26: Externalised BAO plugin validation and updated tests
+              (OpenAI ChatGPT)
+
 ## Version 3.9.28
 - 2025-08-26: Throttled optimisation progress updates and added tests
               (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.9.28
+**Version:** 3.9.29
 **Last Updated:** 2025-08-26
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -238,6 +238,9 @@ archive](https://data.sdss.org/sas/dr12/boss/) does not provide a
 - Engines are selected interactively from the `engines/` directory. Parsers
   are
   discovered automatically when their source folders are imported.
+- Model plugins must be validated once using
+  `engine_interface.validate_plugin` before passing them to engine
+  routines or chi-squared helpers.
 - After each run you may choose to evaluate another model or exit. Cache files
   are cleaned automatically.
 - When a run finishes the suite prints the abstract text from each model along

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -40,7 +40,9 @@ modules are:
     be developed without modifying the rest of the codebase.
 
 Plugins are validated through ``engine_interface.validate_plugin`` before
-use. Engines expect the attributes listed in
+use. Chi-squared helpers assume this step has already succeeded, so
+validation should occur once before any iterative evaluation begins.
+Engines expect the attributes listed in
 ``engine_interface.REQUIRED_ATTRIBUTES``.  The resulting object exposes
 distance functions, CMB helpers and initial parameter guesses derived
 from the model YAML.

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -90,14 +90,15 @@ def chi_squared_sne(cosmo_params, mu_model_func, sne_data_df):
 def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
     r"""Return chi-squared for BAO observables.
 
-    If ``bao_data_df`` carries ``covariance_matrix_inv`` on ``.attrs`` the
-    full residual vector is evaluated as :math:`\Delta^T C^{-1} \Delta`.
+    Callers must validate ``model_plugin`` via
+    ``engine_interface.validate_plugin`` before invoking this helper. If
+    ``bao_data_df`` carries ``covariance_matrix_inv`` on ``.attrs`` the full
+    residual vector is evaluated as :math:`\Delta^T C^{-1} \Delta`.
     Datasets lacking a covariance (or providing an ill-conditioned one) fall
     back to diagonal errors. The calculation is vectorised so that distance
     functions operate on arrays directly.
     """
     logger = logging.getLogger()
-    engine_interface.validate_plugin(model_plugin)
     if getattr(model_plugin, "valid_for_bao", True) is False:
         logger.warning("(chi2_bao): Model invalid for BAO; skipping.")
         return np.inf
@@ -541,7 +542,8 @@ def fit_combined_parameters(
     sne_data_df, bao_data_df, cmb_data_df : pandas.DataFrame or ``None``
         Observational datasets to include in the fit.
     model_plugin : object
-        Validated plugin providing the cosmological model.
+        Plugin providing the cosmological model. It is validated once at the
+        start of the routine.
     maxiter : int, optional
         Maximum number of iterations for the combined optimisation. The
         default of ``2000`` mirrors previous behaviour but tests can reduce
@@ -764,9 +766,11 @@ def calculate_bao_observables(
     cosmo_params,
     z_smooth=None,
 ):
-    """
-    Calculates BAO observable predictions for a given model and its parameters.
-    Also calculates smooth curves for plotting if z_smooth is provided.
+    """Calculate BAO predictions for a validated model.
+
+    The plugin is validated once before computations begin.  The function
+    returns model predictions for each BAO data point and optionally smooth
+    curves for plotting if ``z_smooth`` is provided.
     """
     logger = logging.getLogger()
     engine_interface.validate_plugin(model_plugin)

--- a/tests/test_bao_covariance.py
+++ b/tests/test_bao_covariance.py
@@ -49,6 +49,7 @@ class BaoCovarianceTestCase(unittest.TestCase):
             "get_sound_horizon_rs_Mpc": lambda *_: 150.0,
         }
         cls.plugin = engine_interface.build_plugin(model_data, funcs)
+        engine_interface.validate_plugin(cls.plugin)
 
     def test_covariance_changes_chi2(self):
         """Using the covariance matrix yields a distinct chi-squared value."""


### PR DESCRIPTION
## Summary
- remove redundant `validate_plugin` call from BAO chi-squared helper and document requirement
- document one-time plugin validation in BAO routines and API overview
- enforce explicit validation in covariance test and bump version to 3.9.29

## Testing
- `pre-commit run --files engines/cosmo_engine_comb.py tests/test_bao_covariance.py README.md docs/api_overview.md CHANGELOG.md`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68ae3bd59d30832fa5118fab3c6e9fb1