### PR TITLE
Refactor BAO chi-squared helper to use pre-extracted arrays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ feature mismatches and suggests reinstalling with suitable wheels.
 The default engine is `engines/cosmo_engine_comb.py`. All model plugins are
 validated
 through `copernican_lib/engine_interface.py` before being passed to the
-engine.
-This
+engine. The BAO χ² helper accepts pre-extracted arrays so callers can
+convert data frames once outside optimisation loops. This
 ensures the expected functions are present and callable. Starting with
 version 1.11.4 the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.30
+- 2025-08-27: Refactored BAO χ² to accept arrays and updated tests (OpenAI ChatGPT)
+
 ## Version 3.9.29
 - 2025-08-26: Externalised BAO plugin validation and updated tests
               (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.9.29
-**Last Updated:** 2025-08-26
+**Version:** 3.9.30
+**Last Updated:** 2025-08-27
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and

--- a/copernican.py
+++ b/copernican.py
@@ -831,8 +831,20 @@ def main_workflow():
 
             chi2_bao = np.inf
             if pred_df is not None and np.isfinite(rs_Mpc):
+                z = bao_data_df["redshift"].to_numpy(dtype=float)
+                obs_type = bao_data_df["observable_type"].to_numpy()
+                obs_val = bao_data_df["value"].to_numpy(dtype=float)
+                obs_err = bao_data_df["error"].to_numpy(dtype=float)
+                cov_inv = bao_data_df.attrs.get("covariance_matrix_inv")
                 chi2_bao = cosmo_engine_selected.chi_squared_bao(
-                    bao_data_df, model_plugin, fitted_cosmo_p, rs_Mpc
+                    z,
+                    obs_type,
+                    obs_val,
+                    obs_err,
+                    model_plugin,
+                    fitted_cosmo_p,
+                    rs_Mpc,
+                    covariance_matrix_inv=cov_inv,
                 )
                 logger.info(
                     (

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -33,11 +33,14 @@ modules are:
   - `engines.cosmo_engine_comb` – reference engine providing high level
     optimisation routines such as ``fit_sne_parameters``,
     ``fit_combined_parameters``, ``calculate_bao_observables`` and generic
-    ``chi_squared_*`` helpers.  ``fit_combined_parameters`` accepts optional
-    ``maxiter``, ``maxfun`` and ``prefit_maxiter`` arguments to bound
-    optimisation time. Engines are regular Python modules that operate
-    purely on data frames and plugin callables so alternative backends can
-    be developed without modifying the rest of the codebase.
+    ``chi_squared_*`` helpers. ``chi_squared_bao`` accepts arrays
+    ``(z, observable_type, value, error)`` and an optional inverse
+    covariance so repeated evaluations can reuse cached data.
+    ``fit_combined_parameters`` accepts optional ``maxiter``, ``maxfun`` and
+    ``prefit_maxiter`` arguments to bound optimisation time. Engines are
+    regular Python modules that operate purely on data frames and plugin
+    callables so alternative backends can be developed without modifying the
+    rest of the codebase.
 
 Plugins are validated through ``engine_interface.validate_plugin`` before
 use. Chi-squared helpers assume this step has already succeeded, so

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -87,23 +87,35 @@ def chi_squared_sne(cosmo_params, mu_model_func, sne_data_df):
     return chi2 if np.isfinite(chi2) else np.inf
 
 
-def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
+def chi_squared_bao(
+    z,
+    obs_type,
+    obs_val,
+    obs_err,
+    model_plugin,
+    cosmo_params,
+    model_rs_Mpc,
+    covariance_matrix_inv=None,
+):
     r"""Return chi-squared for BAO observables.
 
     Callers must validate ``model_plugin`` via
-    ``engine_interface.validate_plugin`` before invoking this helper. If
-    ``bao_data_df`` carries ``covariance_matrix_inv`` on ``.attrs`` the full
-    residual vector is evaluated as :math:`\Delta^T C^{-1} \Delta`.
-    Datasets lacking a covariance (or providing an ill-conditioned one) fall
-    back to diagonal errors. The calculation is vectorised so that distance
-    functions operate on arrays directly.
+    ``engine_interface.validate_plugin`` before invoking this helper. The
+    arrays ``z``, ``obs_type``, ``obs_val`` and ``obs_err`` must be
+    extracted from the data frame once before optimisation. When
+    ``covariance_matrix_inv`` is provided the residual vector is evaluated as
+    :math:`\Delta^T C^{-1} \Delta`. Datasets lacking a covariance (or
+    providing an ill-conditioned one) fall back to diagonal errors. The
+    calculation is vectorised so that distance functions operate on arrays
+    directly.
     """
+
     logger = logging.getLogger()
     if getattr(model_plugin, "valid_for_bao", True) is False:
         logger.warning("(chi2_bao): Model invalid for BAO; skipping.")
         return np.inf
-    if bao_data_df is None or bao_data_df.empty:
-        logger.error("(chi2_bao): BAO data is empty.")
+    if z is None or len(z) == 0:
+        logger.error("(chi2_bao): BAO data arrays are empty.")
         return np.inf
     if not (np.isfinite(model_rs_Mpc) and model_rs_Mpc > 0):
         return np.inf
@@ -115,15 +127,9 @@ def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
         C_LIGHT = model_plugin.FIXED_PARAMS.get("C_LIGHT_KM_S", 299792.458)
     except AttributeError as e:
         logger.error(
-            "(chi2_bao): Model plugin missing required function: %s",
-            e,
+            "(chi2_bao): Model plugin missing required function: %s", e
         )
         return np.inf
-
-    z = bao_data_df["redshift"].to_numpy(dtype=float)
-    obs_type = bao_data_df["observable_type"].to_numpy()
-    obs_val = bao_data_df["value"].to_numpy(dtype=float)
-    obs_err = bao_data_df["error"].to_numpy(dtype=float)
 
     pred = np.full_like(obs_val, np.nan, dtype=float)
 
@@ -175,8 +181,7 @@ def chi_squared_bao(bao_data_df, model_plugin, cosmo_params, model_rs_Mpc):
         logger.warning("(chi2_bao): Non-finite residuals in BAO data.")
         return np.inf
 
-    # Use the full covariance matrix when provided by the parser.
-    C_inv = bao_data_df.attrs.get("covariance_matrix_inv")
+    C_inv = covariance_matrix_inv
     if C_inv is not None:
         try:
             if C_inv.shape[0] != len(resid):
@@ -350,7 +355,7 @@ def chi_squared_combined(
     params,
     plugin,
     sne_df=None,
-    bao_df=None,
+    bao_arrays=None,
     cmb_df=None,
     num_cosmo_params=None,
     cmb_extra_names=None,
@@ -364,8 +369,13 @@ def chi_squared_combined(
         optional SNe nuisance parameters.
     plugin : object
         Model plugin implementing the required distance and CMB functions.
-    sne_df, bao_df, cmb_df : DataFrame, optional
-        Data for the respective observations. Any of them may be ``None``.
+    sne_df : DataFrame, optional
+        SNe Ia observations.
+    bao_arrays : tuple, optional
+        Tuple ``(z, obs_type, obs_val, obs_err, cov_inv)`` extracted from the
+        BAO data frame. ``cov_inv`` may be ``None``.
+    cmb_df : DataFrame, optional
+        CMB observations.
     num_cosmo_params : int, optional
         Number of cosmological parameters at the start of ``params``. Required
         when nuisance parameters are present.
@@ -400,13 +410,18 @@ def chi_squared_combined(
             sne_df,
         )
 
-    if bao_df is not None and getattr(plugin, "valid_for_bao", True):
+    if bao_arrays is not None and getattr(plugin, "valid_for_bao", True):
+        z, obs_type, obs_val, obs_err, cov_inv = bao_arrays
         rs_val = plugin.get_sound_horizon_rs_Mpc(*cosmo_params)
         chi2_total += chi_squared_bao(
-            bao_df,
+            z,
+            obs_type,
+            obs_val,
+            obs_err,
             plugin,
             cosmo_params,
             rs_val,
+            covariance_matrix_inv=cov_inv,
         )
 
     if cmb_df is not None and getattr(plugin, "valid_for_cmb", True):
@@ -590,6 +605,16 @@ def fit_combined_parameters(
                 bounds.append((float(val) - spread, float(val) + spread))
                 param_names.append(key)
 
+    bao_arrays = None
+    if bao_data_df is not None:
+        bao_arrays = (
+            bao_data_df["redshift"].to_numpy(dtype=float),
+            bao_data_df["observable_type"].to_numpy(),
+            bao_data_df["value"].to_numpy(dtype=float),
+            bao_data_df["error"].to_numpy(dtype=float),
+            bao_data_df.attrs.get("covariance_matrix_inv"),
+        )
+
     # --- Optional Pre-fit: refine cosmological parameters using SNe only ---
     if sne_data_df is not None:
         logger.info("Running SNe pre-fit to obtain better starting values...")
@@ -630,7 +655,7 @@ def fit_combined_parameters(
             p,
             model_plugin,
             sne_df=sne_data_df,
-            bao_df=bao_data_df,
+            bao_arrays=bao_arrays,
             cmb_df=cmb_data_df,
             num_cosmo_params=num_cosmo_params,
             cmb_extra_names=cmb_extra_names,
@@ -655,7 +680,7 @@ def fit_combined_parameters(
             final_params,
             model_plugin,
             sne_df=sne_data_df,
-            bao_df=bao_data_df,
+            bao_arrays=bao_arrays,
             cmb_df=cmb_data_df,
             num_cosmo_params=num_cosmo_params,
             cmb_extra_names=cmb_extra_names,
@@ -676,18 +701,23 @@ def fit_combined_parameters(
             sne_data_df,
         )
     chi2_bao = np.nan
-    if bao_data_df is not None and getattr(
+    if bao_arrays is not None and getattr(
         model_plugin,
         "valid_for_bao",
         True,
     ):
         cosmo_subset = final_params[:num_cosmo_params]
         rs_val = model_plugin.get_sound_horizon_rs_Mpc(*cosmo_subset)
+        z_arr, type_arr, val_arr, err_arr, cov_inv = bao_arrays
         chi2_bao = chi_squared_bao(
-            bao_data_df,
+            z_arr,
+            type_arr,
+            val_arr,
+            err_arr,
             model_plugin,
             cosmo_subset,
             rs_val,
+            covariance_matrix_inv=cov_inv,
         )
     chi2_cmb = np.nan
     if cmb_data_df is not None and getattr(

--- a/tests/test_bao_covariance.py
+++ b/tests/test_bao_covariance.py
@@ -54,26 +54,42 @@ class BaoCovarianceTestCase(unittest.TestCase):
     def test_covariance_changes_chi2(self):
         """Using the covariance matrix yields a distinct chi-squared value."""
         rs = 150.0
-        cov = self.df
-        chi2_cov = chi_squared_bao(cov, self.plugin, (), rs)
+        z = self.df["redshift"].to_numpy(dtype=float)
+        obs_type = self.df["observable_type"].to_numpy()
+        obs_val = self.df["value"].to_numpy(dtype=float)
+        obs_err = self.df["error"].to_numpy(dtype=float)
+        cov_inv = self.df.attrs.get("covariance_matrix_inv")
 
-        diag_df = cov.copy()
-        diag_df.attrs["covariance_matrix_inv"] = None
-        chi2_diag = chi_squared_bao(diag_df, self.plugin, (), rs)
+        chi2_cov = chi_squared_bao(
+            z,
+            obs_type,
+            obs_val,
+            obs_err,
+            self.plugin,
+            (),
+            rs,
+            covariance_matrix_inv=cov_inv,
+        )
 
-        z = cov["redshift"].to_numpy(dtype=float)
-        obs_type = cov["observable_type"].to_numpy()
+        chi2_diag = chi_squared_bao(
+            z,
+            obs_type,
+            obs_val,
+            obs_err,
+            self.plugin,
+            (),
+            rs,
+        )
+
         pred = np.zeros(len(z), dtype=float)
         mask = obs_type == "DH_over_rs"
         if np.any(mask):
             hz = self.plugin.get_Hz_per_Mpc(z[mask])
             pred[mask] = 299792.458 / hz / rs
-        resid = cov["value"].to_numpy(dtype=float) - pred
+        resid = obs_val - pred
 
-        cov_inv = cov.attrs["covariance_matrix_inv"]
         chi2_cov_manual = float(resid @ cov_inv @ resid)
-        err = cov["error"].to_numpy(dtype=float)
-        chi2_diag_manual = float(np.sum((resid / err) ** 2))
+        chi2_diag_manual = float(np.sum((resid / obs_err) ** 2))
 
         self.assertAlmostEqual(chi2_cov, chi2_cov_manual)
         self.assertAlmostEqual(chi2_diag, chi2_diag_manual)

--- a/tests/test_bossdr12_parser.py
+++ b/tests/test_bossdr12_parser.py
@@ -80,12 +80,22 @@ class BossDR12ParserTestCase(unittest.TestCase):
         df = self.parser.parse_boss_dr12(str(self.data_dir))
         params = (67.66, 0.31, 0.112, 5e-5, 1090)
         rs = self.plugin.get_sound_horizon_rs_Mpc(*params)
-        chi2 = engine.chi_squared_bao(df, self.plugin, params, rs)
-        self.assertLess(chi2, 10.0)
-
         z = df["redshift"].to_numpy(dtype=float)
         obs_type = df["observable_type"].to_numpy()
         obs_val = df["value"].to_numpy(dtype=float)
+        obs_err = df["error"].to_numpy(dtype=float)
+        cov_inv = df.attrs.get("covariance_matrix_inv")
+        chi2 = engine.chi_squared_bao(
+            z,
+            obs_type,
+            obs_val,
+            obs_err,
+            self.plugin,
+            params,
+            rs,
+            covariance_matrix_inv=cov_inv,
+        )
+        self.assertLess(chi2, 10.0)
 
         pred = np.full_like(obs_val, np.nan, dtype=float)
         mask = obs_type == "DM_over_rs"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -82,7 +82,21 @@ class FunctionalTestCase(unittest.TestCase):
         pred_df, rs_mpc, _ = engine.calculate_bao_observables(
             bao_df, self.plugin, params
         )
-        chi2_bao = engine.chi_squared_bao(bao_df, self.plugin, params, rs_mpc)
+        z = bao_df["redshift"].to_numpy(dtype=float)
+        obs_type = bao_df["observable_type"].to_numpy()
+        obs_val = bao_df["value"].to_numpy(dtype=float)
+        obs_err = bao_df["error"].to_numpy(dtype=float)
+        cov_inv = bao_df.attrs.get("covariance_matrix_inv")
+        chi2_bao = engine.chi_squared_bao(
+            z,
+            obs_type,
+            obs_val,
+            obs_err,
+            self.plugin,
+            params,
+            rs_mpc,
+            covariance_matrix_inv=cov_inv,
+        )
         self.assertTrue(np.isfinite(chi2_bao))
 
         camb_params = self.plugin.get_camb_params(params)


### PR DESCRIPTION
## Summary
- Refactor `chi_squared_bao` to operate on precomputed arrays and optional inverse covariance
- Cache BAO arrays outside optimization loops in `fit_combined_parameters`
- Update CLI, docs, and tests for the new BAO chi-squared API

## Testing
- `pre-commit run --files engines/cosmo_engine_comb.py copernican.py tests/test_bossdr12_parser.py tests/test_bao_covariance.py tests/test_core.py AGENTS.md README.md CHANGELOG.md docs/api_overview.md`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68af23b763bc832f852ea3aa4cfcfced