### PR TITLE
Parallelize combined chi-squared computation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,10 @@ validated
 through `copernican_lib/engine_interface.py` before being passed to the
 engine. The BAO χ² helper accepts pre-extracted arrays so callers can
 convert data frames once outside optimisation loops. This
-ensures the expected functions are present and callable. Starting with
+ensures the expected functions are present and callable. Chi-squared
+values for SNe, BAO and CMB are evaluated concurrently when multiple
+datasets are supplied, using processes when objects are picklable and
+threads otherwise. Starting with
 version 1.11.4 the test suite no longer runs automatically. Execute
 `copernican.py --run-tests` or run `python -m unittest discover` to verify
 that the reference LCDM model and data parsers operate correctly. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,13 @@ put dates that are in the future or in the past! Follow this template:
 Version headers run newest to oldest, and within each version the newest
 entries come first):
 
+## Version 3.9.31
+- 2025-08-27: Parallelised combined χ² computation and added tests and
+              docs (OpenAI ChatGPT)
+
 ## Version 3.9.30
-- 2025-08-27: Refactored BAO χ² to accept arrays and updated tests (OpenAI ChatGPT)
+- 2025-08-27: Refactored BAO χ² to accept arrays and updated tests
+              (OpenAI ChatGPT)
 
 ## Version 3.9.29
 - 2025-08-26: Externalised BAO plugin validation and updated tests

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ parsers are discovered automatically under
    are fitted in turn.
 5. **BAO Analysis** – BAO observables are computed using the fitted
    parameters (from the combined fit if that engine was selected) and
-   chi-squared statistics are reported.
+   chi-squared statistics are reported. When several datasets are
+   available the SNe, BAO and CMB chi-squared contributions are evaluated
+   concurrently to reduce runtime.
 6. **CMB Analysis** – CMB power spectra are generated using the fitted
    cosmological parameters **and** any extra CMB-specific values from a
    combined optimisation. The chi-squared contribution is then calculated.

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -1,5 +1,7 @@
 # Copernican Suite API Overview
 
+**Last Updated:** 2025-08-27
+
 The suite exposes a lightweight API intended for advanced scripting.
 Most functionality lives in the ``copernican_lib`` package which can be
 imported directly without using the command-line interface.  The core
@@ -35,12 +37,13 @@ modules are:
     ``fit_combined_parameters``, ``calculate_bao_observables`` and generic
     ``chi_squared_*`` helpers. ``chi_squared_bao`` accepts arrays
     ``(z, observable_type, value, error)`` and an optional inverse
-    covariance so repeated evaluations can reuse cached data.
-    ``fit_combined_parameters`` accepts optional ``maxiter``, ``maxfun`` and
-    ``prefit_maxiter`` arguments to bound optimisation time. Engines are
-    regular Python modules that operate purely on data frames and plugin
-    callables so alternative backends can be developed without modifying the
-    rest of the codebase.
+    covariance so repeated evaluations can reuse cached data. The engine
+    evaluates SNe, BAO and CMB chi-squared terms concurrently when several
+    datasets are provided. ``fit_combined_parameters`` accepts optional
+    ``maxiter``, ``maxfun`` and ``prefit_maxiter`` arguments to bound
+    optimisation time. Engines are regular Python modules that operate
+    purely on data frames and plugin callables so alternative backends can
+    be developed without modifying the rest of the codebase.
 
 Plugins are validated through ``engine_interface.validate_plugin`` before
 use. Chi-squared helpers assume this step has already succeeded, so

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -14,7 +14,9 @@ cached by rounded parameter tuples which keeps repeated evaluations fast
 during iterative searches.
 """
 
+import concurrent.futures
 import logging
+import pickle
 from functools import lru_cache
 
 import camb
@@ -26,6 +28,15 @@ from copernican_lib.optim_utils import minimize_with_progress
 # ===========================================================================
 # --- CHI-SQUARED HELPER FUNCTIONS ---
 # ===========================================================================
+
+
+def _is_picklable(obj):
+    """Return ``True`` if ``obj`` can be pickled."""
+    try:
+        pickle.dumps(obj)
+        return True
+    except Exception:
+        return False
 
 
 def chi_squared_sne(cosmo_params, mu_model_func, sne_data_df):
@@ -360,7 +371,13 @@ def chi_squared_combined(
     num_cosmo_params=None,
     cmb_extra_names=None,
 ):
-    """Return global chi-squared summed over all available datasets.
+    r"""Return global chi-squared summed over all available datasets.
+
+    When more than one dataset is supplied the individual chi-squared
+    calculations are evaluated concurrently using
+    :mod:`concurrent.futures`.  A process pool is preferred when the plugin
+    and data are picklable; otherwise a thread pool is used.  If the parallel
+    setup fails the function falls back to serial execution.
 
     Parameters
     ----------
@@ -397,41 +414,73 @@ def chi_squared_combined(
         extra_slice = params[start:end]
         extra_params = {n: v for n, v in zip(cmb_extra_names, extra_slice)}
 
-    chi2_total = 0.0
-
+    tasks = []
     if sne_df is not None and getattr(
         plugin,
         "valid_for_distance_metrics",
         True,
     ):
-        chi2_total += chi_squared_sne(
-            cosmo_params,
-            plugin.distance_modulus_model,
-            sne_df,
+        tasks.append(
+            (
+                chi_squared_sne,
+                (cosmo_params, plugin.distance_modulus_model, sne_df),
+                {},
+            )
         )
 
     if bao_arrays is not None and getattr(plugin, "valid_for_bao", True):
         z, obs_type, obs_val, obs_err, cov_inv = bao_arrays
         rs_val = plugin.get_sound_horizon_rs_Mpc(*cosmo_params)
-        chi2_total += chi_squared_bao(
-            z,
-            obs_type,
-            obs_val,
-            obs_err,
-            plugin,
-            cosmo_params,
-            rs_val,
-            covariance_matrix_inv=cov_inv,
+        tasks.append(
+            (
+                chi_squared_bao,
+                (z, obs_type, obs_val, obs_err, plugin, cosmo_params, rs_val),
+                {"covariance_matrix_inv": cov_inv},
+            )
         )
 
     if cmb_df is not None and getattr(plugin, "valid_for_cmb", True):
-        chi2_total += chi_squared_cmb(
-            cosmo_params,
-            cmb_df,
-            plugin,
-            extra_params,
+        tasks.append(
+            (
+                chi_squared_cmb,
+                (cosmo_params, cmb_df, plugin, extra_params),
+                {},
+            )
         )
 
+    if len(tasks) <= 1:
+        results = [func(*args, **kwargs) for func, args, kwargs in tasks]
+        chi2_total = sum(results) if results else 0.0
+        return chi2_total if np.isfinite(chi2_total) else np.inf
+
+    all_picklable = all(
+        _is_picklable(obj)
+        for obj in (
+            plugin,
+            sne_df,
+            bao_arrays,
+            cmb_df,
+            extra_params,
+        )
+        if obj is not None
+    )
+    executor_cls = (
+        concurrent.futures.ProcessPoolExecutor
+        if all_picklable
+        else concurrent.futures.ThreadPoolExecutor
+    )
+    logger = logging.getLogger()
+    try:
+        with executor_cls() as exe:
+            futs = [exe.submit(f, *a, **kw) for f, a, kw in tasks]
+            results = [f.result() for f in futs]
+    except Exception as exc:
+        logger.warning(
+            "Parallel chi-squared failed (%s); falling back to serial", exc
+        )
+        results = [func(*args, **kwargs) for func, args, kwargs in tasks]
+
+    chi2_total = sum(results)
     return chi2_total if np.isfinite(chi2_total) else np.inf
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -182,6 +182,54 @@ class FunctionalTestCase(unittest.TestCase):
         )
         np.testing.assert_allclose(result, ref[:, 0][ells], rtol=1e-7)
 
+    def test_chi_squared_combined_parallel(self):
+        """chi_squared_combined sums concurrent dataset contributions."""
+        sne_df = data_loaders.load_sne_data("jla_2014").head(2)
+        if sne_df.attrs.get("covariance_matrix_inv") is not None:
+            attrs = sne_df.attrs
+            attrs["covariance_matrix_inv"] = attrs["covariance_matrix_inv"][
+                :2, :2
+            ]
+            attrs["diag_errors_for_plot"] = attrs["diag_errors_for_plot"][:2]
+        bao_df = data_loaders.load_bao_data("compound_bao_set").head(2)
+        cmb_df = data_loaders.load_cmb_data("planck_2018_lite").head(5).copy()
+        cmb_attrs = cmb_df.attrs
+        cmb_attrs["covariance_matrix_inv"] = cmb_attrs[
+            "covariance_matrix_inv"
+        ][:5, :5]
+        params = self.plugin.INITIAL_GUESSES
+        z = bao_df["redshift"].to_numpy(dtype=float)
+        obs_type = bao_df["observable_type"].to_numpy()
+        obs_val = bao_df["value"].to_numpy(dtype=float)
+        obs_err = bao_df["error"].to_numpy(dtype=float)
+        cov_inv = bao_df.attrs.get("covariance_matrix_inv")
+        total_parallel = engine.chi_squared_combined(
+            params,
+            self.plugin,
+            sne_df=sne_df,
+            bao_arrays=(z, obs_type, obs_val, obs_err, cov_inv),
+            cmb_df=cmb_df,
+        )
+        rs_val = self.plugin.get_sound_horizon_rs_Mpc(*params)
+        total_serial = (
+            engine.chi_squared_sne(
+                params, self.plugin.distance_modulus_model, sne_df
+            )
+            + engine.chi_squared_bao(
+                z,
+                obs_type,
+                obs_val,
+                obs_err,
+                self.plugin,
+                params,
+                rs_val,
+                covariance_matrix_inv=cov_inv,
+            )
+            + engine.chi_squared_cmb(params, cmb_df, self.plugin)
+        )
+        self.assertTrue(np.isfinite(total_parallel))
+        self.assertAlmostEqual(total_parallel, total_serial)
+
 
 class PlotterUtilTestCase(unittest.TestCase):
     """Test helper utilities in ``plotter``."""


### PR DESCRIPTION
## Summary
- compute SNe, BAO and CMB chi-squared terms concurrently in the combined engine
- document parallel chi-squared evaluation and thread/process fallbacks
- add regression test covering the parallel chi-squared path

## Testing
- `pre-commit run --files engines/cosmo_engine_comb.py README.md docs/api_overview.md AGENTS.md CHANGELOG.md tests/test_core.py`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68af481b2254832f9d28b0e90b30a8fe