### PR TITLE
Enforce Last Updated fields across docs and scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 # Copernican Suite Development Guide
+**Last Updated:** 2025-08-27
 
 Development notes were previously kept at the top of this file. That history
 now
@@ -218,7 +219,8 @@ these rules:
 4. **Update documentation**, including this `AGENTS.md`, `README.md` and the
    `docs/` directory, whenever behaviour or structure changes. Each task must
    expand the documentation's scope and size, refresh version strings and
-   update all `Last Updated` fields.
+   ensure every file carries a `Last Updated` field. Update that field on
+   every edit and add one when missing.
 5. **Keep these laws synchronized across `README.md` and `AGENTS.md`.**
    Amendments to any rule require an explicit human request.
 6. **Bump the project version according to Semantic Versioning whenever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changelog
+**Last Updated:** 2025-08-27
+
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the
 latest version header. AI assistant warning: please, always check the current
@@ -22,6 +25,8 @@ entries come first):
 ## Version 3.9.31
 - 2025-08-27: Parallelised combined χ² computation and added tests and
               docs (OpenAI ChatGPT)
+- 2025-08-27: Added Last Updated fields and clarified development rules
+              (OpenAI ChatGPT)
 
 ## Version 3.9.30
 - 2025-08-27: Refactored BAO χ² to accept arrays and updated tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Contributing to the Copernican Suite
+**Last Updated:** 2025-08-12
 
 Thank you for considering a contribution. Before opening a pull request,
 please

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
 # Copernican Suite License (CSL) v1.5
+**Last Updated:** 2025-08-12
 
 > **Effective Date:** June 22, 2025
 > **Copyright** © 2025 Apostol Apostolov and Black Epsilon Ltd., Republic of

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,4 +1,5 @@
 # Copernican Suite Development Plan
+**Last Updated:** 2025-08-15
 
 ## Overview
 Copernican Suite has grown from a single script into a modular, cross-platform

--- a/README.md
+++ b/README.md
@@ -548,7 +548,8 @@ development protocols and interface requirements.
 > 4. **Update documentation**, including this `AGENTS.md`, `README.md` and the
 > `docs/` directory, whenever behaviour or structure changes. Each task must
 > expand the documentation's scope and size, refresh version strings and
-> update all `Last Updated` fields.
+> ensure every file carries a `Last Updated` field. Update that field on
+> every edit and add one when missing.
 > 5. **Keep these laws synchronized across `README.md` and `AGENTS.md`.**
 > Amendments to any rule require an explicit human request.
 > 6. **Bump the project version according to Semantic Versioning whenever**

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,4 +1,5 @@
 # Third-Party Licenses
+**Last Updated:** 2025-08-23
 
 The Copernican Suite relies on the following runtime dependencies. Their
 versions and license texts are shipped under [`licenses/`](licenses/) so

--- a/data/cmb/planck2018lite/readme_baseline.md
+++ b/data/cmb/planck2018lite/readme_baseline.md
@@ -1,4 +1,5 @@
 # Baseline likelihoods release
+**Last Updated:** 2025-07-06
 
 This file contains 10 likelihood files that forms the baseline Planck likelihood data release. One is used for the low-&#8467; TT (`commander`), three provide the low-&#8467; polarization part (`simall`) to account for either the EE contribution (baseline) the BB one or both the EE and BB one (options). On the high-&#8467; side, two files are provided for the baseline TT and TTTEEE `plik` likelihood, and two others for the foreground and nuisance marginalized `plik_lite`. Finally, the lensing likelihood is provided in two versions, one model dependent, and the other marginalized over the CMB reconstructed in the `plik_lite` likelihood.
 

--- a/docs/dataset_metadata.md
+++ b/docs/dataset_metadata.md
@@ -1,4 +1,5 @@
 # Dataset Metadata Fields
+**Last Updated:** 2025-08-22
 
 Each dataset folder contains a `metadata_*.yml` file that describes the
 source. All fields are optional except for `dataset_name`, `dataset_id`,

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -1,4 +1,5 @@
 # Copernican Suite Architecture
+**Last Updated:** 2025-08-17
 
 This short document explains the updated folder layout introduced in
 version 1.14.2.  The `copernican_lib` package now collects all

--- a/docs/latex_syntax.md
+++ b/docs/latex_syntax.md
@@ -1,4 +1,5 @@
 # LaTeX Syntax Guide
+**Last Updated:** 2025-08-17
 
 This document describes the supported LaTeX-like syntax for cosmological model
 YAML files. Expressions are parsed by `latex_utils.py` and converted to NumPy-

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,4 +1,5 @@
 # Packaging Guide
+**Last Updated:** 2025-08-26
 
 This document explains how to prepare the suite for development or packaging.
 

--- a/start.bat
+++ b/start.bat
@@ -1,5 +1,6 @@
 @REM Copyright (c) 2025 Copernican Suite developers.
 @REM See LICENSE.md in the repository root for details.
+@REM Last Updated: 2025-08-26
 
 @echo off
 REM Start the Copernican Suite on Windows.

--- a/start.command
+++ b/start.command
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2025 Copernican Suite developers.
 # See LICENSE.md in the repository root for details.
+# Last Updated: 2025-08-26
 
 # Start the Copernican Suite on macOS.
 #

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2025 Copernican Suite developers.
 # See LICENSE.md in the repository root for details.
+# Last Updated: 2025-08-26
 
 # Start the Copernican Suite on Unix-like systems.
 #


### PR DESCRIPTION
## Summary
- add Last Updated metadata to documentation and start scripts
- require updating the Last Updated field in all edited files via AGENTS and README
- record policy update in changelog

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md CONTRIBUTING.md LICENSE.md PLAN.md README.md THIRD_PARTY_LICENSES.md data/cmb/planck2018lite/readme_baseline.md docs/dataset_metadata.md docs/design_overview.md docs/latex_syntax.md docs/packaging.md start.bat start.command start.sh`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68af4f5316c0832f88e3e687d3ab3ecd