### PR TITLE
feat: log dataset file hashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Copernican Suite Development Guide
-**Last Updated:** 2025-08-28
+**Last Updated:** 2025-08-27
 
 Development notes were previously kept at the top of this file. That history
 now
@@ -26,9 +26,12 @@ using Matplotlib's standard text rendering. Dataset names retain their
 original spacing and the second line wraps after 190 characters when
 necessary.
 Each run directory also includes a `run_manifest_*.yml` file listing the
-selected models, engine, dataset hashes and Git state to aid reproducibility.
-Parsers must register under the `dataset_id` stated in their metadata so
-the loaders can locate them directly without discovery.
+selected models, engine, dataset hashes and Git state to aid
+reproducibility. The data loaders compute and log SHA256 digests for all
+non-parser files in each dataset directory and store these hashes on the
+returned DataFrames. The manifest copies this mapping verbatim. Parsers
+must register under the `dataset_id` stated in their metadata so the
+loaders can locate them directly without discovery.
 
 The program enables Python's ``faulthandler`` at startup and registers
 ``SIGILL``, ``SIGSEGV`` and ``SIGFPE`` handlers. When triggered, they dump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Log changes here
 
+## Version 3.11.2
+- 2025-08-27: Logged SHA256 digests for dataset files and propagated them
+               through the run manifest (OpenAI ChatGPT)
+
 ## Version 3.11.1
 - 2025-08-27: Added xarray to locked dependencies and documented automatic
   installation of emcee, xarray and ArviZ (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.11.1
+**Version:** 3.11.2
 **Last Updated:** 2025-08-27
 
 The Copernican Suite is a Python toolkit for testing cosmological models

--- a/copernican.py
+++ b/copernican.py
@@ -803,8 +803,10 @@ def main_workflow():
         ]:
             ds_id = df.attrs.get("dataset_id")
             data_dir = registry.get(ds_id, {}).get("data_dir")
+            # ``file_hashes`` enables manifest reproducibility.
+            hashes = df.attrs.get("file_hashes", {})
             if ds_id and data_dir:
-                dataset_info.append((ds_id, data_dir))
+                dataset_info.append((ds_id, data_dir, hashes))
 
         manifest = run_manifest.build_manifest(
             models=[

--- a/copernican_lib/data_loaders.py
+++ b/copernican_lib/data_loaders.py
@@ -17,7 +17,7 @@ import logging
 import os
 
 from . import console_output as console
-from .utils import check_dataset_id, load_metadata_from_dir
+from .utils import check_dataset_id, compute_sha256, load_metadata_from_dir
 
 # Each parser is registered via a decorator so that ``copernican.py`` can list
 # available data sources dynamically. The loaders below simply call the
@@ -385,6 +385,27 @@ def _log_dataset_info(df, data_type, logger):
             )
 
 
+def _attach_file_hashes(df, data_dir, logger):
+    """Compute SHA256 hashes for files in ``data_dir`` and log them.
+
+    The resulting mapping is stored on ``df.attrs['file_hashes']`` so later
+    stages such as the run manifest can embed the exact input digests.  Each
+    hash is logged for audit purposes to aid reproducibility.
+    """
+
+    file_hashes = {}
+    for root, _, files in os.walk(data_dir):
+        for fname in sorted(files):
+            if fname.endswith(".py"):
+                continue
+            path = os.path.join(root, fname)
+            rel = os.path.relpath(path, data_dir)
+            file_hashes[rel] = compute_sha256(path)
+    df.attrs["file_hashes"] = file_hashes
+    for rel, digest in file_hashes.items():
+        logger.info("SHA256 %s: %s", rel, digest)
+
+
 # --- Main Loading Functions ---
 def load_sne_data(dataset_id=None, **kwargs):
     """Load SNe data for the chosen ``dataset_id``."""
@@ -419,6 +440,7 @@ def load_sne_data(dataset_id=None, **kwargs):
             logger.info(
                 f"Successfully loaded {len(data_df)} SNe data points.",
             )
+            _attach_file_hashes(data_df, data_dir, logger)
             _log_dataset_info(data_df, "SNe", logger)
         elif data_df is None:
             logger.error(
@@ -470,6 +492,7 @@ def load_bao_data(dataset_id=None, **kwargs):
             logger.info(
                 f"Successfully loaded {len(data_df)} BAO data points.",
             )
+            _attach_file_hashes(data_df, data_dir, logger)
             _log_dataset_info(data_df, "BAO", logger)
         elif data_df is None:
             logger.error(
@@ -521,6 +544,7 @@ def load_cmb_data(dataset_id=None, **kwargs):
             logger.info(
                 f"Successfully loaded {len(data_df)} CMB data points.",
             )
+            _attach_file_hashes(data_df, data_dir, logger)
             _log_dataset_info(data_df, "CMB", logger)
         elif data_df is None:
             logger.error(
@@ -573,6 +597,7 @@ def load_gw_data(dataset_id=None, **kwargs):
             logger.info(
                 f"Successfully loaded {len(data_df)} GW data points.",
             )
+            _attach_file_hashes(data_df, data_dir, logger)
             _log_dataset_info(data_df, "GW", logger)
         elif data_df is None:
             logger.error(
@@ -628,7 +653,8 @@ def load_siren_data(dataset_id=None, **kwargs):
                 f"{len(data_df)} standard siren data points."
             )
             logger.info(msg)
-            _log_dataset_info(data_df, "SIREN", logger)
+            _attach_file_hashes(data_df, data_dir, logger)
+            _log_dataset_info(data_df, "Standard siren", logger)
         elif data_df is None:
             logger.error(
                 f"Standard siren parser '{dataset_id}' returned None.",

--- a/copernican_lib/run_manifest.py
+++ b/copernican_lib/run_manifest.py
@@ -2,15 +2,16 @@
 
 The manifest records critical information required to reproduce a run.
 It captures model and engine details, parameter priors, dataset hashes
-and the Git state.  Each run directory stores the resulting YAML file so
-that analyses can be traced back unambiguously.
+provided by the data loaders and the Git state.  Each run directory
+stores the resulting YAML file so that analyses can be traced back
+unambiguously.
 """
 
 from __future__ import annotations
 
 import os
 import subprocess
-from typing import Iterable, Tuple
+from typing import Dict, Iterable, Tuple
 
 import yaml
 
@@ -51,7 +52,7 @@ def _git_info() -> dict:
 def build_manifest(
     models: Iterable[Tuple[object, str]],
     engine_module: object,
-    datasets: Iterable[Tuple[str, str]],
+    datasets: Iterable[Tuple[str, str, Dict[str, str]]],
     seed: int,
 ) -> dict:
     """Collect manifest information for the current run.
@@ -66,7 +67,9 @@ def build_manifest(
         Selected engine module object.  ``ENGINE_VERSION`` is queried when
         available.
     datasets:
-        Iterable of ``(dataset_id, data_dir)`` tuples.
+        Iterable of ``(dataset_id, data_dir, file_hashes)`` tuples.  The
+        ``file_hashes`` mapping mirrors the ``file_hashes`` attribute attached
+        to the :class:`pandas.DataFrame` produced by the dataset loader.
     seed:
         RNG seed applied to the run.
     """
@@ -100,15 +103,7 @@ def build_manifest(
             }
         )
 
-    for dataset_id, data_dir in datasets:
-        file_hashes = {}
-        for root, _, files in os.walk(data_dir):
-            for fname in sorted(files):
-                if fname.endswith(".py"):
-                    continue
-                path = os.path.join(root, fname)
-                rel = os.path.relpath(path, data_dir)
-                file_hashes[rel] = utils.compute_sha256(path)
+    for dataset_id, data_dir, file_hashes in datasets:
         manifest["datasets"][dataset_id] = {
             "path": data_dir,
             "hashes": file_hashes,

--- a/docs/data_overview.md
+++ b/docs/data_overview.md
@@ -1,5 +1,5 @@
 # Data Directory Overview
-**Last Updated:** 2025-08-24
+**Last Updated:** 2025-08-27
 
 This document explains the layout of the `data/` directory and the role of the
 parser scripts stored with each dataset.
@@ -29,9 +29,12 @@ information (for example `title`, `volume`, `journal` and `DOI`) are read
 by `copernican_lib/data_loaders.py` after the parser returns so individual
 parsers remain metadata-agnostic. Parsed DataFrames expose the same
 information on their `.attrs` property, and `dataset_id` is used when
-constructing output filenames. See `dataset_metadata.md` for a full
-description of these fields. The reference tables remain read-only, while
-parser `.py` files and accompanying `metadata_*.yml` files may be updated.
+constructing output filenames. The loaders also compute a SHA256 digest
+for every non-parser file in the dataset directory. These hashes are
+stored on `df.attrs['file_hashes']` and logged so manifests can reproduce
+exact inputs. See `dataset_metadata.md` for a full description of the
+metadata fields. The reference tables remain read-only, while parser
+`.py` files and accompanying `metadata_*.yml` files may be updated.
 
 ## Supernovae Datasets
 

--- a/tests/test_data_hashes.py
+++ b/tests/test_data_hashes.py
@@ -1,0 +1,23 @@
+import importlib
+import os
+import unittest
+
+from copernican_lib import data_loaders, utils
+
+
+class DataHashingTest(unittest.TestCase):
+    """Verify SHA256 hashes are stored and logged for dataset files."""
+
+    def test_bao_compound_hashes(self):
+        importlib.import_module("data.bao.compound.cosmo_parser_compound")
+        with self.assertLogs(level="INFO") as log:
+            df = data_loaders.load_bao_data(dataset_id="compound_bao_set")
+        hashes = df.attrs.get("file_hashes", {})
+        fname = os.path.join("data", "bao", "compound", "compound.yml")
+        expected = utils.compute_sha256(fname)
+        self.assertEqual(hashes.get("compound.yml"), expected)
+        self.assertTrue(any(expected in msg for msg in log.output))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_run_manifest.py
+++ b/tests/test_run_manifest.py
@@ -22,10 +22,11 @@ def test_manifest_contains_required_fields():
         with open(data_path, "w", encoding="utf-8") as fh:
             fh.write("hello world\n")
         engine = SimpleNamespace(__name__="engine", ENGINE_VERSION="0.0")
+        file_hashes = {"data.txt": utils.compute_sha256(data_path)}
         manifest = run_manifest.build_manifest(
             models=[(_dummy_plugin(), "1.0")],
             engine_module=engine,
-            datasets=[("ds", tmpdir)],
+            datasets=[("ds", tmpdir, file_hashes)],
             seed=123,
         )
         path = run_manifest.save_manifest(manifest, tmpdir)
@@ -36,6 +37,6 @@ def test_manifest_contains_required_fields():
         assert "ds" in loaded["datasets"]
         hashes = loaded["datasets"]["ds"]["hashes"]
         assert "data.txt" in hashes
-        assert hashes["data.txt"] == utils.compute_sha256(data_path)
+        assert hashes["data.txt"] == file_hashes["data.txt"]
         assert len(loaded["git"]["commit"]) == 40
         assert "dirty" in loaded["git"]


### PR DESCRIPTION
## Summary
- compute SHA256 hashes for dataset files when loading data and log them for audit
- embed precomputed file hashes in run manifests and main orchestrator
- document hash logging in data overview

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md README.md copernican.py copernican_lib/data_loaders.py copernican_lib/run_manifest.py docs/data_overview.md tests/test_run_manifest.py tests/test_data_hashes.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68af8e48b84c832fae3c55376fc6d917