### PR TITLE
Add CLI seed option and extend RNG seeding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ returned DataFrames. The manifest copies this mapping verbatim. Parsers
 must register under the `dataset_id` stated in their metadata so the
 loaders can locate them directly without discovery.
 
+A `--seed` command line option selects the global RNG seed. The value is
+stored in the run manifest and logged so analyses can be reproduced.
+
 The program enables Python's ``faulthandler`` at startup and registers
 ``SIGILL``, ``SIGSEGV`` and ``SIGFPE`` handlers. When triggered, they dump
 stack traces to both the console and the active log file before exiting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Log changes here
 
+## Version 3.12.0
+- 2025-08-27: Added ``--seed`` CLI option, seeded Python and engine RNGs and
+               logged the value in manifest and logs (OpenAI ChatGPT)
+
 ## Version 3.11.2
 - 2025-08-27: Logged SHA256 digests for dataset files and propagated them
                through the run manifest (OpenAI ChatGPT)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "Copernican Suite"
-version: "3.11.0"
+version: "3.12.0"
 date-released: 2025-08-27
 authors:
   - name: "Copernican Developers"
@@ -10,5 +10,5 @@ preferred-citation:
   authors:
     - name: "Copernican Developers"
   title: "Copernican Suite"
-  version: "3.11.0"
+  version: "3.12.0"
   date-released: 2025-08-27

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.11.2
+**Version:** 3.12.0
 **Last Updated:** 2025-08-27
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -118,7 +118,9 @@ Under the hood the program follows a clear pipeline:
    runner reports informational messages, warnings and errors while
    verifying the reference model and parsers. Add `--strict-warnings`
    to upgrade warnings to errors for reproducible CI runs.
-4. Results, including posterior chains, will appear inside a timestamped
+4. Provide `--seed <n>` to select a deterministic RNG state. It defaults to
+   `0` and seeds NumPy, Python's ``random`` module and supported engines.
+5. Results, including posterior chains, will appear inside a timestamped
    folder under `output/` when the run completes.
 
 ## Dependencies
@@ -515,11 +517,12 @@ not modify them unless explicitly instructed.
 3.  **Initialization**: The script starts and creates the `./output/`
     directory
     for all results.
-4.  **Random Seed Setup**: The global NumPy RNG is seeded so any stochastic
-    algorithms remain reproducible. The chosen seed is written to the log.
+4.  **Random Seed Setup**: The global NumPy and Python ``random`` RNGs are
+    seeded so stochastic algorithms remain reproducible. Supported engines
+    such as CAMB are seeded too. The chosen seed is written to the log and
+    run manifest and can be changed with ``--seed``.
 5.  **Configuration**: The user specifies the file paths for the model and
-    data
-    files.
+    data files.
 6.  **SNe Ia Fitting**: The `cosmo_engine` fits the parameters of both the
     ΛCDM
     model and the alternative model to the SNe Ia data. When

--- a/copernican.py
+++ b/copernican.py
@@ -249,6 +249,7 @@ def parse_args():
         ``strict_warnings`` upgrades all warnings to errors to ensure
         deterministic CI behaviour.  ``yes`` installs missing dependencies
         without asking for confirmation, simplifying non-interactive CI runs.
+        ``seed`` sets the global RNG state for reproducible runs.
     """
 
     parser = argparse.ArgumentParser(description="Copernican Suite")
@@ -268,6 +269,12 @@ def parse_args():
         "-y",
         action="store_true",
         help="install missing packages without prompting",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="RNG seed for NumPy, Python and engines",
     )
     return parser.parse_args()
 
@@ -691,8 +698,9 @@ def main_workflow():
             _sanity_check_numpy_scipy(logger)
         except Exception:
             exit_clean(1)
-        seed = 0
+        seed = args.seed
         utils.set_random_seed(seed)
+        logger.info("Using RNG seed %s", seed)
         start_ts = time.strftime("%y%m%d_%H%M%S")
         run_start_dt = datetime.datetime.now()
         run_start_pc = time.perf_counter()

--- a/copernican_lib/utils.py
+++ b/copernican_lib/utils.py
@@ -17,6 +17,7 @@ science logic rather than housekeeping.
 import hashlib
 import logging
 import os
+import random
 import time
 
 import numpy as np
@@ -133,10 +134,21 @@ def load_metadata_from_dir(data_dir: str) -> dict:
 
 
 def set_random_seed(seed: int = 0) -> None:
-    """Seed NumPy's global RNG and log the selected value.
+    """Seed global RNGs and log the selected value.
 
-    Engines call this helper so that optimisation results can be
-    reproduced exactly when the same seed is provided.
+    Engines call this helper so optimisation results can be reproduced
+    when the same seed is provided.  The Python ``random`` module and
+    optional engine libraries such as CAMB are seeded when available.
     """
     np.random.seed(seed)
-    logging.getLogger().info("Global RNG seed set to %s", seed)
+    random.seed(seed)
+    logger = logging.getLogger()
+    try:  # pragma: no cover - CAMB is optional
+        import camb  # type: ignore
+
+        if hasattr(camb, "set_random_seed"):
+            camb.set_random_seed(seed)
+            logger.info("CAMB RNG seed set to %s", seed)
+    except Exception:
+        logger.debug("CAMB RNG seeding unavailable", exc_info=True)
+    logger.info("Global RNG seed set to %s", seed)

--- a/docs/run_manifest.md
+++ b/docs/run_manifest.md
@@ -1,5 +1,5 @@
 # Run Manifest
-**Last Updated:** 2025-08-28
+**Last Updated:** 2025-08-27
 
 The suite writes a YAML manifest for every evaluation under the run's output
 folder.  The file is named `run_manifest_<timestamp>.yml` and records:
@@ -16,6 +16,9 @@ run exactly.  To rerun an analysis:
    matches the worktree state.
 2. Verify that each data file still produces the recorded SHA256 digest.
 3. Configure the suite with the same model, priors, engine and seed.
+
+The seed is chosen via the ``--seed`` command line option. The value is
+saved in the manifest and main log so runs can be reproduced exactly.
 
 The manifest is intentionally human readable so it can be archived in lab
 notebooks or cited in publications.

--- a/tests/test_seed_option.py
+++ b/tests/test_seed_option.py
@@ -1,0 +1,30 @@
+"""Tests for ``--seed`` command line option."""
+
+import importlib
+import random
+import unittest
+from unittest import mock
+
+import numpy as np
+
+with mock.patch("sys.version_info", (3, 12, 0)):
+    copernican = importlib.import_module("copernican")
+from copernican_lib import utils
+
+
+class SeedOptionTestCase(unittest.TestCase):
+    """Ensure different CLI seeds produce distinct RNG states."""
+
+    def test_cli_seed_changes_rng(self):
+        """Verify that separate seeds lead to different RNG outputs."""
+        values = []
+        for seed in (1, 2):
+            with mock.patch("sys.argv", ["copernican.py", f"--seed={seed}"]):
+                args = copernican.parse_args()
+            utils.set_random_seed(args.seed)
+            values.append((np.random.rand(), random.random()))
+        self.assertNotEqual(values[0], values[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `--seed` flag to `copernican.py` and log selected seed
- expand `utils.set_random_seed` to seed Python and engine RNGs
- document seed handling and bump version to 3.12.0

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md CITATION.cff README.md copernican.py copernican_lib/utils.py docs/run_manifest.md tests/test_seed_option.py`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68af99d60af4832f8262c96949763aba