### PR TITLE
Add result writer and covariance outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Log changes here
 
+## Version 3.13.0
+- 2025-08-28: Added result writer for parameter summaries and exposed
+              covariance matrices from optimisation and MCMC engines
+              (OpenAI ChatGPT)
+
 ## Version 3.12.0
 - 2025-08-27: Added ``--seed`` CLI option, seeded Python and engine RNGs and
                logged the value in manifest and logs (OpenAI ChatGPT)

--- a/copernican.py
+++ b/copernican.py
@@ -33,6 +33,7 @@ import signal
 
 from copernican_lib import console_output as console
 from copernican_lib import run_manifest
+from copernican_lib import result_writer
 from copernican_lib.version import get_version
 
 # Verify interpreter version early so users see clear feedback
@@ -864,6 +865,17 @@ def main_workflow():
                 )
             )
             alt_time += time.perf_counter() - t0
+
+        # Persist parameter estimates so external tools can inspect the
+        # numerical results without parsing logs.  The summary includes fitted
+        # values, 1σ errors and the covariance matrix for each model.
+        result_writer.save_summary(
+            {
+                lcdm.MODEL_NAME: lcdm_sne_fit_results,
+                alt_model_plugin.MODEL_NAME: alt_model_sne_fit_results,
+            },
+            OUTPUT_DIR,
+        )
 
         logger.info("\n--- Stage 3: BAO Analysis ---\n")
 

--- a/copernican_lib/result_writer.py
+++ b/copernican_lib/result_writer.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025 Copernican Suite developers.
+# See LICENSE.md in the repository root for details.
+
+"""Utilities for saving parameter fit summaries.
+
+The Copernican Suite evaluates cosmological models and often produces
+parameter estimates alongside their uncertainties.  This module serialises
+those results to both JSON and YAML so that external tools can ingest the
+numbers without depending on the full code base.  The writer accepts a
+mapping of model names to engine result dictionaries.  Each entry should
+contain ``fitted_cosmological_params`` with best-fit values, optional
+``parameter_errors`` describing 1σ uncertainties and an optional
+``covariance_matrix``.  NumPy arrays are converted to plain Python lists to
+keep the output fully serialisable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+import numpy as np
+import yaml
+
+from .utils import get_timestamp
+
+
+def _to_serialisable(obj: Any) -> Any:
+    """Return ``obj`` converted to JSON/YAML friendly types.
+
+    NumPy arrays are cast to nested lists while scalars become plain ``float``
+    objects.  This keeps the writer lightweight and avoids introducing a
+    heavier dependency such as ``pandas`` for simple transformations.
+    """
+
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, (np.floating, np.integer)):
+        return obj.item()
+    return obj
+
+
+def save_summary(
+    results: Mapping[str, Mapping[str, Any]],
+    output_dir: str | Path,
+    *,
+    timestamp: str | None = None,
+) -> tuple[Path, Path]:
+    """Write parameter summaries for one or more models.
+
+    Parameters
+    ----------
+    results : mapping
+        Mapping of model name to dictionaries containing fit information.  At
+        minimum each entry should provide ``fitted_cosmological_params``.
+    output_dir : path-like
+        Directory where the summary files will be written.
+    timestamp : str, optional
+        Timestamp appended to the filename.  When ``None`` a current timestamp
+        is generated via :func:`copernican_lib.utils.get_timestamp`.
+
+    Returns
+    -------
+    tuple of :class:`~pathlib.Path`
+        Paths to the JSON and YAML files, respectively.  Returning the paths
+        simplifies testing and allows callers to log the exact locations.
+    """
+
+    out_path = Path(output_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    ts = timestamp or get_timestamp()
+
+    summary: Dict[str, Dict[str, Any]] = {}
+    for model_name, res in results.items():
+        params = res.get("fitted_cosmological_params") or {}
+        errors = res.get("parameter_errors") or {}
+        cov = res.get("covariance_matrix")
+        param_names = list(params.keys())
+        cov_entry = None
+        if cov is not None:
+            cov_entry = {
+                "param_names": param_names,
+                "matrix": _to_serialisable(cov),
+            }
+        summary[model_name] = {
+            "parameters": {k: _to_serialisable(v) for k, v in params.items()},
+            "errors_1sigma": (
+                {k: _to_serialisable(v) for k, v in errors.items()}
+                if errors
+                else None
+            ),
+            "covariance_matrix": cov_entry,
+        }
+
+    base_name = f"parameter-summary_{ts}"
+    json_path = out_path / f"{base_name}.json"
+    yaml_path = out_path / f"{base_name}.yml"
+    with open(json_path, "w", encoding="utf-8") as jh:
+        json.dump(summary, jh, indent=2)
+    with open(yaml_path, "w", encoding="utf-8") as yh:
+        yaml.safe_dump(summary, yh, sort_keys=False)
+    return json_path, yaml_path
+
+
+__all__ = ["save_summary"]

--- a/docs/api_overview.md
+++ b/docs/api_overview.md
@@ -1,6 +1,6 @@
 # Copernican Suite API Overview
 
-**Last Updated:** 2025-08-27
+**Last Updated:** 2025-08-28
 
 The suite exposes a lightweight API intended for advanced scripting.
 Most functionality lives in the ``copernican_lib`` package which can be
@@ -34,6 +34,9 @@ modules are:
 - `csv_writer.save_sne_results_detailed_csv`,
   `save_bao_results_csv` and `save_cmb_results_csv` – persist fitting
   results with filenames that encode the dataset, model and timestamp.
+- `result_writer.save_summary(results, output_dir)` – serialize fitted
+  parameters, 1σ errors and covariance matrices to JSON and YAML for later
+  analysis.
   - `engines.cosmo_engine_comb` – reference engine providing high level
     optimisation routines such as ``fit_sne_parameters``,
     ``fit_combined_parameters``, ``calculate_bao_observables`` and generic
@@ -99,3 +102,18 @@ result = engine.fit_sne_parameters(sne, plugin)
 Because the API is intentionally thin, advanced users can orchestrate custom
 pipelines or integrate the suite into larger optimisation frameworks without
 relying on the command-line wrapper.
+
+## Parameter Summary Format
+
+The :mod:`result_writer` helper stores parameter estimates after optimisation
+or sampling.  Files named ``parameter-summary_<timestamp>.json`` and ``.yml``
+are created in the current run directory.  Each model entry contains
+``parameters``, ``errors_1sigma`` and ``covariance_matrix`` with ``param_names``
+and a numeric matrix.  The data is fully serialisable so external analysis
+tools can parse it without importing NumPy or pandas.
+
+Example::
+
+    from copernican_lib import result_writer
+    summary = {"LCDM": engine_results}
+    result_writer.save_summary(summary, "output/run")

--- a/engines/cosmo_engine_comb.py
+++ b/engines/cosmo_engine_comb.py
@@ -738,6 +738,20 @@ def fit_combined_parameters(
         if result and hasattr(result, "message") and result.message:
             message += f" (Optimizer msg: {result.message})"
         success_flag = np.isfinite(chi2_tot)
+
+    covariance = None
+    errors_dict = None
+    if result and hasattr(result, "hess_inv"):
+        try:
+            hess = result.hess_inv
+            if hasattr(hess, "todense"):
+                hess = hess.todense()
+            covariance = np.asarray(hess, dtype=float)
+            errs = np.sqrt(np.diag(covariance))
+            errors_dict = {n: e for n, e in zip(param_names, errs)}
+        except Exception:
+            covariance = None
+            errors_dict = None
     chi2_sne = np.nan
     if sne_data_df is not None and getattr(
         model_plugin,
@@ -836,6 +850,9 @@ def fit_combined_parameters(
         "reduced_chi2": reduced,
         "message": message,
         "n_evals_wrapper": eval_total,
+        "parameter_errors": errors_dict,
+        "covariance_matrix": covariance,
+        "param_names": param_names,
     }
 
 

--- a/engines/cosmo_engine_mcmc.py
+++ b/engines/cosmo_engine_mcmc.py
@@ -114,12 +114,21 @@ def fit_sne_parameters(
     mean_params = np.mean(chain[start:], axis=(0, 1))
     fitted = {n: v for n, v in zip(names, mean_params)}
 
+    # Flatten the tail of the chain so a standard covariance calculation can be
+    # performed.  The diagonal of this covariance yields 1σ parameter errors.
+    flat_chain = chain[start:].reshape(-1, ndim)
+    covariance = np.cov(flat_chain, rowvar=False)
+    errors = np.sqrt(np.diag(covariance))
+    error_dict = {n: e for n, e in zip(names, errors)}
+
     return {
         "success": True,
         "samples": chain,
         "fitted_cosmological_params": fitted,
         "model_name": getattr(model_plugin, "MODEL_NAME", "Unknown"),
         "param_names": list(names),
+        "parameter_errors": error_dict,
+        "covariance_matrix": covariance,
     }
 
 

--- a/tests/test_result_writer.py
+++ b/tests/test_result_writer.py
@@ -1,0 +1,69 @@
+"""Tests for the parameter summary writer."""
+
+import json
+import numbers
+import os
+import tempfile
+import unittest
+
+import pandas as pd
+import yaml
+
+from copernican_lib import (
+    engine_interface,
+    model_coder,
+    model_parser,
+    result_writer,
+)
+from engines import cosmo_engine_mcmc
+
+
+class TestResultWriter(unittest.TestCase):
+    """Ensure that result summaries are written with expected structure."""
+
+    def _build_lcdm_plugin(self):
+        models_dir = os.path.join(os.path.dirname(__file__), "..", "models")
+        yaml_path = os.path.join(models_dir, "cosmo_model_lcdm.yml")
+        cache_dir = os.path.join(models_dir, "cache")
+        cache_path = model_parser.parse_model(yaml_path, cache_dir)
+        func_dict, parsed = model_coder.generate_callables(cache_path)
+        return engine_interface.build_plugin(parsed, func_dict)
+
+    def test_summary_contains_parameters(self):
+        plugin = self._build_lcdm_plugin()
+        sne_df = pd.DataFrame(
+            {
+                "zcmb": [0.01, 0.02],
+                "mu_obs": [40.0, 41.0],
+                "e_mu_obs": [0.1, 0.1],
+            }
+        )
+        res = cosmo_engine_mcmc.fit_sne_parameters(
+            sne_df, plugin, n_walkers=4, n_steps=6, pool_size=1
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            json_path, yaml_path = result_writer.save_summary(
+                {plugin.MODEL_NAME: res}, tmpdir, timestamp="test"
+            )
+            with open(json_path, "r", encoding="utf-8") as fh:
+                jdata = json.load(fh)
+            with open(yaml_path, "r", encoding="utf-8") as fh:
+                ydata = yaml.safe_load(fh)
+            for data in (jdata, ydata):
+                self.assertIn(plugin.MODEL_NAME, data)
+                entry = data[plugin.MODEL_NAME]
+                self.assertIn("parameters", entry)
+                self.assertIn("errors_1sigma", entry)
+                self.assertIn("covariance_matrix", entry)
+                for val in entry["parameters"].values():
+                    self.assertIsInstance(val, numbers.Real)
+                for val in entry["errors_1sigma"].values():
+                    self.assertIsInstance(val, numbers.Real)
+                matrix = entry["covariance_matrix"]["matrix"]
+                for row in matrix:
+                    for val in row:
+                        self.assertIsInstance(val, numbers.Real)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `result_writer.save_summary` for JSON/YAML parameter summaries
- expose covariance matrices and 1σ errors from optimisation and MCMC engines
- document parameter summary format and add regression tests

## Testing
- `pre-commit run --files copernican_lib/result_writer.py engines/cosmo_engine_comb.py engines/cosmo_engine_mcmc.py copernican.py tests/test_result_writer.py docs/api_overview.md CHANGELOG.md`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68af9c87db90832fba0d16e54fc91b9b