### PR TITLE
Enforce repository virtual env and update development laws

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Copernican Suite Development Guide
-**Last Updated:** 2025-08-27
+**Last Updated:** 2025-08-28
 
 Development notes were previously kept at the top of this file. That history
 now
@@ -261,6 +261,16 @@ these rules:
 18. **Follow current compliance and security requirements for all work.** The
     suite processes user-provided files, so every change must meet the latest
     security guidelines and consider their impact on the `start.*` scripts.
+19. **Add tests alongside new functionality or behaviour changes.** Each
+    feature or fix must include unit tests demonstrating the intended
+    behaviour.
+20. **Audit licenses for new dependencies.** Ensure added packages are
+    license-compatible and update `THIRD_PARTY_LICENSES.md` and the
+    `licenses/` directory accordingly.
+21. **Run the suite exclusively through the managed virtual environment.**
+    Always launch via `start.sh`, `start.command` or `start.bat` so the
+    repository's `.venv` is created or updated automatically; other Python
+    environments must be ignored.
 
 Failure to follow these guidelines will compromise the Copernican Suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-**Last Updated:** 2025-08-27
+**Last Updated:** 2025-08-28
 
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the
@@ -22,6 +22,11 @@ put dates that are in the future or in the past! Follow this template:
 ## Version 3.12.0
 - 2025-08-27: Added ``--seed`` CLI option, seeded Python and engine RNGs and
                logged the value in manifest and logs (OpenAI ChatGPT)
+
+## Version 3.12.1
+- 2025-08-28: Enforced use of repository virtual environment, added laws on
+  testing and dependency licensing, and worked around ArviZ's NumPy pin in
+  start scripts (OpenAI ChatGPT)
 
 ## Version 3.11.2
 - 2025-08-27: Logged SHA256 digests for dataset files and propagated them

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.12.0
-**Last Updated:** 2025-08-27
+**Version:** 3.12.1
+**Last Updated:** 2025-08-28
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
@@ -134,6 +134,10 @@ They also verify that `.venv/bin/activate` exists and hint to install
 `python3.11-venv` when it does not. Inside the virtual environment this
 project relies on `numpy`, `scipy`, `matplotlib`, `pandas`, `sympy`,
 `jsonschema`, `camb==1.6.2`, `emcee`, `xarray` and `arviz`.
+The launchers refuse to run when another virtual environment is active and
+reinstall pinned dependencies on every start so the suite always uses its
+managed `.venv`. ArviZ is installed separately to bypass its outdated NumPy
+constraint; the script handles this automatically.
 
 Versions and SHA256 hashes for all runtime dependencies are pinned in
 `requirements.lock`. When a package is missing the program asks before
@@ -141,8 +145,9 @@ running `pip install --require-hashes -r requirements.lock` and verifies
 each import. Use `--yes` to skip the prompt in automated environments.
 The same versions appear under `[project].dependencies` in `pyproject.toml`.
 Regenerate both files together whenever dependencies change.
-Running outside `.venv` instructs you to launch via `start.*`. Future
-engines may also depend on `numba` or GPU libraries.
+Running `copernican.py` directly now fails with a message directing you to
+use the `start.*` helpers. Future engines may also depend on `numba` or GPU
+libraries.
 
 ## Building & Installation
 Windows users should open `start.bat`, macOS users should run
@@ -598,6 +603,16 @@ accurately** convey their purpose without unnecessary length.
 > 18. **Follow current compliance and security requirements for all work.** The
 > suite processes user-provided files, so every change must meet the latest
 > security guidelines and account for their effect on the `start.*` scripts.
+> 19. **Add tests alongside new functionality or behaviour changes.** Each
+> feature or fix must include unit tests demonstrating the intended
+> behaviour.
+> 20. **Audit licenses for new dependencies.** Ensure added packages are
+> license-compatible and update `THIRD_PARTY_LICENSES.md` and the
+> `licenses/` directory accordingly.
+> 21. **Run the suite exclusively through the managed virtual environment.**
+> Always launch via `start.sh`, `start.command` or `start.bat` so the
+> repository's `.venv` is created or updated automatically; other Python
+> environments must be ignored.
 >
 > Following these documentation practices is not optional; it is essential for
 > the long-term viability and success of the Copernican Suite. Failure to

--- a/copernican.py
+++ b/copernican.py
@@ -55,6 +55,20 @@ if sys.version_info < MIN_PYTHON:
     )
     exit_clean(1)
 
+# Require execution from the repository's virtual environment so that global
+# site-packages are ignored.
+EXPECTED_VENV = (Path(__file__).resolve().parent / ".venv").resolve()
+current_venv = os.environ.get("VIRTUAL_ENV")
+if current_venv is None or Path(current_venv).resolve() != EXPECTED_VENV:
+    console.write(
+        (
+            "ERROR: Run Copernican Suite via start.sh, start.command or "
+            "start.bat inside its managed .venv."
+        ),
+        error=True,
+    )
+    exit_clean(1)
+
 # Enable low-level stack tracing so crashes reveal their origin.
 faulthandler.enable()
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,5 +1,5 @@
 # Packaging Guide
-**Last Updated:** 2025-08-26
+**Last Updated:** 2025-08-28
 
 This document explains how to prepare the suite for development or packaging.
 
@@ -7,7 +7,8 @@ This document explains how to prepare the suite for development or packaging.
 
 The `start.*` launchers verify Python 3.11+ before bootstrapping the suite.
 If the interpreter is missing or outdated they display one of the following
-commands and exit:
+commands and exit. They also refuse to run when another virtual environment is
+active so the repository's `.venv` is always used:
 
 - **Debian/Ubuntu**: `sudo apt install python3.11 python3.11-venv`
 - **macOS**: `brew install python@3.11`
@@ -17,7 +18,8 @@ Run the command for your platform, then re-run the launcher.
 
 ## Bootstrap the virtual environment
 
-Run the launcher in the project root:
+Run the launcher in the project root. It recreates or upgrades `.venv` on every
+start and ignores globally installed packages:
 
 - `start.bat` on Windows
 - `start.command` on macOS
@@ -25,8 +27,8 @@ Run the launcher in the project root:
 
 The script verifies Python 3.11+, then creates or reuses `.venv`, upgrades
 `pip`, installs packages from `requirements.lock` with hash verification and
-installs the project itself with `pip install --no-deps .`. It ignores an
-unset `VIRTUAL_ENV` to avoid shell errors on first launch. Re-run it after
+installs the project itself with `pip install --no-deps .`. ArviZ is installed
+separately to work around its stale NumPy requirement. Re-run the launcher after
 pulling updates to refresh the environment.
 
 `requirements.lock` pins exact versions and SHA256 hashes for all runtime

--- a/start.bat
+++ b/start.bat
@@ -1,6 +1,6 @@
 @REM Copyright (c) 2025 Copernican Suite developers.
 @REM See LICENSE.md in the repository root for details.
-@REM Last Updated: 2025-08-26
+@REM Last Updated: 2025-08-28
 
 @echo off
 REM Start the Copernican Suite on Windows.
@@ -10,9 +10,16 @@ REM re-executes itself inside that environment so later runs reuse it.
 
 setlocal
 cd %~dp0
+set "EXPECTED_VENV=%CD%\.venv"
 
-REM Skip setup when already inside the virtual environment.
-if defined VIRTUAL_ENV goto run
+REM Skip setup when already inside the repository virtual environment.
+if defined VIRTUAL_ENV (
+    if /I not "%VIRTUAL_ENV%"=="%EXPECTED_VENV%" (
+        echo Deactivate the active virtual environment before running start.bat.
+        exit /b 1
+    )
+    goto run
+)
 
 REM Locate python.exe or the py launcher.
 where python >NUL 2>NUL
@@ -63,10 +70,12 @@ if not exist .venv\Scripts\activate.bat (
 call .venv\Scripts\activate.bat
 set PYTHON=python
 %PYTHON% -m pip install --upgrade pip
-REM Install pinned dependencies with hash verification.
-%PYTHON% -m pip install --require-hashes -r requirements.lock
-REM Remove any 'build' directory before and after installing the project
-REM to avoid stale build artifacts.
+set "REQ_NO_ARVIZ=%TEMP%\copernican_req.txt"
+findstr /v "^arviz==" requirements.lock > "%REQ_NO_ARVIZ%"
+%PYTHON% -m pip install --require-hashes -r "%REQ_NO_ARVIZ%"
+del "%REQ_NO_ARVIZ%"
+%PYTHON% -m pip install --no-deps arviz==0.16.1 ^
+    --hash=sha256:872d1d685719f81a31f94c25278cbaef314df7f6cad0671935f26a006182b8d4
 if exist build rmdir /s /q build
 %PYTHON% -m pip install --no-deps .
 if exist build rmdir /s /q build

--- a/start.command
+++ b/start.command
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2025 Copernican Suite developers.
 # See LICENSE.md in the repository root for details.
-# Last Updated: 2025-08-26
+# Last Updated: 2025-08-28
 
 # Start the Copernican Suite on macOS.
 #
@@ -18,7 +18,13 @@ cd "$(dirname "$0")"
 # Relaunch from inside the virtual environment when already activated.
 # Use parameter expansion to avoid an "unbound variable" error when
 # "VIRTUAL_ENV" is unset and "set -u" is active.
-if [ -n "${VIRTUAL_ENV:-}" ]; then
+# Enforce use of the repository's own virtual environment.
+EXPECTED_VENV="$(pwd)/.venv"
+if [ -n "${VIRTUAL_ENV:-}" ] && [ "$VIRTUAL_ENV" != "$EXPECTED_VENV" ]; then
+    echo "Deactivate the active virtual environment before running start.command." >&2
+    exit 1
+fi
+if [ "${VIRTUAL_ENV:-}" = "$EXPECTED_VENV" ]; then
     exec python copernican.py "$@"
 fi
 
@@ -71,8 +77,15 @@ fi
 # avoid stale build artifacts.
 source .venv/bin/activate
 python -m pip install --upgrade pip
-# Install pinned dependencies to ensure reproducible environments.
-python -m pip install --require-hashes -r requirements.lock
+# Install pinned dependencies with ArviZ handled separately to bypass its
+# NumPy requirement.
+REQ_TMP="$(mktemp)"
+grep -v '^arviz==' requirements.lock > "$REQ_TMP"
+python -m pip install --require-hashes -r "$REQ_TMP"
+python -m pip install --no-deps \
+    arviz==0.16.1 \
+    --hash=sha256:872d1d685719f81a31f94c25278cbaef314df7f6cad0671935f26a006182b8d4
+rm "$REQ_TMP"
 # Remove any 'build/' directory before and after installing the project
 # to avoid stale build artifacts.
 rm -rf build

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2025 Copernican Suite developers.
 # See LICENSE.md in the repository root for details.
-# Last Updated: 2025-08-26
+# Last Updated: 2025-08-28
 
 # Start the Copernican Suite on Unix-like systems.
 #
@@ -19,7 +19,13 @@ cd "$(dirname "$0")"
 # If we are already inside the virtual environment simply launch the suite.
 # Use parameter expansion to avoid an "unbound variable" error when
 # "VIRTUAL_ENV" is unset and "set -u" is active.
-if [ -n "${VIRTUAL_ENV:-}" ]; then
+# Enforce use of the repository's own virtual environment.
+EXPECTED_VENV="$(pwd)/.venv"
+if [ -n "${VIRTUAL_ENV:-}" ] && [ "$VIRTUAL_ENV" != "$EXPECTED_VENV" ]; then
+    echo "Deactivate the active virtual environment before running start.sh." >&2
+    exit 1
+fi
+if [ "${VIRTUAL_ENV:-}" = "$EXPECTED_VENV" ]; then
     exec python copernican.py "$@"
 fi
 
@@ -79,8 +85,15 @@ fi
 # project to avoid stale build artifacts.
 source .venv/bin/activate
 python -m pip install --upgrade pip
-# Install pinned dependencies to ensure reproducible environments.
-python -m pip install --require-hashes -r requirements.lock
+# Install pinned dependencies with ArviZ handled separately to bypass its
+# NumPy requirement.
+REQ_TMP="$(mktemp)"
+grep -v '^arviz==' requirements.lock > "$REQ_TMP"
+python -m pip install --require-hashes -r "$REQ_TMP"
+python -m pip install --no-deps \
+    arviz==0.16.1 \
+    --hash=sha256:872d1d685719f81a31f94c25278cbaef314df7f6cad0671935f26a006182b8d4
+rm "$REQ_TMP"
 rm -rf build
 python -m pip install --no-deps .
 rm -rf build


### PR DESCRIPTION
## Summary
- add development laws for test coverage, dependency licensing, and mandatory use of the managed virtual environment
- harden launchers to refuse foreign venvs and install ArviZ separately to bypass its NumPy pin
- require `copernican.py` to run only inside `.venv` and document the new behaviour

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md README.md copernican.py docs/packaging.md start.bat start.command start.sh`
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'emcee')*


------
https://chatgpt.com/codex/tasks/task_e_68af68800790832fa046c6ccda7b7613