### PR TITLE
ci: use python -m pip on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
           steps.cache-venv.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          .\.venv\Scripts\pip install --upgrade pip
+          .\.venv\Scripts\python -m pip install --upgrade pip
           .\.venv\Scripts\pip install --require-hashes -r requirements.lock
           .\.venv\Scripts\pip install --no-deps . pre-commit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Log changes here
 
+## Version 3.13.3
+- 2025-08-28: Replaced direct pip call with python -m pip in Windows workflow
+              (OpenAI ChatGPT)
+
 ## Version 3.13.2
 - 2025-08-28: Replaced ArviZ VCS dependency with pinned commit archive
               (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 3.13.2
+**Version:** 3.13.3
 **Last Updated:** 2025-08-28
 
 The Copernican Suite is a Python toolkit for testing cosmological models


### PR DESCRIPTION
## Summary
- use `python -m pip` for Windows dependency install in tests workflow
- bump suite version to 3.13.3
- document Windows workflow change in changelog

## Testing
- `pre-commit run --files .github/workflows/tests.yml CHANGELOG.md README.md`
- `python -m unittest discover` *(fails: No module named 'emcee')*

------
https://chatgpt.com/codex/tasks/task_e_68b03925889c832f9c79184ce7fa1505