### PR TITLE
feat: support custom build versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Copernican Suite Development Guide
-**Last Updated:** 2025-08-28
+**Last Updated:** 2025-08-29
 
 Development notes were previously kept at the top of this file. That history
 now
@@ -285,3 +285,5 @@ tags using `setuptools_scm`. Runtime code should obtain the current version
 via ``copernican_lib.version.get_version`` rather than hard-coded strings.
 Contributors must update the version whenever a pull request introduces a
 change covered by these rules.
+Setting ``COPERNICAN_VERSION`` in the environment overrides the derived
+version so CI builds can embed custom prerelease identifiers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-**Last Updated:** 2025-08-28
+**Last Updated:** 2025-08-29
 
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the
@@ -18,6 +18,10 @@ put dates that are in the future or in the past! Follow this template:
 
 ```
 ## Log changes here
+
+## Version 3.13.6
+- 2025-08-29: Allowed `COPERNICAN_VERSION` to override runtime version and
+               documented custom prerelease builds (OpenAI ChatGPT)
 
 ## Version 3.13.5
 - 2025-08-28: Pinned h5netcdf dependency for ArviZ to satisfy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 3.13.5
-**Last Updated:** 2025-08-28
+**Version:** 3.13.6
+**Last Updated:** 2025-08-29
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
@@ -643,6 +643,9 @@ features increment `MINOR` and bug fixes increment `PATCH`. Package builds use
 `setuptools_scm` to derive the version from Git tags, so the version string is
 never hard-coded. Runtime code should call
 `copernican_lib.version.get_version` to obtain the current version.
+
+Set ``COPERNICAN_VERSION`` during builds to supply custom prerelease
+identifiers, for example in CI when building off feature branches.
 
 The `MINOR` value only increases when the suite gains a new data type or a
 similarly significant feature, such as introducing CMB support or a new

--- a/copernican_lib/version.py
+++ b/copernican_lib/version.py
@@ -12,6 +12,7 @@ version-like identifier even in degenerate cases. Centralising this lookup
 avoids scattering hard-coded versions across the codebase.
 """
 
+import os
 from importlib.metadata import PackageNotFoundError, version
 
 try:
@@ -28,14 +29,19 @@ PACKAGE_NAME = "copernican-suite"
 def get_version() -> str:
     """Return the Copernican Suite version string.
 
-    The function first tries :mod:`importlib.metadata` to retrieve the
-    installed distribution version. When the package is not installed, the
-    version is derived from the Git worktree using
-    :func:`setuptools_scm.get_version` if the optional dependency is available.
-    If both lookups fail or ``setuptools_scm`` is missing, the placeholder
-    ``"0+unknown"`` is returned.
+    The function first honours the ``COPERNICAN_VERSION`` environment
+    variable so CI or development builds can supply custom prerelease
+    identifiers. If the variable is unset it queries
+    :mod:`importlib.metadata` for the installed distribution version. When the
+    package is not installed, the version is derived from the Git worktree
+    using :func:`setuptools_scm.get_version` if the optional dependency is
+    available. If both lookups fail or ``setuptools_scm`` is missing, the
+    placeholder ``"0+unknown"`` is returned.
     """
 
+    env_version = os.environ.get("COPERNICAN_VERSION")
+    if env_version:
+        return env_version
     try:
         return version(PACKAGE_NAME)
     except PackageNotFoundError:

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,5 +1,5 @@
 # Packaging Guide
-**Last Updated:** 2025-08-28
+**Last Updated:** 2025-08-29
 
 This document explains how to prepare the suite for development or packaging.
 
@@ -44,6 +44,17 @@ pip build .
 ```
 
 The command writes source archives and wheels to the `dist/` directory.
+
+### Custom version strings
+
+Set the ``COPERNICAN_VERSION`` environment variable before building to
+override the version derived from Git. This is useful for CI jobs on
+feature branches. For example, a build off ``work`` might use:
+
+```bash
+export COPERNICAN_VERSION="1.2.1-alpha+work.$(git rev-parse --short HEAD)"
+pip build .
+```
 
 ## Verify the build
 

--- a/tests/test_version_env.py
+++ b/tests/test_version_env.py
@@ -1,0 +1,30 @@
+"""Tests for version overrides via environment variables."""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from copernican_lib.version import get_version
+
+
+class VersionEnvTest(unittest.TestCase):
+    """Ensure COPERNICAN_VERSION takes precedence over SCM lookups."""
+
+    def test_env_override(self) -> None:
+        """get_version returns the environment value when set."""
+
+        test_version = "1.2.3-custom"
+        old = os.environ.get("COPERNICAN_VERSION")
+        os.environ["COPERNICAN_VERSION"] = test_version
+        try:
+            self.assertEqual(get_version(), test_version)
+        finally:
+            if old is None:
+                os.environ.pop("COPERNICAN_VERSION", None)
+            else:
+                os.environ["COPERNICAN_VERSION"] = old
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow overriding runtime version via `COPERNICAN_VERSION`
- document custom build version strings and environment overrides
- add test covering environment version override

## Testing
- `pre-commit run --files copernican_lib/version.py tests/test_version_env.py docs/packaging.md README.md AGENTS.md CHANGELOG.md`
- `python -m unittest discover -v` *(fails: missing managed .venv and ArviZ dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68b188f95c30832f962a1093ebc6d8b1