### PR TITLE
feat: add interactive seed prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,10 @@ returned DataFrames. The manifest copies this mapping verbatim. Parsers
 must register under the `dataset_id` stated in their metadata so the
 loaders can locate them directly without discovery.
 
-A ``COPERNICAN_SEED`` environment variable selects the global RNG seed. The
-value is stored in the run manifest and logged so analyses can be
-reproduced.
+A ``COPERNICAN_SEED`` environment variable overrides the interactive seed
+prompt.  When unset, the program asks users to accept the default ``0``, enter
+their own value or generate a random seed.  The final choice is stored in the
+run manifest and logged so analyses can be reproduced.
 
 The program enables Python's ``faulthandler`` at startup and registers
 ``SIGILL``, ``SIGSEGV`` and ``SIGFPE`` handlers. When triggered, they dump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Log changes here
 
+## Version 4.3.0
+- 2025-08-30: Removed ``--seed`` flag in favour of an interactive seed prompt
+              with manual and random options; updated manifest, utilities,
+              tests and documentation (OpenAI ChatGPT)
+
 ## Version 4.2.1
 - 2025-08-30: Added package manager password notices in launchers and
               updated README and LICENSE (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 4.2.1
+**Version:** 4.3.0
 **Last Updated:** 2025-08-30
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -121,9 +121,9 @@ Under the hood the program follows a clear pipeline:
    reference model and parsers. Toggle strict warning mode from the menu
    or set `COPERNICAN_STRICT_WARNINGS=1` to upgrade warnings to errors for
    reproducible CI runs.
-4. Set `COPERNICAN_SEED=<n>` before launching to select a deterministic RNG
-   state. It defaults to `0` and seeds NumPy, Python's ``random`` module and
-   supported engines.
+4. When prompted, choose an RNG seed or set `COPERNICAN_SEED=<n>` in the
+   environment to skip the prompt. The seed defaults to `0` and is applied to
+   NumPy, Python's ``random`` module and supported engines.
 5. Results, including posterior chains, will appear inside a timestamped
    folder under `output/` when the run completes.
 
@@ -536,10 +536,10 @@ not modify them unless explicitly instructed.
 3.  **Initialization**: The script starts and creates the `./output/`
     directory
     for all results.
-4.  **Random Seed Setup**: The global NumPy and Python ``random`` RNGs are
-    seeded so stochastic algorithms remain reproducible. Supported engines
-    such as CAMB are seeded too. The chosen seed is written to the log and
-    run manifest and can be changed with ``COPERNICAN_SEED``.
+4.  **Random Seed Setup**: Early in the run the suite either reads
+    ``COPERNICAN_SEED`` or prompts for a seed. NumPy, Python's ``random``
+    module and supported engines are seeded with this value, which is written
+    to the log and run manifest.
 5.  **Configuration**: The user specifies the file paths for the model and
     data files.
 6.  **SNe Ia Fitting**: The `cosmo_engine` fits the parameters of both the

--- a/copernican.py
+++ b/copernican.py
@@ -30,6 +30,7 @@ from pathlib import Path
 import faulthandler
 import signal
 from dataclasses import dataclass
+import random
 
 from copernican_lib import console_output as console
 from copernican_lib import run_manifest
@@ -261,7 +262,6 @@ class RuntimeOptions:
     run_tests: bool = False
     strict_warnings: bool = False
     auto_confirm: bool = False
-    seed: int = 0
 
 
 def get_runtime_options() -> RuntimeOptions:
@@ -271,8 +271,53 @@ def get_runtime_options() -> RuntimeOptions:
         run_tests=os.environ.get("COPERNICAN_RUN_TESTS") == "1",
         strict_warnings=os.environ.get("COPERNICAN_STRICT_WARNINGS") == "1",
         auto_confirm=os.environ.get("COPERNICAN_AUTO_INSTALL") == "1",
-        seed=int(os.environ.get("COPERNICAN_SEED", "0")),
     )
+
+
+def select_seed() -> int:
+    """Prompt the user for an RNG seed.
+
+    The ``COPERNICAN_SEED`` environment variable overrides the interactive
+    prompt so automated runs remain deterministic.  When unset users may
+    accept the default ``0``, enter a manual value or request a random
+    seed.  The selected value is applied via :func:`utils.set_random_seed`
+    and returned for convenience.
+    """
+
+    from copernican_lib import utils as _utils
+
+    env_seed = os.environ.get("COPERNICAN_SEED")
+    if env_seed is not None:
+        seed = int(env_seed)
+        _utils.set_random_seed(seed)
+        return seed
+
+    console.write("Select RNG seed:")
+    console.write("1) Use default seed 0")
+    console.write("2) Enter a seed manually")
+    console.write("3) Generate a random seed")
+    while True:
+        choice = input("Choice [1-3]: ").strip() or "1"
+        if choice == "1":
+            seed = 0
+            break
+        if choice == "2":
+            while True:
+                entry = input("Enter integer seed: ").strip()
+                try:
+                    seed = int(entry)
+                    break
+                except ValueError:
+                    console.write("Seed must be an integer.", error=True)
+            break
+        if choice == "3":
+            seed = random.randint(0, 2**32 - 1)
+            console.write(f"Generated random seed {seed}")
+            break
+        console.write("Please choose 1, 2 or 3.", error=True)
+
+    _utils.set_random_seed(seed)
+    return seed
 
 
 def show_splash_screen():
@@ -694,9 +739,8 @@ def main_workflow():
             _sanity_check_numpy_scipy(logger)
         except Exception:
             exit_clean(1)
-        seed = opts.seed
-        utils.set_random_seed(seed)
-        logger.info("Using RNG seed %s", seed)
+        select_seed()
+        logger.info("Using RNG seed %s", utils.get_random_seed())
         start_ts = time.strftime("%y%m%d_%H%M%S")
         run_start_dt = datetime.datetime.now()
         run_start_pc = time.perf_counter()
@@ -819,7 +863,6 @@ def main_workflow():
             ],
             engine_module=cosmo_engine_selected,
             datasets=dataset_info,
-            seed=seed,
         )
         run_manifest.save_manifest(manifest, OUTPUT_DIR)
 

--- a/copernican_lib/run_manifest.py
+++ b/copernican_lib/run_manifest.py
@@ -53,7 +53,6 @@ def build_manifest(
     models: Iterable[Tuple[object, str]],
     engine_module: object,
     datasets: Iterable[Tuple[str, str, Dict[str, str]]],
-    seed: int,
 ) -> dict:
     """Collect manifest information for the current run.
 
@@ -70,8 +69,6 @@ def build_manifest(
         Iterable of ``(dataset_id, data_dir, file_hashes)`` tuples.  The
         ``file_hashes`` mapping mirrors the ``file_hashes`` attribute attached
         to the :class:`pandas.DataFrame` produced by the dataset loader.
-    seed:
-        RNG seed applied to the run.
     """
 
     manifest = {
@@ -80,7 +77,7 @@ def build_manifest(
             "name": getattr(engine_module, "__name__", "unknown"),
             "version": getattr(engine_module, "ENGINE_VERSION", "unknown"),
         },
-        "seed": seed,
+        "seed": utils.get_random_seed(),
         "datasets": {},
         "git": _git_info(),
     }

--- a/copernican_lib/utils.py
+++ b/copernican_lib/utils.py
@@ -133,13 +133,22 @@ def load_metadata_from_dir(data_dir: str) -> dict:
         raise
 
 
+CURRENT_SEED = 0
+
+
 def set_random_seed(seed: int = 0) -> None:
-    """Seed global RNGs and log the selected value.
+    """Seed global RNGs and record the selected value.
 
     Engines call this helper so optimisation results can be reproduced
     when the same seed is provided.  The Python ``random`` module and
     optional engine libraries such as CAMB are seeded when available.
+    The chosen seed is stored for later retrieval by
+    :func:`get_random_seed` so the run manifest and logs can access it
+    without threading the value through multiple functions.
     """
+
+    global CURRENT_SEED
+    CURRENT_SEED = seed
     np.random.seed(seed)
     random.seed(seed)
     logger = logging.getLogger()
@@ -152,3 +161,9 @@ def set_random_seed(seed: int = 0) -> None:
     except Exception:
         logger.debug("CAMB RNG seeding unavailable", exc_info=True)
     logger.info("Global RNG seed set to %s", seed)
+
+
+def get_random_seed() -> int:
+    """Return the seed most recently passed to :func:`set_random_seed`."""
+
+    return CURRENT_SEED

--- a/docs/run_manifest.md
+++ b/docs/run_manifest.md
@@ -1,5 +1,5 @@
 # Run Manifest
-**Last Updated:** 2025-08-27
+**Last Updated:** 2025-08-30
 
 The suite writes a YAML manifest for every evaluation under the run's output
 folder.  The file is named `run_manifest_<timestamp>.yml` and records:
@@ -17,8 +17,10 @@ run exactly.  To rerun an analysis:
 2. Verify that each data file still produces the recorded SHA256 digest.
 3. Configure the suite with the same model, priors, engine and seed.
 
-The seed is chosen via the ``--seed`` command line option. The value is
-saved in the manifest and main log so runs can be reproduced exactly.
+When no ``COPERNICAN_SEED`` environment variable is present the program
+prompts for a seed early in the run.  Users may accept the default ``0``,
+enter a manual value or generate a random seed.  The chosen value is saved
+in the manifest and main log so runs can be reproduced exactly.
 
 The manifest is intentionally human readable so it can be archived in lab
 notebooks or cited in publications.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,12 +4,18 @@
 """Tests for user interaction helpers in ``copernican.py``."""
 
 import importlib
+import os
 import sys
 import unittest
+from pathlib import Path
 from unittest import mock
 
 with mock.patch("sys.version_info", (3, 12, 0)):
-    copernican = importlib.import_module("copernican")
+    with mock.patch.dict(
+        os.environ,
+        {"VIRTUAL_ENV": str(Path(__file__).resolve().parents[1] / ".venv")},
+    ):
+        copernican = importlib.import_module("copernican")
 import copernican_lib.data_loaders
 
 

--- a/tests/test_run_manifest.py
+++ b/tests/test_run_manifest.py
@@ -23,11 +23,11 @@ def test_manifest_contains_required_fields():
             fh.write("hello world\n")
         engine = SimpleNamespace(__name__="engine", ENGINE_VERSION="0.0")
         file_hashes = {"data.txt": utils.compute_sha256(data_path)}
+        utils.set_random_seed(123)
         manifest = run_manifest.build_manifest(
             models=[(_dummy_plugin(), "1.0")],
             engine_module=engine,
             datasets=[("ds", tmpdir, file_hashes)],
-            seed=123,
         )
         path = run_manifest.save_manifest(manifest, tmpdir)
         with open(path, "r", encoding="utf-8") as fh:

--- a/tests/test_seed_option.py
+++ b/tests/test_seed_option.py
@@ -1,32 +1,51 @@
-"""Tests for the ``COPERNICAN_SEED`` environment variable."""
+"""Tests for RNG seed selection paths."""
 
 import importlib
 import os
 import random
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import numpy as np
 
 with mock.patch("sys.version_info", (3, 12, 0)):
-    copernican = importlib.import_module("copernican")
+    with mock.patch.dict(
+        os.environ,
+        {"VIRTUAL_ENV": str(Path(__file__).resolve().parents[1] / ".venv")},
+    ):
+        copernican = importlib.import_module("copernican")
 from copernican_lib import utils
 
 
 class SeedOptionTestCase(unittest.TestCase):
-    """Ensure different environment seeds produce distinct RNG states."""
+    """Verify environment, manual and random seed handling."""
 
     def test_env_seed_changes_rng(self):
-        """Verify that separate seeds lead to different RNG outputs."""
+        """Separate environment seeds yield distinct RNG outputs."""
         values = []
         for seed in (1, 2):
             with mock.patch.dict(
                 os.environ, {"COPERNICAN_SEED": str(seed)}, clear=True
             ):
-                opts = copernican.get_runtime_options()
-            utils.set_random_seed(opts.seed)
+                copernican.select_seed()
             values.append((np.random.rand(), random.random()))
         self.assertNotEqual(values[0], values[1])
+
+    def test_manual_seed_prompt(self):
+        """User-entered seeds are applied."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch("builtins.input", side_effect=["2", "42"]):
+                copernican.select_seed()
+        self.assertEqual(utils.get_random_seed(), 42)
+
+    def test_random_seed_prompt(self):
+        """Random seed generation stores the value."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch("builtins.input", side_effect=["3"]):
+                with mock.patch("random.randint", return_value=99):
+                    copernican.select_seed()
+        self.assertEqual(utils.get_random_seed(), 99)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- prompt users to pick RNG seed or generate a random one
- store chosen seed in global config and run manifest
- document seed workflow and update tests

## Testing
- `pre-commit run --files AGENTS.md CHANGELOG.md README.md copernican.py copernican_lib/run_manifest.py copernican_lib/utils.py docs/run_manifest.md tests/test_run_manifest.py tests/test_seed_option.py`
- `pre-commit run --files tests/test_seed_option.py tests/test_cli.py`
- `pre-commit run --files copernican.py`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_68b2dc962804832f9d1f025ea5a1dca2