### PR TITLE
docs: remove cli references and update tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,15 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Log changes here
 
+## Version 4.3.1
+- 2025-08-30: Removed outdated CLI examples, revised menu and seed tests,
+              and clarified external authentication prompts in LICENSE
+              (OpenAI ChatGPT)
+
 ## Version 4.3.0
-- 2025-08-30: Removed ``--seed`` flag in favour of an interactive seed prompt
-              with manual and random options; updated manifest, utilities,
-              tests and documentation (OpenAI ChatGPT)
+- 2025-08-30: Removed the command-line seed flag in favour of an interactive
+              seed prompt with manual and random options; updated manifest,
+              utilities, tests and documentation (OpenAI ChatGPT)
 
 ## Version 4.2.1
 - 2025-08-30: Added package manager password notices in launchers and
@@ -84,8 +89,8 @@ put dates that are in the future or in the past! Follow this template:
               (OpenAI ChatGPT)
 
 ## Version 3.12.0
-- 2025-08-27: Added ``--seed`` CLI option, seeded Python and engine RNGs and
-               logged the value in manifest and logs (OpenAI ChatGPT)
+- 2025-08-27: Added a command-line seed flag, seeded Python and engine RNGs
+               and logged the value in manifest and logs (OpenAI ChatGPT)
 
 ## Version 3.12.1
 - 2025-08-28: Enforced use of repository virtual environment, added laws on
@@ -476,9 +481,9 @@ put dates that are in the future or in the past! Follow this template:
   added licensing reminders to contributor docs (AI assistant)
 
 ## Version 3.6.1
-- 2025-08-09: Delegated `--run-tests` to `python -m unittest discover`,
-  expanded regression and interface tests, and updated CI to run the full
-  suite on every push (AI assistant)
+- 2025-08-09: Delegated the test-suite menu option to `python -m unittest
+              discover`, expanded regression and interface tests, and
+              updated CI to run the full suite on every push (AI assistant)
 
 ## Version 3.6.0
 - 2025-08-09: Centralised version handling via `copernican_lib.version`,
@@ -913,7 +918,8 @@ put dates that are in the future or in the past! Follow this template:
   (AI assistant)
 - 2025-07-07: Revised AGENTS overview and expanded README with developer guide
   (AI assistant)
-- 2025-07-07: Fixed test discovery and matplotlib cleanup in run-tests mode
+- 2025-07-07: Fixed test discovery and Matplotlib cleanup when running the
+              test suite via the menu option (AI assistant)
   (AI
   assistant)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to the Copernican Suite
-**Last Updated:** 2025-08-12
+**Last Updated:** 2025-08-30
 
 Thank you for considering a contribution. Before opening a pull request,
 please
@@ -7,10 +7,9 @@ read `AGENTS.md` for the full development specification. The quick checklist
 is:
 
 1. Run `pre-commit run --files <changed files>` to apply Black, Isort, Ruff
-   and
-   Flake8 checks.
-2. Run the test suite with `python -m unittest discover` or `copernican.py
-   --run-tests`.
+   and Flake8 checks.
+2. Run the test suite with `python -m unittest discover` or via the launchers'
+   *Run the unit test suite* option.
 3. Document your changes in `CHANGELOG.md` using the `- YYYY-MM-DD: summary
    (author)` format.
 4. Update documentation where needed, including `README.md` and `AGENTS.md`.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -45,7 +45,8 @@ The start scripts may invoke system package managers such as `sudo`, `brew`
 or `winget`. They display a notice explaining that any password prompt comes
 from the package manager and is never captured by the Copernican Suite.
 `sudo -k` and explicit prompts ensure the operating system alone handles
-credential entry.
+credential entry. Any authentication requests originate from those external
+tools; the Copernican Suite never handles, records or stores credentials.
 
 ## 1. Grant of License
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,5 +1,5 @@
 # Copernican Suite Development Plan
-**Last Updated:** 2025-08-31
+**Last Updated:** 2025-08-30
 
 ## Overview
 Copernican Suite has grown from a single script into a modular, cross-platform
@@ -59,8 +59,8 @@ builds will report that version automatically.
 
 ## Testing and Quality Assurance
 - `python -m unittest discover` remains the canonical way to run the test
-  suite. Developers can also invoke `copernican.py --run-tests` to execute the
-  same tests via the main entry point.
+  suite. The launchers also provide a *Run the unit test suite* option that
+  triggers the same command.
 - Tests cover model interfaces, data loaders and regression checks for
   supported datasets. Future additions should extend coverage, especially as
   new engines, parsers or GUI components appear.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 4.3.0
+**Version:** 4.3.1
 **Last Updated:** 2025-08-30
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -167,12 +167,7 @@ Windows users should open `start.bat`, macOS users should run
 `./start.command`, and Linux users can execute `./start.sh`. These helpers
 create a local virtual environment, upgrade `pip` and install the package
 automatically before launching the suite. Running `copernican.py` outside
-this environment prompts you to use the appropriate start script. You can
-also start the program manually:
-
-```bash
-python copernican.py
-```
+this environment prompts you to use the appropriate start script.
 
 To install the package system-wide run:
 

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Copernican Suite developers.
 # See LICENSE.md in the repository root for details.
 
-"""Tests for user interaction helpers in ``copernican.py``."""
+"""Tests for menu interaction helpers in ``copernican.py``."""
 
 import importlib
 import os
@@ -19,8 +19,8 @@ with mock.patch("sys.version_info", (3, 12, 0)):
 import copernican_lib.data_loaders
 
 
-class RunTestsFlagTestCase(unittest.TestCase):
-    """Verify the test runner invokes ``python -m unittest`` discovery."""
+class MenuRunTestsTestCase(unittest.TestCase):
+    """Verify the menu invokes ``python -m unittest`` discovery."""
 
     @mock.patch("subprocess.run")
     def test_run_startup_tests_invokes_unittest_discover(self, run_mock):
@@ -39,7 +39,7 @@ class SelectSourceDisplayTestCase(unittest.TestCase):
     """Ensure selection prompts show names and return identifiers."""
 
     @mock.patch("copernican_lib.data_loaders.console.ask", return_value="1")
-    def test_select_source_shows_name(self, ask_mock):
+    def test_select_source_shows_name(self, _ask_mock):
         registry = {
             "dummy_id": {
                 "dataset_name": "Dummy Dataset",

--- a/tests/test_seed_option.py
+++ b/tests/test_seed_option.py
@@ -18,8 +18,8 @@ with mock.patch("sys.version_info", (3, 12, 0)):
 from copernican_lib import utils
 
 
-class SeedOptionTestCase(unittest.TestCase):
-    """Verify environment, manual and random seed handling."""
+class SeedMenuTestCase(unittest.TestCase):
+    """Verify environment, manual, random and default seed handling."""
 
     def test_env_seed_changes_rng(self):
         """Separate environment seeds yield distinct RNG outputs."""
@@ -46,6 +46,13 @@ class SeedOptionTestCase(unittest.TestCase):
                 with mock.patch("random.randint", return_value=99):
                     copernican.select_seed()
         self.assertEqual(utils.get_random_seed(), 99)
+
+    def test_default_seed_prompt(self):
+        """Accepting the default seed stores zero."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch("builtins.input", side_effect=[""]):
+                copernican.select_seed()
+        self.assertEqual(utils.get_random_seed(), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- drop outdated command-line examples and bump docs to 4.3.1
- add external-auth notice to license
- rename CLI tests to menu tests and cover default seed prompt

## Testing
- `pre-commit run --files CHANGELOG.md CONTRIBUTING.md LICENSE.md PLAN.md README.md tests/test_menu.py tests/test_seed_option.py`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68b2deb71fc8832f8c8ff63b345c6963