### PR TITLE
Split CI into lint and test workflows using Python 3.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+# Last Updated: 2025-08-30
+name: Lint
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up virtual environment
+        run: python -m venv .venv
+
+      - name: Install dependencies
+        run: |
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install --require-hashes -r requirements.lock
+          .venv/bin/pip install --no-deps . pre-commit
+
+      - name: Run pre-commit
+        run: .venv/bin/pre-commit run --all-files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,4 @@
+# Last Updated: 2025-08-30
 name: Tests
 
 on:
@@ -6,7 +7,6 @@ on:
 
 jobs:
   tests:
-    name: Lint and Test
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -18,25 +18,20 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-
-      - name: Cache virtual environment
-        id: cache-venv
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: >-
-            venv-${{ runner.os }}-${{ hashFiles('pyproject.toml',
-            'requirements.lock') }}
+          python-version: '3.12'
 
       - name: Set up virtual environment
-        if: steps.cache-venv.outputs.cache-hit != 'true'
+        if: runner.os != 'Windows'
+        shell: bash
+        run: python -m venv .venv
+
+      - name: Set up virtual environment (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: python -m venv .venv
 
       - name: Install dependencies
-        if: >-
-          runner.os != 'Windows' &&
-          steps.cache-venv.outputs.cache-hit != 'true'
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           .venv/bin/pip install --upgrade pip
@@ -44,32 +39,21 @@ jobs:
           .venv/bin/pip install --no-deps . pre-commit
 
       - name: Install dependencies (Windows)
-        if: >-
-          runner.os == 'Windows' &&
-          steps.cache-venv.outputs.cache-hit != 'true'
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           .\.venv\Scripts\python -m pip install --upgrade pip
           .\.venv\Scripts\pip install --require-hashes -r requirements.lock
           .\.venv\Scripts\pip install --no-deps . pre-commit
 
-      - name: Run pre-commit
-        if: runner.os != 'Windows'
-        shell: bash
-        run: .venv/bin/pre-commit run --all-files
-
-      - name: Run pre-commit (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: .\.venv\Scripts\pre-commit run --all-files
-
       - name: Run unit tests
         if: runner.os != 'Windows'
         shell: bash
-        run: .venv/bin/python copernican.py --run-tests
+        run: COPERNICAN_STRICT_WARNINGS=1 .venv/bin/python -m unittest discover -v
 
       - name: Run unit tests (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: .\.venv\Scripts\python copernican.py --run-tests
-
+        run: |
+          $env:COPERNICAN_STRICT_WARNINGS = '1'
+          .\.venv\Scripts\python -m unittest discover -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ put dates that are in the future or in the past! Follow this template:
 - 2025-08-30: Removed outdated CLI examples, revised menu and seed tests,
               and clarified external authentication prompts in LICENSE
               (OpenAI ChatGPT)
+- 2025-08-30: Split CI into dedicated lint and test workflows using
+              Python 3.12 (OpenAI ChatGPT)
 
 ## Version 4.3.0
 - 2025-08-30: Removed the command-line seed flag in favour of an interactive


### PR DESCRIPTION
## Summary
- Replace monolithic CI with separate lint and test workflows
- Adopt Python 3.12 in CI
- Document the CI overhaul in the changelog

## Testing
- `pre-commit run --all-files`
- `COPERNICAN_STRICT_WARNINGS=1 .venv/bin/python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b2e75844cc832f90329773c7c1f608