### PR TITLE
Use astral-sh Python build 3.12.11 in launchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-**Last Updated:** 2025-08-30
+**Last Updated:** 2025-09-01
 
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the
@@ -18,6 +18,10 @@ put dates that are in the future or in the past! Follow this template:
 
 ```
 ## Log changes here
+
+## Version 4.3.2
+- 2025-09-01: start scripts fetch Python 3.12.11 from astral-sh releases
+              (OpenAI ChatGPT)
 
 ## Version 4.3.1
 - 2025-08-30: Removed outdated CLI examples, revised menu and seed tests,

--- a/start.bat
+++ b/start.bat
@@ -1,6 +1,6 @@
 @REM Copyright (c) 2025 Copernican Suite developers.
 @REM See LICENSE.md in the repository root for details.
-@REM Last Updated: 2025-08-30
+@REM Last Updated: 2025-09-01
 
 @echo off
 set "PKG_NOTICE=Package managers may request your password. The Copernican"
@@ -29,15 +29,17 @@ if defined VIRTUAL_ENV (
 
 REM Bootstrap a dedicated interpreter.
 if not exist "%PYBIN%" (
-    set "BASE=https://github.com/indygreg/python-build-standalone/releases"
-    set "REL=20240710"
-    set "VER=3.12.4"
+    set "BASE=https://github.com/astral-sh/python-build-standalone/releases"
+    set "REL=20250828"
+    set "VER=3.12.11"
     set "ARCH=amd64"
-    set "URL=%BASE%/download/%REL%/cpython-%VER%+%REL%-%ARCH%-pc-windows-"
-    set "URL=%URL%msvc-shared-install_only.zip"
-    powershell -Command "Invoke-WebRequest -Uri '%URL%' -OutFile 'python.zip'"
-    powershell -Command "Expand-Archive 'python.zip' '%PYDIR%'"
-    del python.zip
+    set "URL=%BASE%/download/%REL%/cpython-%VER%+%REL%-%ARCH%-pc-windows-msvc-^"
+    set "URL=%URL%shared-install_only.tar.gz"
+    powershell -Command ^
+        "Invoke-WebRequest -Uri '%URL%' -OutFile 'python.tar.gz'"
+    powershell -Command ^
+        "tar -xzf 'python.tar.gz' -C '%PYDIR%' --strip-components=1"
+    del python.tar.gz
 )
 set "PYTHON=%PYBIN%"
 

--- a/start.command
+++ b/start.command
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2025 Copernican Suite developers.
 # See LICENSE.md in the repository root for details.
-# Last Updated: 2025-08-30
+# Last Updated: 2025-09-01
 
 # Start the Copernican Suite on macOS.
 #
@@ -83,9 +83,9 @@ PY_DIR="$(pwd)/.python"
 PY_BIN="$PY_DIR/bin/python3"
 if [ ! -x "$PY_BIN" ]; then
     mkdir -p "$PY_DIR"
-    BASE="https://github.com/indygreg/python-build-standalone/releases"
-    REL="20240710"
-    VER="3.12.4"
+    BASE="https://github.com/astral-sh/python-build-standalone/releases"
+    REL="20250828"
+    VER="3.12.11"
     ARCH="$(uname -m)"
     PLAT="apple-darwin"
     URL="$BASE/download/$REL/"

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2025 Copernican Suite developers.
 # See LICENSE.md in the repository root for details.
-# Last Updated: 2025-08-30
+# Last Updated: 2025-09-01
 
 # Start the Copernican Suite on Unix-like systems.
 #
@@ -84,9 +84,9 @@ PY_DIR="$(pwd)/.python"
 PY_BIN="$PY_DIR/bin/python3"
 if [ ! -x "$PY_BIN" ]; then
     mkdir -p "$PY_DIR"
-    BASE="https://github.com/indygreg/python-build-standalone/releases"
-    REL="20240710"
-    VER="3.12.4"
+    BASE="https://github.com/astral-sh/python-build-standalone/releases"
+    REL="20250828"
+    VER="3.12.11"
     ARCH="$(uname -m)"
     if [ "$(uname)" = "Darwin" ]; then
         PLAT="apple-darwin"


### PR DESCRIPTION
## Summary
- point start scripts to astral-sh/python-build-standalone release
- bump bootstrap Python to 3.12.11 and 20250828 tag
- document launcher update in changelog

## Testing
- `pre-commit run --files start.sh start.command start.bat CHANGELOG.md`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b5d1df4ee0832fb767a8c4020a279e