### PR TITLE
chore: refresh dependency lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Log changes here
 
+## Version 4.3.4
+- 2025-09-01: Refreshed dependency lock file (OpenAI ChatGPT)
+
+
 ## Version 4.3.3
 - 2025-09-01: Added automated hash locking and pre-commit hook for dependency
               updates; documented new workflow (OpenAI ChatGPT)

--- a/requirements.lock
+++ b/requirements.lock
@@ -187,7 +187,10 @@ xarray-einstats==0.9.1 \
     #   -r requirements.in
     #   arviz
 
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes and the requirement is not
-# satisfied by a package already installed. Consider using the --allow-unsafe flag.
-# setuptools
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
+    # via
+    #   arviz
+    #   setuptools-scm


### PR DESCRIPTION
## Summary
- regenerate dependency lock with hashed setuptools and current timestamp
- log dependency lock refresh in CHANGELOG

## Testing
- `SKIP=make-lock pre-commit run --files requirements.in requirements.lock CHANGELOG.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e5ace1ec832f8c4bf68c5d392645