### PR TITLE
Add contourpy hashes for macOS and Windows wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Log changes here
 
+## Version 4.3.5
+- 2025-09-01: Added macOS and Windows wheel hashes for contourpy==1.3.3
+              to support cross-platform installs (OpenAI ChatGPT)
+
 ## Version 4.3.4
 - 2025-09-01: Refreshed dependency lock file (OpenAI ChatGPT)
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -24,7 +24,10 @@ camb==1.6.2 \
     # via -r requirements.in
 contourpy==1.3.3 \
     --hash=sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1 \
-    --hash=sha256:51e79c1f7470158e838808d4a996fa9bac72c498e93d8ebe5119bc1e6becb0db
+    --hash=sha256:51e79c1f7470158e838808d4a996fa9bac72c498e93d8ebe5119bc1e6becb0db \
+    --hash=sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1 \
+    --hash=sha256:23416f38bfd74d5d28ab8429cc4d63fa67d5068bd711a85edb1c3fb0c3e2f381 \
+    --hash=sha256:3519428f6be58431c56581f1694ba8e50626f2dd550af225f82fb5f5814d2a42
     # via matplotlib
 cycler==0.12.1 \
     --hash=sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30


### PR DESCRIPTION
## Summary
- add macOS and Windows wheel hashes for contourpy==1.3.3 so hash-locked installs work across platforms
- document new hashes in the changelog

## Testing
- `pre-commit run --files requirements.lock CHANGELOG.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5ea083698832f89928a7e50770c0e