### PR TITLE
Automate wheel hash refresh to fix contourpy CI failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,9 @@ repos:
         language: system
         files: ^requirements\.in$
         pass_filenames: false
+      - id: refresh-hashes
+        name: refresh wheel hashes
+        entry: python -m copernican_lib.hash_utils
+        language: system
+        files: ^requirements\.lock$
+        pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Log changes here
 
+## Version 4.3.6
+- 2025-09-01: Automated wheel hash recreation and fixed contourpy macOS ARM
+              hash to unblock CI (OpenAI ChatGPT)
+
+## Version 4.3.5
+- 2025-09-01: Added macOS and Windows wheel hashes for contourpy==1.3.3
+              to support cross-platform installs (OpenAI ChatGPT)
+
 ## Version 4.3.4
 - 2025-09-01: Refreshed dependency lock file (OpenAI ChatGPT)
 

--- a/copernican_lib/hash_utils.py
+++ b/copernican_lib/hash_utils.py
@@ -1,0 +1,148 @@
+"""Dependency hash utilities for the Copernican Suite.
+
+This module automates recreation of platform-specific wheel hashes for
+``requirements.lock`` so ``pip`` can verify downloads on Linux, macOS and
+Windows.  The helper downloads metadata from the PyPI JSON API and inserts
+missing ``--hash=sha256`` lines for any wheel files not already listed.
+
+Keeping this process in code eliminates the repeated manual steps that led
+to past CI failures when new platform wheels were published after the
+lock file was generated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Iterable, Sequence
+from urllib.request import Request, urlopen
+
+
+def fetch_wheel_hashes(package: str, version: str) -> set[str]:
+    """Return hashes for all wheel files of a package release.
+
+    Parameters
+    ----------
+    package:
+        Package name as published on PyPI.
+    version:
+        Exact package version to inspect.
+    """
+    url = f"https://pypi.org/pypi/{package}/{version}/json"
+    req = Request(url, headers={"User-Agent": "copernican-suite"})
+    with urlopen(
+        req
+    ) as resp:  # pragma: no cover - exercised in tests via mock
+        data = json.load(resp)
+
+    def wanted(filename: str) -> bool:
+        if not filename.endswith(".whl") or "cp312" not in filename:
+            return False
+        if "win_amd64" in filename:
+            return True
+        if "manylinux" in filename and (
+            "x86_64" in filename or "aarch64" in filename
+        ):
+            return True
+        if "macosx" in filename and (
+            "x86_64" in filename or "arm64" in filename
+        ):
+            return True
+        return False
+
+    return {
+        file["digests"]["sha256"]
+        for file in data.get("urls", [])
+        if wanted(file["filename"])
+    }
+
+
+def _hash_block(lines: Sequence[str], start: int) -> tuple[int, set[str]]:
+    """Return end index and hashes for the block starting at ``start``.
+
+    The function scans the ``lines`` sequence starting one line below the
+    requirement declaration and collects every ``--hash=sha256`` entry.
+    ``start`` must point to the requirement line itself.
+    """
+    hashes: set[str] = set()
+    end = start + 1
+    while end < len(lines) and lines[end].lstrip().startswith("--hash="):
+        # ``--hash=sha256:<digest>`` may optionally end with a trailing ``\``.
+        digest = lines[end].split(":", 1)[1].split()[0].rstrip("\\")
+        hashes.add(digest)
+        end += 1
+    return end, hashes
+
+
+def update_hashes(path: Path, packages: Iterable[str] | None = None) -> bool:
+    """Insert missing wheel hashes into ``path``.
+
+    Parameters
+    ----------
+    path:
+        Location of the requirements lock file.
+    packages:
+        Optional iterable restricting which packages to refresh.  When omitted
+        all packages found in the file are processed.
+
+    Returns
+    -------
+    bool
+        ``True`` when the file was modified.
+    """
+    lines = path.read_text().splitlines()
+    pkg_pattern = re.compile(
+        r"^(?P<name>[A-Za-z0-9_.-]+)==(?P<ver>[^\\s]+) \\"
+    )
+    targets = {p.lower() for p in packages} if packages else None
+    i = 0
+    changed = False
+    while i < len(lines):
+        match = pkg_pattern.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        name = match.group("name")
+        if targets and name.lower() not in targets:
+            i += 1
+            continue
+        version = match.group("ver")
+        end, existing = _hash_block(lines, i)
+        needed = fetch_wheel_hashes(name, version)
+        if not needed:
+            i = end
+            continue
+        if existing != needed:
+            merged = sorted(needed)
+            block = [f"    --hash=sha256:{h} \\" for h in merged[:-1]]
+            block.append(f"    --hash=sha256:{merged[-1]}")
+            lines[i + 1 : end] = block  # noqa: E203
+            delta = len(block) - (end - (i + 1))
+            end += delta
+            changed = True
+        i = end
+    if changed:
+        path.write_text("\n".join(lines) + "\n")
+    return changed
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Refresh wheel hashes for the provided lock file.
+
+    This command updates ``requirements.lock`` in place.  It exits with ``0``
+    even when modifications occur so pre-commit can rerun automatically.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path", nargs="?", type=Path, default=Path("requirements.lock")
+    )
+    parser.add_argument("packages", nargs="*")
+    args = parser.parse_args(argv)
+    update_hashes(args.path, args.packages or None)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via CLI
+    raise SystemExit(main())

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,7 +9,11 @@ arviz @ https://github.com/arviz-devs/arviz/archive/01c8b9454349247eed2145a27b03
     --hash=sha256:90422f7370cf47a38342e96ecad5b627a26ad4da7cfb6222a6d6c46cfb273177
     # via -r requirements.in
 astropy==7.1.0 \
-    --hash=sha256:c8f254322295b1b8cf24303d6f155bf7efdb6c1282882b966ce3040eff8c53c5
+    --hash=sha256:06ba650db237557912fdd7bb8ffdd87838e23e58b0fa0001b4d43c2bb5a79412 \
+    --hash=sha256:654261df547c150e5b6a022f3785f47a2e547e0cc1c06fbcf6293b5f4e85722a \
+    --hash=sha256:c811a4aedd8fbf6d7611d64d40af1f0c1c1e6621e5992e7e1a7b5fec47dc1fa1 \
+    --hash=sha256:e0fec2f4b5265caab68020eaa320704e7ce9433ae8dbea75c300468fed695437 \
+    --hash=sha256:e4bb022f863cf13eefeb406692f58824c0d9bdb1aa36ae786e87c096d8ebdd07
     # via -r requirements.in
 astropy-iers-data==0.2025.8.25.0.36.58 \
     --hash=sha256:a26ac2a71234fd1ac4039b9ab8d6db56988c243c91791d4fc44c98b3d5901f5c
@@ -24,7 +28,10 @@ camb==1.6.2 \
     # via -r requirements.in
 contourpy==1.3.3 \
     --hash=sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1 \
-    --hash=sha256:51e79c1f7470158e838808d4a996fa9bac72c498e93d8ebe5119bc1e6becb0db
+    --hash=sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6 \
+    --hash=sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b \
+    --hash=sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7 \
+    --hash=sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb
     # via matplotlib
 cycler==0.12.1 \
     --hash=sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30
@@ -33,8 +40,10 @@ emcee==3.1.5 \
     --hash=sha256:3b7a3c6ff7bf2d04d10705ef648f31e8ac3d8edbab986269af15a90611538b06
     # via -r requirements.in
 fonttools==4.55.3 \
+    --hash=sha256:07f8288aacf0a38d174445fc78377a97fb0b83cfe352a90c9d9c1400571963c7 \
+    --hash=sha256:7a8aa2c5e5b8b3bcb2e4538d929f6589a5c6bdb84fd16e2ed92649fb5454f11c \
     --hash=sha256:b8d5e8916c0970fbc0f6f1bece0063363bb5857a7f170121a4493e31c3db3314 \
-    --hash=sha256:da9da6d65cd7aa6b0f806556f4985bcbf603bf0c5c590e61b43aa3e5a0f822d0
+    --hash=sha256:e6e8766eeeb2de759e862004aa11a9ea3d6f6d5ec710551a88b476192b64fd54
     # via matplotlib
 h5netcdf==1.6.4 \
     --hash=sha256:e0018e6a918f2bef2a4aa7b470a952b8a0b5d16a5893d59bea56524cc6207fcf
@@ -43,7 +52,10 @@ h5netcdf==1.6.4 \
     #   arviz
 h5py==3.14.0 \
     --hash=sha256:0cbd41f4e3761f150aa5b662df991868ca533872c95467216f2bec5fcad84882 \
-    --hash=sha256:723a40ee6505bd354bfd26385f2dae7bbfa87655f4e61bab175a49d72ebfc06b
+    --hash=sha256:554ef0ced3571366d4d383427c00c966c360e178b5fb5ee5bb31a435c424db0c \
+    --hash=sha256:6da62509b7e1d71a7d110478aa25d245dd32c8d9a1daee9d2a42dba8717b047a \
+    --hash=sha256:bf4897d67e613ecf5bdfbdab39a1158a64df105827da70ea1d90243d796d367f \
+    --hash=sha256:e0045115d83272090b0717c555a31398c2c089b87d212ceba800d3dc5d952e23
     # via
     #   -r requirements.in
     #   h5netcdf
@@ -54,14 +66,18 @@ jsonschema-specifications==2025.4.1 \
     --hash=sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af
     # via jsonschema
 kiwisolver==1.4.7 \
-    --hash=sha256:18077b53dc3bb490e330669a99920c5e6a496889ae8c63b58fbc57c3d7f33a18 \
-    --hash=sha256:693902d433cf585133699972b6d7c42a8b9f8f826ebcaf0132ff55200afc599e
+    --hash=sha256:48b571ecd8bae15702e4f22d3ff6a0f13e54d3d00cd25216d5e7f658242065ee \
+    --hash=sha256:58cb20602b18f86f83a5c87d3ee1c766a79c0d452f8def86d925e6c60fbf7bfb \
+    --hash=sha256:612a10bdae23404a72941a0fc8fa2660c6ea1217c4ce0dbcab8a8f6543ea9e7f \
+    --hash=sha256:693902d433cf585133699972b6d7c42a8b9f8f826ebcaf0132ff55200afc599e \
+    --hash=sha256:942216596dc64ddb25adb215c3c783215b23626f8d84e8eff8d6d45c3f29f75a
     # via matplotlib
 matplotlib==3.10.5 \
-    --hash=sha256:080c3676a56b8ee1c762bcf8fca3fe709daa1ee23e6ef06ad9f3fc17332f2d2a \
-    --hash=sha256:33775bbeb75528555a15ac29396940128ef5613cf9a2d31fb1bfd18b3c0c0903 \
-    --hash=sha256:903352681b59f3efbf4546985142a9686ea1d616bb054b09a537a06e4b892ccf \
-    --hash=sha256:a17e57e33de901d221a07af32c08870ed4528db0b6059dce7d7e65c1122d4bea
+    --hash=sha256:00b6feadc28a08bd3c65b2894f56cf3c94fc8f7adcbc6ab4516ae1e8ed8f62e2 \
+    --hash=sha256:97b9d6443419085950ee4a5b1ee08c363e5c43d7176e55513479e53669e88468 \
+    --hash=sha256:a17e57e33de901d221a07af32c08870ed4528db0b6059dce7d7e65c1122d4bea \
+    --hash=sha256:c04cba0f93d40e45b3c187c6c52c17f24535b27d545f757a2fffebc06c12b98b \
+    --hash=sha256:ee98a5c5344dc7f48dc261b6ba5d9900c008fc12beb3fa6ebda81273602cc389
     # via
     #   -r requirements.in
     #   arviz
@@ -69,12 +85,12 @@ mpmath==1.3.0 \
     --hash=sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c
     # via sympy
 numpy==2.2.6 \
-    --hash=sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42 \
-    --hash=sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566 \
+    --hash=sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff \
     --hash=sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282 \
-    --hash=sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf \
+    --hash=sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3 \
     --hash=sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2 \
-    --hash=sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303 \
+    --hash=sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c \
+    --hash=sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87 \
     --hash=sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249
     # via
     #   -r requirements.in
@@ -102,15 +118,23 @@ packaging==25.0 \
     #   setuptools-scm
     #   xarray
 pandas==2.3.2 \
-    --hash=sha256:1d81573b3f7db40d020983f78721e9bfc425f411e616ef019a10ebf597aedb2e \
+    --hash=sha256:0bd281310d4f412733f319a5bc552f86d62cddc5f51d2e392c8787335c994175 \
+    --hash=sha256:1b9b52693123dd234b7c985c68b709b0b009f4521000d0525f2b95c22f15944b \
+    --hash=sha256:3fbb977f802156e7a3f829e9d1d5398f6192375a3e2d1a9ee0803e35fe70a2b9 \
+    --hash=sha256:8c13b81a9347eb8c7548f53fd9a4f08d4dfe996836543f805c987bafa03317ae \
     --hash=sha256:96d31a6b4354e3b9b8a2c848af75d31da390657e3ac6f30c05c82068b9ed79b9
     # via
     #   -r requirements.in
     #   arviz
     #   xarray
 pillow==10.4.0 \
-    --hash=sha256:76a911dfe51a36041f2e756b00f96ed84677cdeb75d25c767f296c1c1eda1319 \
-    --hash=sha256:86dcb5a1eb778d8b25659d5e4341269e8590ad6b4e8b44d9f4b07f8d136c414a
+    --hash=sha256:1d846aea995ad352d4bdcc847535bd56e0fd88d36829d2c90be880ef1ee4668a \
+    --hash=sha256:29dbdc4207642ea6aad70fbde1a9338753d33fb23ed6956e706936706f52dd80 \
+    --hash=sha256:673655af3eadf4df6b5457033f086e90299fdd7a47983a13827acf7459c15d94 \
+    --hash=sha256:866b6942a92f56300012f5fbac71f2d610312ee65e22f1aa2609e491284e5597 \
+    --hash=sha256:86dcb5a1eb778d8b25659d5e4341269e8590ad6b4e8b44d9f4b07f8d136c414a \
+    --hash=sha256:bf2342ac639c4cf38799a44950bbc2dfcb685f052b9e262f446482afaf4bffca \
+    --hash=sha256:f5b92f4d70791b4a67157321c4e8225d60b119c5cc9aee8ecf153aace4aad4ef
     # via matplotlib
 psutil==7.0.0 \
     --hash=sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456
@@ -130,7 +154,11 @@ pytz==2025.1 \
     --hash=sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57
     # via pandas
 pyyaml==6.0.2 \
-    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
+    --hash=sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5 \
+    --hash=sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8 \
+    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+    --hash=sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab \
+    --hash=sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725
     # via
     #   -r requirements.in
     #   astropy
@@ -140,15 +168,21 @@ referencing==0.36.2 \
     #   jsonschema
     #   jsonschema-specifications
 rpds-py==0.27.0 \
-    --hash=sha256:4300e15e7d03660f04be84a125d1bdd0e6b2f674bc0723bc0fd0122f1a4585dc \
-    --hash=sha256:5fa01b3d5e3b7d97efab65bd3d88f164e289ec323a8c033c5c38e53ee25c007e
+    --hash=sha256:09965b314091829b378b60607022048953e25f0b396c2b70e7c4c81bcecf932e \
+    --hash=sha256:19c990fdf5acecbf0623e906ae2e09ce1c58947197f9bced6bbd7482662231c4 \
+    --hash=sha256:5fa01b3d5e3b7d97efab65bd3d88f164e289ec323a8c033c5c38e53ee25c007e \
+    --hash=sha256:6c27a7054b5224710fcfb1a626ec3ff4f28bcb89b899148c72873b18210e446b \
+    --hash=sha256:8a06aa1197ec0281eb1d7daf6073e199eb832fe591ffa329b88bae28f25f5fe5
     # via
     #   jsonschema
     #   referencing
 scipy==1.16.1 \
-    --hash=sha256:0a55ffe0ba0f59666e90951971a884d1ff6f4ec3275a48f472cfb64175570f77 \
-    --hash=sha256:226652fca853008119c03a8ce71ffe1b3f6d2844cc1686e8f9806edafae68596 \
-    --hash=sha256:adccd93a2fa937a27aae826d33e3bfa5edf9aa672376a4852d23a7cd67a2e5b7 \
+    --hash=sha256:15240c3aac087a522b4eaedb09f0ad061753c5eebf1ea430859e5bf8640d5919 \
+    --hash=sha256:65f81a25805f3659b48126b5053d9e823d3215e4a63730b5e1671852a1705921 \
+    --hash=sha256:6c62eea7f607f122069b9bad3f99489ddca1a5173bef8a0c75555d7488b6f725 \
+    --hash=sha256:81b433bbeaf35728dad619afc002db9b189e45eebe2cd676effe1fb93fef2b9c \
+    --hash=sha256:886cc81fdb4c6903a3bb0464047c25a6d1016fef77bb97949817d0c0d79f9e04 \
+    --hash=sha256:f7b8013c6c066609577d910d1a2a077021727af07b6fab0ee22c2f901f22352a \
     --hash=sha256:f965bbf3235b01c776115ab18f092a95aa74c271a52577bcb0563e85738fd618
     # via
     #   -r requirements.in

--- a/tests/test_hash_utils.py
+++ b/tests/test_hash_utils.py
@@ -1,0 +1,49 @@
+"""Tests for :mod:`copernican_lib.hash_utils`.
+
+The tests patch network access so no real HTTP requests are performed."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from copernican_lib import hash_utils
+
+
+def test_update_hashes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure missing hashes are inserted and existing ones kept."""
+    req = tmp_path / "req.lock"
+    req.write_text("pkg==1.0 \\\n    --hash=sha256:aaa\n")
+
+    sample = {
+        "urls": [
+            {
+                "filename": "pkg-1.0-cp312-cp312-win_amd64.whl",
+                "digests": {"sha256": "aaa"},
+            },
+            {
+                "filename": "pkg-1.0-cp312-cp312-macosx_11_0_arm64.whl",
+                "digests": {"sha256": "bbb"},
+            },
+        ]
+    }
+
+    class Dummy:
+        def __enter__(self) -> io.BytesIO:  # pragma: no cover - trivial
+            return io.BytesIO(json.dumps(sample).encode())
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            pass
+
+    monkeypatch.setattr(hash_utils, "urlopen", lambda req: Dummy())
+
+    changed = hash_utils.update_hashes(req, ["pkg"])
+    assert changed
+    text = req.read_text().splitlines()
+    assert text[1].endswith("\\")
+    assert text[2] == "    --hash=sha256:bbb"


### PR DESCRIPTION
## Summary
- add `hash_utils` helper to fetch platform wheel hashes from PyPI and update `requirements.lock`
- wire new helper into pre-commit and refresh `contourpy` hashes, fixing macOS ARM job
- document automated hash workflow in changelog

## Testing
- `pre-commit run --files requirements.lock CHANGELOG.md .pre-commit-config.yaml copernican_lib/hash_utils.py tests/test_hash_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5ea083698832f89928a7e50770c0e