### PR TITLE
Close NetCDF file in MCMC test and restore pre-commit deps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# Last Updated: 2025-09-02
+# Last Updated: 2025-09-03
 name: Lint
 
 on:
@@ -24,7 +24,8 @@ jobs:
         run: |
           .venv/bin/pip install --upgrade pip
           .venv/bin/pip install -r requirements.lock
-          .venv/bin/pip install --no-deps . pre-commit pip-tools
+          .venv/bin/pip install --no-deps .
+          .venv/bin/pip install pre-commit pip-tools
 
       - name: Run pre-commit
         run: .venv/bin/pre-commit run --all-files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-**Last Updated:** 2025-09-02
+**Last Updated:** 2025-09-03
 
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the
@@ -18,6 +18,10 @@ put dates that are in the future or in the past! Follow this template:
 
 ```
 ## Log changes here
+
+## Version 4.3.13
+- 2025-09-03: Closed NetCDF handle in MCMC test to resolve Windows temp file cleanup (OpenAI ChatGPT)
+- 2025-09-03: Installed pre-commit with dependencies in CI to fix missing cfgv import (OpenAI ChatGPT)
 
 ## Version 4.3.12
 - 2025-09-02: Removed dependency hash verification and related tooling, tests and documentation (OpenAI ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 4.3.12
-**Last Updated:** 2025-09-02
+**Version:** 4.3.13
+**Last Updated:** 2025-09-03
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,5 +1,5 @@
 # Packaging Guide
-**Last Updated:** 2025-09-02
+**Last Updated:** 2025-09-03
 
 This document explains how to prepare the suite for development or packaging.
 
@@ -28,6 +28,11 @@ after pulling updates to refresh the environment.
 `requirements.lock` pins exact versions for all runtime
 dependencies. Adding or updating a package requires editing this file and the
 license summary in `THIRD_PARTY_LICENSES.md`.
+
+Development helpers such as `pre-commit` are installed without the
+`--no-deps` flag so their own dependencies are pulled in automatically.
+This keeps the environment consistent across platforms without manually
+tracking every transient requirement.
 
 ## Build optional distributions
 

--- a/tests/test_engine_mcmc.py
+++ b/tests/test_engine_mcmc.py
@@ -55,9 +55,13 @@ class TestMCMCEngine(unittest.TestCase):
                 path,
                 metadata={"model": plugin.MODEL_NAME},
             )
-            ds = xr.open_dataset(path, group="posterior")
-            for name in plugin.PARAMETER_NAMES:
-                self.assertIn(name, ds.data_vars)
+            # Use a context manager so Windows can remove the file when the
+            # temporary directory cleans up. Without explicitly closing the
+            # dataset the cleanup step fails because the file handle remains
+            # open on that platform.
+            with xr.open_dataset(path, group="posterior") as ds:
+                for name in plugin.PARAMETER_NAMES:
+                    self.assertIn(name, ds.data_vars)
 
     def test_log_probability_penalty(self):
         plugin = self._build_lcdm_plugin()


### PR DESCRIPTION
## Summary
- close sampler NetCDF file in MCMC test to allow Windows to clean up temp directories
- install pre-commit with dependencies in lint workflow to fix missing cfgv module
- document dependency install approach and bump project version

## Testing
- `pre-commit run --files tests/test_engine_mcmc.py .github/workflows/lint.yml README.md CHANGELOG.md docs/packaging.md`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68b7158049d8832fb3cddf83b976dcf3