### PR TITLE
Document python -m piptools locking workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Copernican Suite Development Guide
-**Last Updated:** 2025-09-01
+**Last Updated:** 2025-09-22
 
 Development notes were previously kept at the top of this file. That history
 now
@@ -278,8 +278,9 @@ these rules:
     repository's `.venv` is created or updated automatically; other Python
     environments must be ignored.
 22. **Refresh dependencies whenever packages are added or changed.**
-    Run `pip-compile requirements.in`, commit the updated
-    `requirements.lock`, and audit `THIRD_PARTY_LICENSES.md`.
+   Run `python -m piptools compile requirements.in --allow-unsafe
+   --output-file requirements.lock` (or simply `make lock`), commit the
+   updated `requirements.lock`, and audit `THIRD_PARTY_LICENSES.md`.
 
 Failure to follow these guidelines will compromise the Copernican Suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ put dates that are in the future or in the past! Follow this template:
 ```
 ## Log changes here
 
+## Version 4.3.15
+- 2025-09-22: Switched the dependency lock automation to
+              `python -m piptools compile`, refreshed documentation and
+              regenerated the lock file to keep the managed environment
+              reproducible (OpenAI ChatGPT)
+
 ## Version 4.3.14
 - 2025-09-22: Bundled pip-tools with locked dependencies, refreshed the lock
                file, documentation and licensing metadata so `make lock`

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-# Last Updated: 2025-09-02
+# Last Updated: 2025-09-22
 
 .PHONY: lock
 lock:
-	pip-compile --quiet --allow-unsafe --output-file requirements.lock requirements.in
+	python -m piptools compile \
+		--quiet \
+		--allow-unsafe \
+		--output-file requirements.lock \
+		requirements.in
 	sed -i '1i# Last Updated: $(shell date -I)' requirements.lock
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version:** 4.3.14
+**Version:** 4.3.15
 **Last Updated:** 2025-09-22
 
 The Copernican Suite is a Python toolkit for testing cosmological models
@@ -156,11 +156,12 @@ package is missing the program asks before running `pip install
 same versions
 appear under `[project].dependencies` in `pyproject.toml`. Regenerate both
 files together whenever dependencies change.
-`pip-tools` now ships alongside the runtime stack so `pip-compile` is always
-available before running `make lock`. Use the bundled start scripts to enter
-the managed environment before regenerating locks; they guarantee the tool is
-installed with the pinned dependencies. This requirement is codified as law
-22 under "AI-driven and human development" laws and protocols.
+`pip-tools` now ships alongside the runtime stack so `python -m piptools
+compile` is always available before running `make lock`. Use the bundled
+start scripts to enter the managed environment before regenerating locks; they
+guarantee the module resolves to the pinned version. The `make lock` target
+wraps `python -m piptools compile --allow-unsafe`, so law 22 under
+"AI-driven and human development" covers this workflow explicitly.
 Running `copernican.py` directly now fails with a message directing you to
 use the `start.*` helpers. Future engines may also depend on `numba` or GPU
 libraries.
@@ -626,9 +627,9 @@ accurately** convey their purpose without unnecessary length.
 > repository's `.venv` is created or updated automatically; other Python
 > environments must be ignored.
 > 22. **Refresh dependencies whenever packages are added or changed.**
->    Run `pip-compile requirements.in`,
->    commit the updated `requirements.lock`, and audit
->    `THIRD_PARTY_LICENSES.md`.
+>    Run `python -m piptools compile requirements.in --allow-unsafe
+>    --output-file requirements.lock` (or simply `make lock`), commit the
+>    updated `requirements.lock`, and audit `THIRD_PARTY_LICENSES.md`.
 >
 > Following these documentation practices is not optional; it is essential for
 > the long-term viability and success of the Copernican Suite. Failure to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "xarray==2025.8.0",
     "xarray-einstats==0.9.1",
     "typing_extensions==4.15.0",
-    "pip-tools==7.4.1",  # ensure pip-compile is installed for make lock
+    "pip-tools==7.4.1",  # ensure python -m piptools compile is available
     "arviz @ https://github.com/arviz-devs/arviz/archive/01c8b9454349247eed2145a27b03f9231acb412f.tar.gz",
 ]
 


### PR DESCRIPTION
## Summary
- switch the lock target to call `python -m piptools compile` so dependency refresh works without the `pip-compile` entry point
- document the revised locking workflow, bumping the README version to 4.3.15 and clarifying law 22
- sync AGENTS and the changelog with the new dependency management process

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68d09c1006d4832f804a61a989eea76b