### PR TITLE
Harden launcher download URL validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-**Last Updated:** 2025-09-28
+**Last Updated:** 2025-09-30
 
 ## How to Log Changes
 Add one line for each substantive commit or pull request directly under the
@@ -18,6 +18,12 @@ put dates that are in the future or in the past! Follow this template:
 
 ```
 ## Log changes here
+
+## Version 4.3.19
+- 2025-09-30: Hardened the launchers to validate the Python download URL, pass
+              strict arguments to PowerShell and surface empty URL errors on
+              all platforms; documented the guard and bumped suite metadata
+              (OpenAI ChatGPT)
 
 ## Version 4.3.18
 - 2025-09-28: Guarded the Windows launcher download flow by exporting the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**Version:** 4.3.18
-**Last Updated:** 2025-09-28
+**Version:** 4.3.19
+**Last Updated:** 2025-09-30
 
 The Copernican Suite is a Python toolkit for testing cosmological models
 against Supernovae Type Ia (SNe Ia), Baryon Acoustic Oscillation (BAO), and
@@ -173,13 +173,12 @@ create a local virtual environment, upgrade `pip` and install the package
 automatically before launching the suite. Running `copernican.py` outside
 this environment prompts you to use the appropriate start script.
 
-The Windows launcher now assembles the download URL without relying on
-line continuations, surfaces it to PowerShell through environment
-variables and creates the `.python` directory before extracting the
-standalone interpreter. These safeguards prevent the
-`Invoke-WebRequest` call from receiving an empty URI on PowerShell,
-which previously surfaced as "Invalid URI: The hostname could not be
-parsed." errors on some shells.
+The launchers now assemble the Python download URL once, validate that it
+is non-empty and halt with an explicit "Copernican Suite download URL is
+empty." error when the release metadata is missing. The Windows helper
+passes the URL and archive path to PowerShell as strict parameters so
+`Invoke-WebRequest` cannot start with undefined values, while the Unix
+launchers rely on `curl -fL` to surface HTTP failures immediately.
 
 To install the package system-wide run:
 

--- a/start.bat
+++ b/start.bat
@@ -1,6 +1,6 @@
 @REM Copyright (c) 2025 Copernican Suite developers.
 @REM See LICENSE.md in the repository root for details.
-@REM Last Updated: 2025-09-28
+@REM Last Updated: 2025-09-30
 @echo off
 set "PKG_NOTICE=Package managers may request your password. The Copernican"
 set "PKG_NOTICE=%PKG_NOTICE% Suite never reads or stores it."
@@ -38,21 +38,38 @@ if not exist "%PYBIN%" (
     set "URL_BASE=%BASE%/download/%REL%/"
     set "URL_FILE=cpython-%VER%+%REL%-%ARCH%-pc-windows-msvc-"
     set "URL_FILE=%URL_FILE%shared-install_only.tar.gz"
-    set "URL=%URL_BASE%%URL_FILE%"
-    REM Surface the URL and archive path to PowerShell via environment variables
-    REM so it can validate the values before downloading and unpacking.
-    set "COPERNICAN_PYTHON_URL=%URL%"
-    set "COPERNICAN_PYTHON_TAR=python.tar.gz"
-    set "COPERNICAN_PYDIR=%PYDIR%"
+    set "DOWNLOAD_URL=%URL_BASE%%URL_FILE%"
+    set "DOWNLOAD_TAR=python.tar.gz"
+    REM Fail fast when the computed URL is blank so the user sees a clear
+    REM diagnostic instead of a confusing PowerShell error.
+    if "%DOWNLOAD_URL%"=="" (
+        echo Copernican Suite download URL is empty.
+        exit /b 1
+    )
+    REM Download the archive with strict argument checking to avoid silent
+    REM truncation when environment variables are missing.
     powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command ^
-        "$url = $env:COPERNICAN_PYTHON_URL;" ^
-        "if ([string]::IsNullOrWhiteSpace($url))" ^
-        " { throw 'Copernican Suite download URL is empty.' }" ^
-        "Invoke-WebRequest -Uri $url -OutFile $env:COPERNICAN_PYTHON_TAR"
+        "& { param([string]$url, [string]$outFile) ^
+            Set-StrictMode -Version Latest; ^
+            if ([string]::IsNullOrWhiteSpace($url)) { ^
+                throw 'Copernican Suite download URL is empty.' ^
+            } ^
+            Invoke-WebRequest -Uri $url -OutFile $outFile ^
+        }" ^
+        -Args "%DOWNLOAD_URL%", "%DOWNLOAD_TAR%"
+    if errorlevel 1 exit /b 1
+    REM Extract the interpreter once the archive exists and surface a helpful
+    REM message if the download step was skipped or failed.
     powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command ^
-        "$tarPath = $env:COPERNICAN_PYTHON_TAR;" ^
-        "$targetDir = $env:COPERNICAN_PYDIR;" ^
-        "tar -xzf $tarPath -C $targetDir --strip-components=1"
+        "& { param([string]$tarPath, [string]$targetDir) ^
+            Set-StrictMode -Version Latest; ^
+            if (-not (Test-Path -Path $tarPath -PathType Leaf)) { ^
+                throw 'Copernican Suite download archive is missing.' ^
+            } ^
+            & tar -xzf $tarPath -C $targetDir --strip-components=1 ^
+        }" ^
+        -Args "%DOWNLOAD_TAR%", "%PYDIR%"
+    if errorlevel 1 exit /b 1
     del python.tar.gz
 )
 set "PYTHON=%PYBIN%"

--- a/start.command
+++ b/start.command
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2025 Copernican Suite developers.
 # See LICENSE.md in the repository root for details.
-# Last Updated: 2025-09-02
+# Last Updated: 2025-09-30
 
 # Start the Copernican Suite on macOS.
 #
@@ -88,9 +88,15 @@ if [ ! -x "$PY_BIN" ]; then
     VER="3.12.11"
     ARCH="$(uname -m)"
     PLAT="apple-darwin"
-    URL="$BASE/download/$REL/"
-    URL="${URL}cpython-${VER}+${REL}-${ARCH}-${PLAT}-install_only.tar.gz"
-    curl -L "$URL" | tar -xz -C "$PY_DIR" --strip-components=1
+    # Build the release URL once so we can validate it before invoking curl.
+    # An empty URL means the release metadata above is stale.
+    URL_PATH="cpython-${VER}+${REL}-${ARCH}-${PLAT}-install_only.tar.gz"
+    DOWNLOAD_URL="$BASE/download/$REL/$URL_PATH"
+    if [ -z "$DOWNLOAD_URL" ]; then
+        echo "Copernican Suite download URL is empty." >&2
+        exit 1
+    fi
+    curl -fL "$DOWNLOAD_URL" | tar -xz -C "$PY_DIR" --strip-components=1
 fi
 PYTHON="$PY_BIN"
 

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2025 Copernican Suite developers.
 # See LICENSE.md in the repository root for details.
-# Last Updated: 2025-09-02
+# Last Updated: 2025-09-30
 
 # Start the Copernican Suite on Unix-like systems.
 #
@@ -93,9 +93,15 @@ if [ ! -x "$PY_BIN" ]; then
     else
         PLAT="unknown-linux-gnu"
     fi
-    URL="$BASE/download/$REL/"
-    URL="${URL}cpython-${VER}+${REL}-${ARCH}-${PLAT}-install_only.tar.gz"
-    curl -L "$URL" | tar -xz -C "$PY_DIR" --strip-components=1
+    # Build the release URL once so we can validate it before invoking curl.
+    # An empty URL means the release metadata above is stale.
+    URL_PATH="cpython-${VER}+${REL}-${ARCH}-${PLAT}-install_only.tar.gz"
+    DOWNLOAD_URL="$BASE/download/$REL/$URL_PATH"
+    if [ -z "$DOWNLOAD_URL" ]; then
+        echo "Copernican Suite download URL is empty." >&2
+        exit 1
+    fi
+    curl -fL "$DOWNLOAD_URL" | tar -xz -C "$PY_DIR" --strip-components=1
 fi
 PYTHON="$PY_BIN"
 


### PR DESCRIPTION
## Summary
- ensure the Windows launcher fails fast when the computed Python download URL is empty and pass strict arguments into PowerShell before extracting the archive
- mirror the same URL validation in the Unix launchers and rely on curl -fL so HTTP errors abort immediately
- document the tighter safeguards, bump the recorded suite version, and log the change in the changelog

## Testing
- pre-commit run --files CHANGELOG.md README.md start.bat start.sh start.command

------
https://chatgpt.com/codex/tasks/task_e_68d6a09d4bdc832f989cf601e389d3db